### PR TITLE
fix(#26): on-disk lock file prevents two processes opening the same data file

### DIFF
--- a/src/DocumentForge.Core/Exceptions.cs
+++ b/src/DocumentForge.Core/Exceptions.cs
@@ -38,3 +38,23 @@ public class TransactionException : DocumentForgeException
 {
     public TransactionException(string message) : base(message) { }
 }
+
+/// <summary>
+/// Thrown when DocumentForgeDb.Open / Create cannot acquire the on-disk
+/// lock for the data file because another process is holding it. The
+/// message names the holder (pid + hostname + open time) so operators can
+/// kill the right process before retrying.
+/// </summary>
+public class DatabaseLockedException : DocumentForgeException
+{
+    public string FilePath { get; }
+    public int HolderPid { get; }
+    public string HolderHost { get; }
+    public DatabaseLockedException(string filePath, int holderPid, string holderHost, string message)
+        : base(message)
+    {
+        FilePath = filePath;
+        HolderPid = holderPid;
+        HolderHost = holderHost;
+    }
+}

--- a/src/DocumentForge.Engine/DatabaseOptions.cs
+++ b/src/DocumentForge.Engine/DatabaseOptions.cs
@@ -4,4 +4,14 @@ public sealed class DatabaseOptions
 {
     public int CacheSizeInPages { get; set; } = 1000; // 8MB default
     public bool EnableWal { get; set; } = true;
+
+    /// <summary>
+    /// Reclaim the on-disk lock even if the prior holder may still be alive.
+    /// Default false — Open throws <see cref="Core.DatabaseLockedException"/>
+    /// if another live process holds the lock. Set true only when you're
+    /// certain no other writer is active (e.g. containerised redeploys
+    /// where the previous container is gone but its pid isn't visible from
+    /// the new one).
+    /// </summary>
+    public bool ForceUnlock { get; set; } = false;
 }

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -9,6 +9,7 @@ namespace DocumentForge.Engine;
 
 public sealed class DocumentForgeDb : IDisposable
 {
+    private readonly DatabaseLock _lock;
     private readonly DataFile _dataFile;
     private readonly PageCache _pageCache;
     private readonly PageAllocator _allocator;
@@ -28,9 +29,10 @@ public sealed class DocumentForgeDb : IDisposable
 
     public string FilePath { get; }
 
-    private DocumentForgeDb(string filePath, DataFile dataFile, DatabaseOptions options)
+    private DocumentForgeDb(string filePath, DataFile dataFile, DatabaseLock lockHandle, DatabaseOptions options)
     {
         FilePath = filePath;
+        _lock = lockHandle;
         _dataFile = dataFile;
         _pageCache = new PageCache(dataFile, options.CacheSizeInPages);
         _allocator = new PageAllocator(dataFile, _pageCache);
@@ -102,37 +104,63 @@ public sealed class DocumentForgeDb : IDisposable
     public static DocumentForgeDb Create(string filePath, DatabaseOptions? options = null)
     {
         options ??= new DatabaseOptions();
-        var dataFile = DataFile.Create(filePath);
-        var db = new DocumentForgeDb(filePath, dataFile, options);
-        db._catalog.Load();
-        // New DB has no indexes yet
-        return db;
+        // Acquire the on-disk lock BEFORE creating the data file so two
+        // concurrent Create calls don't both succeed and end up with
+        // overlapping writes. If the data file exists already and is locked
+        // by someone else, the FileMode.CreateNew below would fail anyway —
+        // checking the lock first gives a clearer error.
+        var lockHandle = DatabaseLock.Acquire(filePath, options.ForceUnlock);
+        try
+        {
+            var dataFile = DataFile.Create(filePath);
+            var db = new DocumentForgeDb(filePath, dataFile, lockHandle, options);
+            db._catalog.Load();
+            // New DB has no indexes yet
+            return db;
+        }
+        catch
+        {
+            lockHandle.Dispose();
+            throw;
+        }
     }
 
     public static DocumentForgeDb Open(string filePath, DatabaseOptions? options = null)
     {
         options ??= new DatabaseOptions();
 
-        // CRASH RECOVERY: before opening the data file, check for an unfinished recovery log.
-        // If it exists and has records, it means we crashed mid-flush.
-        // Replay the log entries directly onto the data file to restore durability.
-        var recoveryPath = filePath + ".recovery";
-        int recoveredPages = ReplayRecoveryLog(filePath, recoveryPath);
-
-        var dataFile = DataFile.Open(filePath);
-        var db = new DocumentForgeDb(filePath, dataFile, options);
-        db._catalog.Load();
-        // Load persistent indexes (no rebuild from scratch!)
-        db._indexManager.LoadFromCatalog();
-        // Eagerly build location maps for all collections - avoids 1s lag on first query
-        foreach (var collName in db._catalog.GetCollectionNames())
+        // Acquire the on-disk lock BEFORE recovery replay or any data-file
+        // mutation. The recovery log is rewritten by replay, so two processes
+        // racing on Open could each clobber the other's recovery progress.
+        var lockHandle = DatabaseLock.Acquire(filePath, options.ForceUnlock);
+        try
         {
-            db._catalog.GetCollection(collName)?.BuildLocationMap();
-        }
+            // CRASH RECOVERY: before opening the data file, check for an unfinished recovery log.
+            // If it exists and has records, it means we crashed mid-flush.
+            // Replay the log entries directly onto the data file to restore durability.
+            var recoveryPath = filePath + ".recovery";
+            int recoveredPages = ReplayRecoveryLog(filePath, recoveryPath);
 
-        if (recoveredPages > 0)
-            Console.WriteLine($"[DocumentForge] Recovered {recoveredPages} page(s) from crash recovery log.");
-        return db;
+            var dataFile = DataFile.Open(filePath);
+            var db = new DocumentForgeDb(filePath, dataFile, lockHandle, options);
+            db._catalog.Load();
+            // Load persistent indexes (no rebuild from scratch!)
+            db._indexManager.LoadFromCatalog();
+            // Eagerly build location maps for all collections - avoids 1s lag on first query
+            foreach (var collName in db._catalog.GetCollectionNames())
+            {
+                db._catalog.GetCollection(collName)?.BuildLocationMap();
+            }
+
+            if (recoveredPages > 0)
+                Console.WriteLine($"[DocumentForge] Recovered {recoveredPages} page(s) from crash recovery log.");
+            return db;
+        }
+        catch
+        {
+            lockHandle.Dispose();
+            throw;
+        }
     }
 
     public static DocumentForgeDb OpenOrCreate(string filePath, DatabaseOptions? options = null)
@@ -1072,6 +1100,10 @@ public sealed class DocumentForgeDb : IDisposable
             _dataFile.Dispose();
             var recoveryPath = FilePath + ".recovery";
             try { if (File.Exists(recoveryPath) && new FileInfo(recoveryPath).Length == 0) File.Delete(recoveryPath); } catch { }
+            // Release the on-disk lock LAST so a crash mid-shutdown still leaves
+            // the lock visible. Releasing earlier would briefly let a second
+            // opener race in while we're still flushing/closing.
+            _lock.Dispose();
             _disposed = true;
         }
     }

