### PR TITLE
fix(#27): consistent backup via db.Snapshot + POST /admin/snapshot

### DIFF
--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -117,7 +117,7 @@ public static class ServeCommand
         Console.WriteLine("             GET|DELETE|PUT /collections/{name}/by/{field}/{value}  (by any field)");
         Console.WriteLine("             DELETE /collections/{name} | GET /indexes/{collection} | POST /index");
         Console.WriteLine("             POST /seed | GET /health");
-        Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint");
+        Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
         Console.WriteLine("             POST /admin/compact/{collection}");
         Console.WriteLine("             POST /admin/rebuild-indexes/{collection}");
         Console.WriteLine("             POST /admin/rebuild-index/{collection}/{indexName}");
@@ -582,6 +582,36 @@ public static class ServeCommand
             return Results.Ok(new { success = true, timeMs = sw.Elapsed.TotalMilliseconds });
         });
 
+        // Take a consistent snapshot of the data file. Blocks writes briefly
+        // (the duration of FlushAll + the file copy) and returns when the
+        // snapshot is durable. The result file at targetPath is a
+        // self-contained .dfdb that DocumentForgeDb.Open can load directly.
+        //
+        // For multi-GB datasets the copy dominates wall time; consider
+        // running this against a follower instead so the leader's writes
+        // aren't paused.
+        app.MapPost("/admin/snapshot", (SnapshotRequest req) =>
+        {
+            if (string.IsNullOrWhiteSpace(req.TargetPath))
+                return Results.BadRequest(new { error = "targetPath is required." });
+            try
+            {
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                db.Snapshot(req.TargetPath);
+                sw.Stop();
+                long bytes = 0;
+                try { bytes = new FileInfo(req.TargetPath).Length; } catch { }
+                return Results.Ok(new
+                {
+                    success = true,
+                    targetPath = req.TargetPath,
+                    bytesCopied = bytes,
+                    timeMs = Math.Round(sw.Elapsed.TotalMilliseconds, 1)
+                });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
         // Rebuild every index on a collection from scratch.
         // Needed after a bulk insert that used ?skipIndexes=true, or any time
         // an operator suspects index corruption.
@@ -793,6 +823,7 @@ public static class ServeCommand
 public record QueryRequest(string Sql);
 public record SeedRequest(int? Orders);
 public record CreateIndexRequest(string Collection, string Path, string? Name = null, bool Unique = false);
+public record SnapshotRequest(string TargetPath);
 public record StartLeaderRequest(int Port, string? SharedSecret = null);
 public record StartFollowerRequest(string Host, int Port, string? SharedSecret = null);
 public record PromoteRequest(int Port);

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -1009,6 +1009,54 @@ public sealed class DocumentForgeDb : IDisposable
         _pageCache.FlushAll();
     }
 
+    /// <summary>
+    /// Take a consistent on-disk snapshot of the database to <paramref name="targetPath"/>.
+    /// Acquires the write lock briefly: flushes every dirty page, fsyncs, then
+    /// copies the data file. New writes are blocked for the duration of the
+    /// flush + copy and resume on return.
+    ///
+    /// <para>
+    /// Result file is a self-contained <c>.dfdb</c> that <see cref="Open"/> can
+    /// load directly. The recovery log and WAL are NOT copied — the snapshot
+    /// is always taken at a checkpointed boundary, so the data file alone is
+    /// authoritative. Operators restoring from the snapshot just point a new
+    /// node at it; no recovery dance.
+    /// </para>
+    ///
+    /// <para>
+    /// For a multi-GB dataset the copy itself dominates the wall time. If the
+    /// pause is unacceptable, run the snapshot against a follower node — the
+    /// follower's pause doesn't affect the leader's write throughput.
+    /// </para>
+    /// </summary>
+    public void Snapshot(string targetPath)
+    {
+        if (string.Equals(Path.GetFullPath(targetPath), Path.GetFullPath(FilePath),
+                StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("Snapshot targetPath must differ from the live data file.");
+
+        _transactionManager.AcquireWriteLock();
+        try
+        {
+            // FlushAll fsyncs the data file via OnAfterFlushComplete and
+            // truncates the recovery log. After this returns, the on-disk
+            // data file alone reflects the full committed state.
+            _pageCache.FlushAll();
+
+            // Copy under the write lock so no concurrent writer can race in
+            // between flush and copy. File.Copy on .NET reads with FileShare
+            // semantics that match a normal read — we still hold the data
+            // file's own handle, but Copy goes through a separate read path.
+            var targetDir = Path.GetDirectoryName(targetPath);
+            if (!string.IsNullOrEmpty(targetDir)) Directory.CreateDirectory(targetDir);
+            File.Copy(FilePath, targetPath, overwrite: true);
+        }
+        finally
+        {
+            _transactionManager.ReleaseWriteLock();
+        }
+    }
+
     public void Dispose()
     {
         if (!_disposed)

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -2246,6 +2246,82 @@ public class EngineTests : IDisposable
         }
     }
 
+    // --- Snapshot / backup API (issue #27) ---
+
+    [Fact]
+    public void Snapshot_ProducesIndependentFileWithSameContent()
+    {
+        _db.Insert("orders", """{"pnr":"ABC","seat":"12A"}""");
+        _db.Insert("orders", """{"pnr":"DEF","seat":"14B"}""");
+        _db.CreateIndex("orders", "pnr", "idx_orders_pnr", unique: true);
+
+        var snapshotPath = Path.Combine(Path.GetTempPath(), $"snapshot_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            _db.Snapshot(snapshotPath);
+            Assert.True(File.Exists(snapshotPath));
+
+            // The snapshot must open as an independent DB with the same docs
+            // AND the same indexes (so queries plan correctly post-restore).
+            using var restored = DocumentForgeDb.Open(snapshotPath);
+            var rows = restored.Execute("SELECT * FROM orders").Documents;
+            Assert.Equal(2, rows.Count);
+            Assert.Single(restored.GetIndexes("orders"));
+
+            // Indexed lookup against the snapshot finds the row — proves the
+            // index entries copied over and the catalog pointer survived.
+            var byPnr = restored.Execute("SELECT * FROM orders WHERE pnr = 'ABC'").Documents;
+            Assert.Single(byPnr);
+            Assert.Equal("12A", byPnr[0]["seat"].AsString);
+        }
+        finally
+        {
+            try { File.Delete(snapshotPath); } catch { }
+            try { File.Delete(snapshotPath + ".wal"); } catch { }
+            try { File.Delete(snapshotPath + ".recovery"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Snapshot_LiveDbContinuesToWorkAfterSnapshot()
+    {
+        _db.Insert("orders", """{"pnr":"BEFORE"}""");
+
+        var snapshotPath = Path.Combine(Path.GetTempPath(), $"snapshot_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            _db.Snapshot(snapshotPath);
+
+            // Live DB must accept new writes after the snapshot returns; the
+            // brief write-lock window during snapshot shouldn't leave the
+            // engine in any kind of degraded state.
+            _db.Insert("orders", """{"pnr":"AFTER"}""");
+            Assert.Equal(2, _db.Execute("SELECT * FROM orders").Documents.Count);
+
+            // The snapshot must not contain the post-snapshot row.
+            using var restored = DocumentForgeDb.Open(snapshotPath);
+            var rows = restored.Execute("SELECT * FROM orders").Documents;
+            Assert.Single(rows);
+            Assert.Equal("BEFORE", rows[0]["pnr"].AsString);
+        }
+        finally
+        {
+            try { File.Delete(snapshotPath); } catch { }
+            try { File.Delete(snapshotPath + ".wal"); } catch { }
+            try { File.Delete(snapshotPath + ".recovery"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Snapshot_SameAsLivePath_ThrowsClearError()
+    {
+        // Copying to the same path would self-truncate the live data file
+        // mid-flush. The engine catches that ahead of File.Copy with an
+        // ArgumentException so the failure mode is "no-op + clear error",
+        // not "corrupt the live database".
+        Assert.Throws<ArgumentException>(() => _db.Snapshot(_dbPath));
+    }
+
     public void Dispose()
     {
         _db.Dispose();


### PR DESCRIPTION
Closes #27.

## Summary
- New \`db.Snapshot(targetPath)\` engine method. Acquires the write lock, calls FlushAll, copies the data file, releases the lock. Snapshot is a self-contained .dfdb that \`Open\` loads directly.
- New REST endpoint \`POST /admin/snapshot\` returns bytes copied + elapsed ms. Rejects same-path with a clear ArgumentException.
- Multi-GB tip in the doc-comment: run against a follower if the brief write pause is unacceptable.

## Tests
- [x] Snapshot opens as an independent DB with same content + indexes; indexed lookups work.
- [x] Live DB keeps working after snapshot; new writes don't appear in the snapshot.
- [x] Same-path snapshot throws ArgumentException (would self-truncate the live file).
- [x] Full suite: 84/84 (was 81; +3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)