### PR TITLE
fix(#12): expose follower + leader endpoints on /replication/status

### DIFF
--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -650,10 +650,25 @@ public static class ServeCommand
 
     private static void MapReplicationEndpoints(WebApplication app, DocumentForgeDb db, NodeConfig config)
     {
-        // Current role + observability - safe for routine polling
+        // Current role + observability - safe for routine polling.
+        //
+        // The follower list and the follower's `leader.endpoint` are both
+        // populated from socket-level state the engine already tracks
+        // (FollowerCount, RemoteEndPoint, the configured _host:_port).
+        // Admin UIs use these to draw the topology graph without operators
+        // having to hand-tag each connection with a shard id (issue #12).
+        //
+        // Note: per-follower live ack tracking (`lastAckSeq`, `lagSeq`) is
+        // intentionally not here. The wire protocol is fire-and-forget today
+        // — we know each follower's seq AT HANDSHAKE only — and surfacing
+        // a stale value as if it were live would be worse than omitting it.
+        // Phase 2 of the multi-doc tx work (issue #13) is the natural place
+        // to add ack framing; the lag fields land then.
         app.MapGet("/replication/status", () =>
         {
             var rep = config.Replication;
+            var currentSeq = db.LeaderCurrentSeq;
+            var followers = db.GetLogicalFollowers();
             return Results.Ok(new
             {
                 node = config.NodeName,
@@ -661,15 +676,29 @@ public static class ServeCommand
                 readOnly = db.IsReadOnly,
                 leader = new
                 {
-                    currentSeq = db.LeaderCurrentSeq,
-                    followerCount = db.GetLogicalFollowerCount()
+                    currentSeq,
+                    followerCount = db.GetLogicalFollowerCount(),
+                    followers = followers.Select(f => new
+                    {
+                        endpoint = f.Endpoint,
+                        connectedAt = f.ConnectedAtUtc,
+                        handshakeSeq = f.HandshakeSeq,
+                        // Worst-case lag: how far behind the follower was when it
+                        // handshaked. If the link has stayed up, real lag is at
+                        // most this; we can't claim less without acks.
+                        worstCaseLagSeq = currentSeq > f.HandshakeSeq
+                            ? currentSeq - f.HandshakeSeq : 0UL,
+                    }).ToArray(),
                 },
                 follower = new
                 {
                     lastAppliedSeq = db.FollowerLastSeq,
                     opsApplied = db.LogicallyReplicatedOps(),
                     gapsDetected = db.GapsDetected,
-                    autoFailoverPromoted = db.WasAutoFailoverPromoted
+                    autoFailoverPromoted = db.WasAutoFailoverPromoted,
+                    leader = db.LogicalFollowerLeaderEndpoint is null
+                        ? null
+                        : (object)new { endpoint = db.LogicalFollowerLeaderEndpoint },
                 }
             });
         });

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -740,6 +740,19 @@ public sealed class DocumentForgeDb : IDisposable
     public int GetLogicalFollowerCount() => _logicalServer?.FollowerCount ?? 0;
 
     /// <summary>
+    /// Snapshot of currently-connected followers as the leader sees them.
+    /// Surfaces in <c>/replication/status</c> so admin UIs can wire up topology
+    /// without operators hand-typing shard membership. Empty list if this node
+    /// isn't a leader (or has no followers).
+    /// </summary>
+    public IReadOnlyList<FollowerInfo> GetLogicalFollowers() =>
+        _logicalServer?.GetFollowers() ?? Array.Empty<FollowerInfo>();
+
+    /// <summary>The leader this follower is reading from as <c>"host:port"</c>,
+    /// or null if this node isn't a follower.</summary>
+    public string? LogicalFollowerLeaderEndpoint => _logicalFollower?.LeaderEndpoint;
+
+    /// <summary>
     /// Start this DB as a logical replication follower (read-only replica).
     /// Applies incoming ops through the engine's own Insert/Delete/CreateIndex so indexes
     /// and location maps stay coherent. Queries on this instance will see replicated data.

--- a/src/DocumentForge.Transactions/LogicalReplication.cs
+++ b/src/DocumentForge.Transactions/LogicalReplication.cs
@@ -106,10 +106,28 @@ public sealed class OpLogBuffer
 /// <summary>
 /// Leader-side logical replication server with sequence numbers and follower catchup.
 /// </summary>
+/// <summary>
+/// Snapshot of one connected follower as the leader sees it. Exposed via
+/// <see cref="LogicalReplicationServer.GetFollowers"/> so the admin status
+/// endpoint can wire up topology without manual configuration.
+/// </summary>
+/// <param name="Endpoint">Remote address as <c>"host:port"</c>, or <c>"unknown"</c>
+/// if the socket has already torn down between snapshot and stringify.</param>
+/// <param name="ConnectedAtUtc">When the follower handshake completed.</param>
+/// <param name="HandshakeSeq">The follower's last-applied seq at handshake.
+/// We don't track ongoing acks today (Phase 2 of replication tx work);
+/// callers reading lag should compare this against
+/// <see cref="LogicalReplicationServer.CurrentSeq"/> with the understanding
+/// that it's a worst-case lower bound, not a live ack.</param>
+public readonly record struct FollowerInfo(string Endpoint, DateTime ConnectedAtUtc, ulong HandshakeSeq);
+
 public sealed class LogicalReplicationServer : IDisposable
 {
     private readonly TcpListener _listener;
-    private readonly List<TcpClient> _followers = new();
+    // Records the metadata we collected at handshake alongside the live socket
+    // so the status endpoint can report "who is connected" without the follower
+    // having to identify itself separately.
+    private readonly List<FollowerConn> _followers = new();
     private readonly object _lock = new();
     private readonly CancellationTokenSource _cts = new();
     private readonly string? _secret;
@@ -125,6 +143,35 @@ public sealed class LogicalReplicationServer : IDisposable
     public int Port { get; }
     public int FollowerCount { get { lock (_lock) return _followers.Count; } }
     public ulong CurrentSeq => (ulong)Interlocked.Read(ref _nextSeq) - 1;
+
+    /// <summary>
+    /// Snapshot of currently-connected followers. Used by the
+    /// <c>/replication/status</c> admin endpoint for topology auto-discovery.
+    /// </summary>
+    public IReadOnlyList<FollowerInfo> GetFollowers()
+    {
+        lock (_lock)
+        {
+            var list = new List<FollowerInfo>(_followers.Count);
+            foreach (var f in _followers)
+                list.Add(new FollowerInfo(f.Endpoint, f.ConnectedAtUtc, f.HandshakeSeq));
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// One connected follower's bookkeeping. Endpoint and timestamps are
+    /// stamped during the handshake handler before the socket gets added
+    /// to the broadcast list, so by the time <see cref="GetFollowers"/>
+    /// observes the entry every field is already populated.
+    /// </summary>
+    private sealed class FollowerConn
+    {
+        public required TcpClient Client { get; init; }
+        public required string Endpoint { get; init; }
+        public required DateTime ConnectedAtUtc { get; init; }
+        public required ulong HandshakeSeq { get; init; }
+    }
 
     public LogicalReplicationServer(int port, int opLogCapacity = 10_000, string? secret = null)
     {
@@ -162,17 +209,17 @@ public sealed class LogicalReplicationServer : IDisposable
                 return;
             }
 
-            var dead = new List<TcpClient>();
+            var dead = new List<FollowerConn>();
             foreach (var f in _followers)
             {
-                try { f.GetStream().Write(record, 0, record.Length); }
+                try { f.Client.GetStream().Write(record, 0, record.Length); }
                 catch { dead.Add(f); }
             }
             foreach (var d in dead)
             {
                 _followers.Remove(d);
-                try { d.Close(); } catch { }
-                Console.WriteLine("[LogicalRep] Follower disconnected");
+                try { d.Client.Close(); } catch { }
+                Console.WriteLine($"[LogicalRep] Follower disconnected ({d.Endpoint})");
             }
         }
     }
@@ -258,8 +305,19 @@ public sealed class LogicalReplicationServer : IDisposable
                 catch { client.Close(); return; }
             }
 
-            // Add to live broadcast list
-            lock (_lock) _followers.Add(client);
+            // Add to live broadcast list with the metadata that the status
+            // endpoint will surface. RemoteEndPoint is captured now because
+            // it's only reachable while the socket is connected; once it
+            // closes, the endpoint is gone.
+            var endpoint = client.Client.RemoteEndPoint?.ToString() ?? "unknown";
+            var conn = new FollowerConn
+            {
+                Client = client,
+                Endpoint = endpoint,
+                ConnectedAtUtc = DateTime.UtcNow,
+                HandshakeSeq = followerLastSeq,
+            };
+            lock (_lock) _followers.Add(conn);
         }
         catch (Exception ex)
         {
@@ -323,7 +381,7 @@ public sealed class LogicalReplicationServer : IDisposable
         try { _listener.Stop(); } catch { }
         lock (_lock)
         {
-            foreach (var f in _followers) try { f.Close(); } catch { }
+            foreach (var f in _followers) try { f.Client.Close(); } catch { }
             _followers.Clear();
         }
         _disposed = true;
@@ -357,6 +415,9 @@ public sealed class LogicalReplicationFollower : IDisposable
     public long OpsApplied => Interlocked.Read(ref _opsApplied);
     public long GapsDetected => Interlocked.Read(ref _gapsDetected);
     public DateTimeOffset LastMessageAt { get { lock (this) return _lastMessageAt; } }
+
+    /// <summary>The leader this follower is configured to read from, as <c>"host:port"</c>.</summary>
+    public string LeaderEndpoint => $"{_host}:{_port}";
 
     public LogicalReplicationFollower(string host, int port, string seqFilePath, Action<LogicalOp> apply, string? secret = null)
     {

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -2174,6 +2174,78 @@ public class EngineTests : IDisposable
             Assert.Empty(reopened.GetIndexes($"c{i:D3}"));
     }
 
+    // --- Replication topology exposure (issue #12) ---
+
+    [Fact]
+    public async System.Threading.Tasks.Task LogicalReplication_LeaderExposesConnectedFollowerEndpoints()
+    {
+        // The /replication/status endpoint needs to surface enough about
+        // connected followers that an admin UI can wire a topology graph
+        // automatically. Today we expose endpoint, connectedAt, and the
+        // handshake seq (worst-case lag baseline). Ack-driven live lag is
+        // tracked separately under the Phase 2 replication-tx work.
+        int port = 5800 + System.Random.Shared.Next(100);
+        var leaderPath = Path.Combine(Path.GetTempPath(), $"topoleader_{Guid.NewGuid():N}.dfdb");
+        var follower1Path = Path.Combine(Path.GetTempPath(), $"topofol1_{Guid.NewGuid():N}.dfdb");
+        var follower2Path = Path.Combine(Path.GetTempPath(), $"topofol2_{Guid.NewGuid():N}.dfdb");
+
+        try
+        {
+            using var leader = DocumentForgeDb.Create(leaderPath);
+            leader.StartLogicalReplicationServer(port);
+            await System.Threading.Tasks.Task.Delay(150);
+
+            // Pre-seed an op on the leader so the second follower's handshake
+            // seq differs from the first — gives the lag column something to
+            // distinguish.
+            leader.Insert("orders", """{"pnr":"X"}""");
+
+            using var follower1 = DocumentForgeDb.Create(follower1Path);
+            follower1.StartLogicalReplicationFollower("localhost", port);
+            for (int i = 0; i < 30 && leader.GetLogicalFollowerCount() < 1; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+
+            leader.Insert("orders", """{"pnr":"Y"}""");
+            leader.Insert("orders", """{"pnr":"Z"}""");
+
+            using var follower2 = DocumentForgeDb.Create(follower2Path);
+            follower2.StartLogicalReplicationFollower("localhost", port);
+            for (int i = 0; i < 30 && leader.GetLogicalFollowerCount() < 2; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+
+            var followers = leader.GetLogicalFollowers();
+            Assert.Equal(2, followers.Count);
+
+            // Both endpoints are loopback addresses with whatever ephemeral
+            // ports the OS assigned. The status endpoint just needs them
+            // recognisable as host:port — we don't pin the exact port.
+            foreach (var f in followers)
+            {
+                Assert.Contains(":", f.Endpoint);
+                Assert.NotEqual("unknown", f.Endpoint);
+                Assert.True(f.ConnectedAtUtc > DateTime.UtcNow.AddMinutes(-1));
+            }
+
+            // The follower side knows its leader's endpoint — what the
+            // status payload uses to populate `follower.leader.endpoint`.
+            Assert.Equal($"localhost:{port}", follower1.LogicalFollowerLeaderEndpoint);
+            Assert.Equal($"localhost:{port}", follower2.LogicalFollowerLeaderEndpoint);
+
+            // A non-replicating db reports null so the JSON omits the field
+            // gracefully via the null-coalesce in /replication/status.
+            using var standalone = DocumentForgeDb.Create(
+                Path.Combine(Path.GetTempPath(), $"topostandalone_{Guid.NewGuid():N}.dfdb"));
+            Assert.Null(standalone.LogicalFollowerLeaderEndpoint);
+            Assert.Empty(standalone.GetLogicalFollowers());
+        }
+        finally
+        {
+            try { File.Delete(leaderPath); File.Delete(leaderPath + ".wal"); File.Delete(leaderPath + ".recovery"); } catch { }
+            try { File.Delete(follower1Path); File.Delete(follower1Path + ".wal"); File.Delete(follower1Path + ".recovery"); File.Delete(follower1Path + ".followerseq"); } catch { }
+            try { File.Delete(follower2Path); File.Delete(follower2Path + ".wal"); File.Delete(follower2Path + ".recovery"); File.Delete(follower2Path + ".followerseq"); } catch { }
+        }
+    }
+
     public void Dispose()
     {
         _db.Dispose();


### PR DESCRIPTION
Closes #12.

## Summary
- Leader-side: \`/replication/status\` now lists each connected follower with \`endpoint\`, \`connectedAt\`, \`handshakeSeq\`, and \`worstCaseLagSeq\`. Endpoint is captured from \`RemoteEndPoint\` at handshake time before the conn is added to the broadcast list.
- Follower-side: \`follower.leader.endpoint\` exposes \`<host>:<port>\` so a follower can report which leader it's reading from.
- Per-follower live ack tracking is intentionally NOT here. The wire protocol is fire-and-forget today (no ACK frame) and surfacing a stale value as if it were live would mislead operators. Phase 2 replication-tx (#13) is the natural place for that.

## Test plan
- [x] New test: two followers connect; leader exposes both endpoints with valid \`host:port\` strings and \`ConnectedAtUtc > now-1m\`. Each follower's \`LogicalFollowerLeaderEndpoint\` is \`localhost:<port>\`. Standalone DB returns null + empty list.
- [x] Full suite: 82/82 (was 81; +1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)