--- a/src/DocumentForge.Storage/DatabaseLock.cs
+++ b/src/DocumentForge.Storage/DatabaseLock.cs
@@ -1,0 +1,220 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using DocumentForge.Core;
+
+namespace DocumentForge.Storage;
+
+/// <summary>
+/// On-disk lock that prevents two engine instances from opening the same data
+/// file. Without this, deploy races (k8s rolling restart, systemd restart, an
+/// accidentally-mounted-twice volume) silently produce two writers on the same
+/// pages — page-level CRC32 catches the resulting corruption AFTER it happens
+/// but nothing prevents it.
+///
+/// <para>
+/// Implementation: open <c>{datafile}.lock</c> with <c>FileShare.None</c>. If
+/// the OS rejects (sharing violation), parse the existing lock file's JSON
+/// header to surface the holder's pid + hostname in the error. If the holder
+/// is dead — its pid no longer exists locally — auto-reclaim the lock.
+/// </para>
+///
+/// <para>
+/// Limitations: on networked filesystems (NFS, SMB), <c>FileShare.None</c>
+/// semantics aren't reliably enforced across hosts. Two processes on different
+/// machines can still race past this. Use a clustered file system or only
+/// mount the data dir on a single host. We document this rather than try to
+/// solve it.
+/// </para>
+/// </summary>
+public sealed class DatabaseLock : IDisposable
+{
+    private readonly FileStream _stream;
+    private readonly string _path;
+    private bool _disposed;
+
+    public string LockFilePath => _path;
+
+    private DatabaseLock(FileStream stream, string path)
+    {
+        _stream = stream;
+        _path = path;
+    }
+
+    /// <summary>
+    /// Acquire the lock for <paramref name="dataFilePath"/>. Throws
+    /// <see cref="DatabaseLockedException"/> if another live process holds it
+    /// or the prior holder was on a different machine (which we can't probe).
+    /// </summary>
+    /// <param name="force">Reclaim the lock regardless of whether the prior
+    /// holder still appears alive. Use only when you're certain no other
+    /// writer is active (e.g. a containerised redeploy where the previous
+    /// container has been terminated but its pid isn't visible from the new
+    /// one, or a different-host stale lock you've manually verified).</param>
+    public static DatabaseLock Acquire(string dataFilePath, bool force = false)
+    {
+        var lockPath = dataFilePath + ".lock";
+
+        // Two distinct checks. Both have to pass.
+        //
+        // (1) Stale-file metadata check. If a lock file already exists on disk,
+        // its content tells us who PREVIOUSLY held it. FileShare.None will not
+        // raise on a stale lock file (the holder is dead, no handle is open),
+        // so without this peek a different-host crashed holder would silently
+        // get its lock taken — exactly the cross-host accident we're trying
+        // to prevent.
+        //
+        // (2) FileShare.None acquire. Catches the case where the prior holder
+        // is still alive on this machine (or, on POSIX, where another process
+        // happened to hit the file between (1) and (2)).
+        if (!force && File.Exists(lockPath))
+        {
+            var holder = TryReadHolder(lockPath);
+            if (holder is not null)
+            {
+                bool sameHost = string.Equals(holder.Value.Host, Environment.MachineName,
+                    StringComparison.OrdinalIgnoreCase);
+
+                if (!sameHost)
+                {
+                    // Cross-host stale lock — we can't tell whether the foreign
+                    // process is still alive. Refuse rather than risk dual writers.
+                    throw new DatabaseLockedException(dataFilePath,
+                        holder.Value.Pid, holder.Value.Host,
+                        $"Database '{dataFilePath}' has a lock file from pid {holder.Value.Pid} on host '{holder.Value.Host}' " +
+                        $"(opened {holder.Value.OpenedAtUtc:o}). Cross-host liveness can't be probed; if that process is " +
+                        $"no longer running, delete '{lockPath}' or pass DatabaseOptions.ForceUnlock = true.");
+                }
+
+                if (sameHost && IsProcessAlive(holder.Value.Pid))
+                {
+                    throw new DatabaseLockedException(dataFilePath,
+                        holder.Value.Pid, holder.Value.Host,
+                        $"Database '{dataFilePath}' is locked by pid {holder.Value.Pid} on this host " +
+                        $"(opened {holder.Value.OpenedAtUtc:o}). Either stop that process or pass " +
+                        $"DatabaseOptions.ForceUnlock = true if you're sure it's gone.");
+                }
+
+                // Same host, dead pid → stale local lock from a crashed run.
+                // Delete the file so Open below starts clean. If a race leaves
+                // the file held by a third party, the Open will throw and we
+                // surface the error fresh.
+                try { File.Delete(lockPath); } catch { }
+            }
+            // If TryReadHolder returned null (corrupt/empty/unparseable), we
+            // fall through to the Open attempt — FileShare.None will catch a
+            // genuine concurrent holder.
+        }
+
+        try
+        {
+            return Open(lockPath);
+        }
+        catch (IOException ex)
+        {
+            // The peek above said nothing was holding it, but Open still failed.
+            // That means a concurrent Acquire raced past us and took it. Surface
+            // the holder info we have at THIS instant — it'll be the new holder.
+            var holder = TryReadHolder(lockPath);
+            var msg = holder is null
+                ? $"Database '{dataFilePath}' is locked by another process (and the lock file is unreadable: {ex.Message})."
+                : $"Database '{dataFilePath}' is locked by pid {holder.Value.Pid} on host '{holder.Value.Host}', opened {holder.Value.OpenedAtUtc:o}.";
+            throw new DatabaseLockedException(dataFilePath,
+                holder?.Pid ?? 0, holder?.Host ?? "unknown", msg);
+        }
+    }
+
+    private static DatabaseLock Open(string lockPath)
+    {
+        // FileShare.None is the load-bearing piece — it's what makes a second
+        // Open from another process raise IOException. We pre-create the file
+        // if it doesn't exist (DeleteOnClose is intentionally NOT used because
+        // it's POSIX-flaky and we'd rather leave the file behind on crash so
+        // operators can see "yes, this DB has been opened before").
+        var stream = new FileStream(
+            lockPath,
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None,
+            bufferSize: 256,
+            options: FileOptions.None);
+
+        // Truncate any stale content from a prior holder and stamp our own.
+        stream.SetLength(0);
+        var holder = new HolderInfo
+        {
+            Pid = Environment.ProcessId,
+            Host = Environment.MachineName,
+            OpenedAtUtc = DateTime.UtcNow,
+        };
+        var bytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(holder));
+        stream.Write(bytes, 0, bytes.Length);
+        stream.Flush(true);
+
+        return new DatabaseLock(stream, lockPath);
+    }
+
+    private static HolderInfo? TryReadHolder(string lockPath)
+    {
+        try
+        {
+            // FileShare.ReadWrite — even though the holder has it open
+            // FileShare.None for ITS handle, we (a different process) can
+            // still open with read-share when reading the metadata. On
+            // Windows this works because we're requesting a disjoint share
+            // mode; on POSIX where shares aren't enforced the read just
+            // succeeds. Either way, peek at the JSON.
+            using var fs = new FileStream(lockPath, FileMode.Open,
+                FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs, Encoding.UTF8);
+            var json = reader.ReadToEnd();
+            if (string.IsNullOrWhiteSpace(json)) return null;
+            return JsonSerializer.Deserialize<HolderInfo>(json);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        if (pid <= 0) return false;
+        try
+        {
+            using var p = Process.GetProcessById(pid);
+            return !p.HasExited;
+        }
+        catch (ArgumentException)
+        {
+            // GetProcessById throws ArgumentException if no such process.
+            return false;
+        }
+        catch
+        {
+            // Permission error or similar — be conservative and say "alive"
+            // so we don't reclaim a lock we can't actually verify is dead.
+            return true;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        // Release the file handle first; the OS only un-shares the file when
+        // the handle is closed. Then delete the lock file so the next opener
+        // finds a clean slate. If delete fails (another process raced and is
+        // already opening it), that's fine — they'll truncate it themselves.
+        try { _stream.Dispose(); } catch { }
+        try { File.Delete(_path); } catch { }
+    }
+
+    private record struct HolderInfo
+    {
+        public int Pid { get; init; }
+        public string Host { get; init; }
+        public DateTime OpenedAtUtc { get; init; }
+    }
+}

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -2322,12 +2322,78 @@ public class EngineTests : IDisposable
         Assert.Throws<ArgumentException>(() => _db.Snapshot(_dbPath));
     }
 
