### PR TITLE
fix(#24): SetIndexCatalogPage must Flush(true), not Flush()

### DIFF
--- a/src/DocumentForge.Storage/DataFile.cs
+++ b/src/DocumentForge.Storage/DataFile.cs
@@ -160,7 +160,14 @@ public sealed class DataFile : IDataFile
             _stream.Seek(24, SeekOrigin.Begin);
             var buf = BitConverter.GetBytes(pageId.Value);
             _stream.Write(buf, 0, 4);
-            _stream.Flush();
+            // Flush(true) → FlushFileBuffers on Windows / fsync on POSIX. The
+            // bare Flush() we used before only pushed the managed buffer; the
+            // 4-byte header pointer could sit in the OS write cache through a
+            // power loss and come back as Invalid on next open, leaving the
+            // catalog page allocated and indexes orphaned. Match the discipline
+            // used by Flush() on line 136 — every header-mutating write must
+            // hit disk before we return.
+            _stream.Flush(true);
         }
     }
 


### PR DESCRIPTION
Partial fix for #24. Closes the most urgent of the three fsync gaps that audit surfaced.

## Summary
- One-character change: \`_stream.Flush()\` → \`_stream.Flush(true)\` in [DataFile.SetIndexCatalogPage](src/DocumentForge.Storage/DataFile.cs:163).
- Without this, the index-catalog header pointer can sit in the OS write cache through a power loss and come back as Invalid on next open, leaving the catalog page allocated but the indexes it points at orphaned.

## Why no test
The failure mode is real OS-level write-cache loss (power loss, kernel crash). xUnit can't simulate that. The crash-injection harness tracked at #28 is the natural place to verify this fix actually does its job; until that lands this is reviewed-by-eye.

## Remaining in #24
The audit surfaced two more fsync gaps that aren't a one-line fix:
- \`PageCache.Evict\` / \`EvictLru\` write to the data file but don't fsync — recovery-log discipline needs to be tightened or every eviction needs to fsync (throughput hit).
- \`DataFile.AllocatePage\` extends the file + updates the page-count header without fsync.

Both want more discussion before changing. Issue #24 stays open for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)