-    public void Dispose()
+    // --- On-disk lock (issue #26) ---
+
+    [Fact]
+    public void Open_RejectsConcurrentSecondOpener()
+    {
+        // The first DB instance is _db (held open by the test fixture). A
+        // second Open of the same path must surface a clear error rather than
+        // silently allowing both to write.
+        Assert.Throws<DatabaseLockedException>(() => DocumentForgeDb.Open(_dbPath));
+    }
+
+    [Fact]
+    public void Open_AfterClose_AcquiresFreshLock()
+    {
+        // Round-trip: dispose the held lock, reopen — the second open must
+        // succeed once the first has cleanly released.
+        _db.Dispose();
+        using var reopened = DocumentForgeDb.Open(_dbPath);
+        // Smoke-test: a real op proves the engine is functional, not just
+        // that the constructor returned.
+        reopened.Insert("orders", """{"pnr":"AFTER"}""");
+        Assert.Single(reopened.Execute("SELECT * FROM orders").Documents);
+    }
+
+    [Fact]
+    public void Open_StaleLockFromDeadHolder_AutoReclaims()
     {
         _db.Dispose();
+        var lockPath = _dbPath + ".lock";
+
+        // Plant a stale lock pointing at a definitely-dead pid on this host.
+        // 0x7FFFFFFF is impossibly out of range for a real process; the
+        // reclaim path will see it doesn't exist and take the lock.
+        var stale = """{"Pid":2147483646,"Host":""" + System.Text.Json.JsonSerializer.Serialize(Environment.MachineName) + ""","OpenedAtUtc":"2020-01-01T00:00:00Z"}""";
+        File.WriteAllText(lockPath, stale);
+
+        using var reopened = DocumentForgeDb.Open(_dbPath);
+        reopened.Insert("orders", """{"pnr":"X"}""");
+        Assert.Single(reopened.Execute("SELECT * FROM orders").Documents);
+    }
+
+    [Fact]
+    public void Open_StaleLockFromDifferentHost_RefusesWithoutForce()
+    {
+        _db.Dispose();
+        var lockPath = _dbPath + ".lock";
+
+        // Holder claims to be on a different host. We can't probe whether
+        // it's alive remotely, so the safe default is to refuse and surface
+        // the error. The user has to either delete the lock file or pass
+        // ForceUnlock = true.
+        var foreign = """{"Pid":1234,"Host":"some-other-machine","OpenedAtUtc":"2020-01-01T00:00:00Z"}""";
+        File.WriteAllText(lockPath, foreign);
+
+        var ex = Assert.Throws<DatabaseLockedException>(() => DocumentForgeDb.Open(_dbPath));
+        Assert.Equal("some-other-machine", ex.HolderHost);
+        Assert.Equal(1234, ex.HolderPid);
+
+        // ForceUnlock = true bypasses the cross-host check.
+        using var forced = DocumentForgeDb.Open(_dbPath, new DatabaseOptions { ForceUnlock = true });
+        Assert.Equal(0, forced.Execute("SELECT * FROM orders").Documents.Count);
+    }
+
+    public void Dispose()
+    {
+        // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock
+        // round-trip tests). Tolerate the redundant Dispose without throwing.
+        try { _db.Dispose(); } catch { }
         try { File.Delete(_dbPath); } catch { }
         try { File.Delete(_dbPath + ".wal"); } catch { }
         try { File.Delete(_dbPath + ".recovery"); } catch { }
         try { File.Delete(_dbPath + ".followerseq"); } catch { }
+        try { File.Delete(_dbPath + ".lock"); } catch { }
     }
 }


### PR DESCRIPTION
Closes #26.

## Summary
- New \`DatabaseLock\` in \`DocumentForge.Storage\`. Acquired by \`Open\`/\`Create\` before any data-file or recovery-log mutation.
- Two-stage check: metadata peek for cross-host / live-local / stale-local cases, plus \`FileShare.None\` for same-instant races.
- \`DatabaseLockedException\` carries holder pid + hostname so operators can find and stop the right process.
- \`DatabaseOptions.ForceUnlock\` opt-out for container-redeploy scenarios where pid visibility isn't reliable.
- Released last in \`Dispose\` so a crash mid-shutdown leaves the file in place for the next opener to evaluate.

## Tests
- [x] Concurrent second opener → \`DatabaseLockedException\`.
- [x] Close + reopen round-trips cleanly and the engine is functional.
- [x] Stale local lock (dead pid) → auto-reclaim.
- [x] Stale cross-host lock → refuse without \`ForceUnlock\`, succeed with it.
- [x] Full suite: 85/85 (was 81; +4).

## Documented limitation
On networked filesystems (NFS, SMB), \`FileShare.None\` isn't reliably enforced across hosts. The metadata-peek catches obvious cross-host scenarios but isn't a substitute for using a clustered filesystem (or only mounting the data dir on one host) for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)