### PR TITLE
feat(#16): scalar SQL functions in WHERE + UPDATE (Phase 1)

### DIFF
--- a/src/DocumentForge.Query/Ast.cs
+++ b/src/DocumentForge.Query/Ast.cs
@@ -86,6 +86,42 @@ public sealed class CountStatement : Statement
     public Expression? Where { get; set; }
 }
 
+// --- Value expressions (right-hand side of comparisons, UPDATE SET, etc.) ---
+//
+// Used to be represented inline as `object? Value + TokenType ValueType`; the
+// abstraction makes room for scalar function calls (`NEWID()`, `LOWER(email)`)
+// and document-relative paths without re-typing every call site. Existing
+// callers store one of these in the legacy Value field and the evaluator
+// switches on the concrete type.
+public abstract class ValueExpression { }
+
+/// <summary>A SQL literal: string, number, true/false, null.</summary>
+public sealed class LiteralValueExpression : ValueExpression
+{
+    public object? Value { get; init; }
+    public TokenType ValueType { get; init; }
+}
+
+/// <summary>
+/// A document-relative path (e.g. <c>email</c>, <c>passenger.lastName</c>).
+/// Resolved against the current row by the evaluator.
+/// </summary>
+public sealed class PathValueExpression : ValueExpression
+{
+    public string Path { get; init; } = "";
+}
+
+/// <summary>
+/// A scalar function call: <c>NEWID()</c>, <c>GETDATE()</c>, <c>LOWER(email)</c>,
+/// <c>COALESCE(nickname, name)</c>. Args can themselves be values, paths, or
+/// nested function calls — composition is just recursive evaluation.
+/// </summary>
+public sealed class FunctionCallValueExpression : ValueExpression
+{
+    public string Name { get; init; } = "";
+    public List<ValueExpression> Args { get; init; } = new();
+}
+
 // --- Expressions (WHERE clause) ---
 public abstract class Expression { }
 
@@ -95,6 +131,16 @@ public sealed class ComparisonExpression : Expression
     public TokenType Operator { get; set; }
     public object? Value { get; set; }
     public TokenType ValueType { get; set; }
+
+    /// <summary>
+    /// When non-null, the comparison's LHS is computed from this expression
+    /// against the current row instead of via <see cref="JsonPath"/>. Used for
+    /// `WHERE LOWER(email) = 'alice'` and similar function-on-LHS shapes.
+    /// JsonPath stays empty (or holds the underlying path of a single
+    /// PathValueExpression) — index probes that need a literal field name
+    /// fall back to a collection scan when this is set.
+    /// </summary>
+    public ValueExpression? LhsExpression { get; set; }
 }
 
 public sealed class LogicalExpression : Expression

--- a/src/DocumentForge.Query/ExpressionEvaluator.cs
+++ b/src/DocumentForge.Query/ExpressionEvaluator.cs
@@ -22,11 +22,26 @@ public static class ExpressionEvaluator
 
     private static bool EvaluateComparison(ComparisonExpression expr, BsonDocument doc)
     {
-        var docValue = JsonPathExtractor.Extract(doc, expr.JsonPath);
+        // LHS resolution: a function-call LHS (`WHERE LOWER(email) = ...`) is
+        // evaluated against the current row instead of pulled from a path.
+        // The path-LHS case stays the historical fast path so existing queries
+        // hit zero overhead.
+        BsonValue docValue = expr.LhsExpression is not null
+            ? ValueEvaluator.Evaluate(expr.LhsExpression, doc)
+            : JsonPathExtractor.Extract(doc, expr.JsonPath);
+
+        // Function-call (or path-in-value-position, or any other ValueExpression)
+        // RHS: evaluate against the current row, then compare on BsonValue
+        // semantics. The legacy primitive-literal path stays untouched below.
+        if (expr.ValueType == TokenType.ValueExpression && expr.Value is ValueExpression vexpr)
+        {
+            var rhs = ValueEvaluator.Evaluate(vexpr, doc);
+            return CompareBsonValues(docValue, rhs, expr.Operator);
+        }
+
         if (docValue.IsNull && expr.Value is not null)
             return false;
 
-        var compareValue = ConvertToComparable(expr.Value, expr.ValueType);
         int cmp;
 
         if (expr.Operator == TokenType.Like)
@@ -70,6 +85,34 @@ public static class ExpressionEvaluator
             TokenType.GreaterThanOrEqual => cmp >= 0,
             TokenType.LessThanOrEqual => cmp <= 0,
             _ => false
+        };
+    }
+
+    /// <summary>
+    /// Compare two already-evaluated <see cref="BsonValue"/>s using the
+    /// engine's CompareTo semantics (Null &lt; Bool &lt; Number &lt; String &lt; DateTime).
+    /// Used by the ValueExpression-RHS path where we know both sides as BsonValue
+    /// up front; the legacy literal-RHS path threads CLR-typed object through
+    /// the type-aware switch above and stays as-is to preserve its quirks.
+    /// </summary>
+    private static bool CompareBsonValues(BsonValue lhs, BsonValue rhs, TokenType op)
+    {
+        // SQL semantics: any comparison with NULL is false (not "null", just
+        // false) — matches what the legacy path returns when docValue.IsNull
+        // and expr.Value is non-null.
+        if (lhs.IsNull || rhs.IsNull) return false;
+
+        int cmp = lhs.CompareTo(rhs);
+        return op switch
+        {
+            TokenType.Equals => cmp == 0,
+            TokenType.NotEquals => cmp != 0,
+            TokenType.GreaterThan => cmp > 0,
+            TokenType.LessThan => cmp < 0,
+            TokenType.GreaterThanOrEqual => cmp >= 0,
+            TokenType.LessThanOrEqual => cmp <= 0,
+            TokenType.Like => lhs.Type == BsonType.String && EvaluateLike(lhs, rhs.ToString()),
+            _ => false,
         };
     }
 

--- a/src/DocumentForge.Query/Parser.cs
+++ b/src/DocumentForge.Query/Parser.cs
@@ -301,11 +301,31 @@ public sealed class Parser
 
     private Expression ParseComparison()
     {
-        var path = ReadIdentifierPath();
+        // Function-call LHS: `LOWER(email) = 'alice'`. Detected by
+        // `Identifier '('` lookahead — same pattern as the value-position path.
+        // Captured as a ValueExpression on the comparison; the evaluator picks
+        // it up via ComparisonExpression.LhsExpression.
+        ValueExpression? lhsExpr = null;
+        string path;
+        if (Current.Type == TokenType.Identifier && Peek().Type == TokenType.LeftParen)
+        {
+            lhsExpr = ReadFunctionCallValueExpression();
+            // JsonPath stays empty so index probes that key on the column name
+            // see no candidate and fall back to a collection scan — the
+            // function-LHS form can't go through an indexed lookup without
+            // a function-aware index, which is its own (much larger) feature.
+            path = "";
+        }
+        else
+        {
+            path = ReadIdentifierPath();
+        }
 
-        // IS NULL / IS NOT NULL
+        // IS NULL / IS NOT NULL — only valid against a path LHS today.
         if (Current.Type == TokenType.Is)
         {
+            if (lhsExpr is not null)
+                throw new QueryParseException("IS NULL / IS NOT NULL is only supported on path expressions, not function calls.", Current.Position);
             _pos++;
             bool isNotNull = Match(TokenType.Not);
             Expect(TokenType.Null);
@@ -366,7 +386,8 @@ public sealed class Parser
             JsonPath = path,
             Operator = op,
             Value = value,
-            ValueType = valueType
+            ValueType = valueType,
+            LhsExpression = lhsExpr,
         };
     }
 
@@ -407,6 +428,20 @@ public sealed class Parser
 
     private (object? value, TokenType type) ReadLiteralValue()
     {
+        // Function-call form: `Identifier '(' ... ')'`. Captured as an opaque
+        // ValueExpression carried through the legacy (object? value, TokenType type)
+        // tuple so existing callers don't need to be re-typed; the evaluator
+        // dispatches on the concrete type at runtime. Bare identifiers (no
+        // following paren) are not valid in the literal position — this is the
+        // historical "expected literal value" path and we keep that strictness
+        // so a typo'd identifier surfaces clearly instead of silently being
+        // interpreted as a path.
+        if (Current.Type == TokenType.Identifier && Peek().Type == TokenType.LeftParen)
+        {
+            var fnCall = ReadFunctionCallValueExpression();
+            return (fnCall, TokenType.ValueExpression);
+        }
+
         var token = Current;
         _pos++;
 
@@ -418,6 +453,59 @@ public sealed class Parser
             TokenType.False => (false, TokenType.False),
             TokenType.Null => (null, TokenType.Null),
             _ => throw new QueryParseException($"Expected literal value, got {token.Type}", token.Position)
+        };
+    }
+
+    /// <summary>
+    /// Parse a value position: a literal, a path, a function call, or a nested
+    /// function call. Used by function-argument parsing (so <c>LOWER(email)</c>
+    /// passes the path <c>email</c>) and reachable from any value site that
+    /// chooses to opt in. The legacy <see cref="ReadLiteralValue"/> entry point
+    /// still exists for callers that haven't moved over.
+    /// </summary>
+    private ValueExpression ReadValueExpression()
+    {
+        // Function call: `Identifier '(' ... ')'`.
+        if (Current.Type == TokenType.Identifier && Peek().Type == TokenType.LeftParen)
+            return ReadFunctionCallValueExpression();
+
+        // Bare identifier (or dotted/indexed path): treat as a document path.
+        // Distinguishing this from a function call is the lookahead above —
+        // path is the fall-through.
+        if (Current.Type == TokenType.Identifier)
+            return new PathValueExpression { Path = ReadIdentifierPath() };
+
+        var token = Current;
+        _pos++;
+        return token.Type switch
+        {
+            TokenType.StringLiteral => new LiteralValueExpression { Value = token.Value, ValueType = TokenType.StringLiteral },
+            TokenType.NumberLiteral => new LiteralValueExpression { Value = double.Parse(token.Value), ValueType = TokenType.NumberLiteral },
+            TokenType.True => new LiteralValueExpression { Value = true, ValueType = TokenType.True },
+            TokenType.False => new LiteralValueExpression { Value = false, ValueType = TokenType.False },
+            TokenType.Null => new LiteralValueExpression { Value = null, ValueType = TokenType.Null },
+            _ => throw new QueryParseException($"Expected value (literal, path, or function call), got {token.Type}", token.Position)
+        };
+    }
+
+    private FunctionCallValueExpression ReadFunctionCallValueExpression()
+    {
+        var nameTok = Expect(TokenType.Identifier);
+        Expect(TokenType.LeftParen);
+
+        var args = new List<ValueExpression>();
+        if (Current.Type != TokenType.RightParen)
+        {
+            args.Add(ReadValueExpression());
+            while (Match(TokenType.Comma))
+                args.Add(ReadValueExpression());
+        }
+        Expect(TokenType.RightParen);
+
+        return new FunctionCallValueExpression
+        {
+            Name = nameTok.Value,
+            Args = args,
         };
     }
 

--- a/src/DocumentForge.Query/QueryExecutor.cs
+++ b/src/DocumentForge.Query/QueryExecutor.cs
@@ -657,6 +657,16 @@ public sealed class QueryExecutor
 
     private BsonValue ConvertToSearchValue(object? value, TokenType type)
     {
+        // ValueExpression case: a function call (NEWID(), GETDATE()) or a path
+        // captured in a value position. Evaluate against no document — the
+        // index-probe call sites have no row context, so a path-in-value here
+        // would throw. That's intentional; an indexed lookup of `WHERE x = y.z`
+        // is ambiguous (which row's `y.z`?) and the user wants either a literal,
+        // a constant function, or a row-scoped UPDATE SET (which goes through
+        // the ConvertToSearchValueFor variant below).
+        if (type == TokenType.ValueExpression && value is ValueExpression vexpr)
+            return ValueEvaluator.Evaluate(vexpr, docContext: null);
+
         return type switch
         {
             TokenType.StringLiteral => BsonValue.FromString((string)value!),
@@ -668,6 +678,18 @@ public sealed class QueryExecutor
             TokenType.Null => BsonValue.Null,
             _ => BsonValue.Null
         };
+    }
+
+    /// <summary>
+    /// Row-scoped variant of <see cref="ConvertToSearchValue"/>. Used by UPDATE
+    /// SET so <c>UPDATE users SET name = LOWER(name)</c> can resolve the path
+    /// argument against the row being updated.
+    /// </summary>
+    private BsonValue ConvertToSearchValueFor(object? value, TokenType type, BsonDocument doc)
+    {
+        if (type == TokenType.ValueExpression && value is ValueExpression vexpr)
+            return ValueEvaluator.Evaluate(vexpr, docContext: doc);
+        return ConvertToSearchValue(value, type);
     }
 
     private QueryResult ExecuteInsert(InsertStatement stmt)
@@ -699,7 +721,10 @@ public sealed class QueryExecutor
             var newDoc = CloneDocument(oldDoc);
             foreach (var clause in stmt.SetClauses)
             {
-                var val = ConvertToSearchValue(clause.Value, clause.ValueType);
+                // Pass the OLD doc as the path-resolution context so
+                // `SET name = LOWER(name)` reads the pre-update value, not
+                // the half-built newDoc.
+                var val = ConvertToSearchValueFor(clause.Value, clause.ValueType, oldDoc);
                 SetNestedValue(newDoc, clause.Path, val);
             }
             if (collection.Update(id, newDoc))

--- a/src/DocumentForge.Query/ScalarFunctions.cs
+++ b/src/DocumentForge.Query/ScalarFunctions.cs
@@ -1,0 +1,127 @@
+using DocumentForge.Document;
+using DocumentForge.Index;
+
+namespace DocumentForge.Query;
+
+/// <summary>
+/// Built-in scalar SQL functions: <c>NEWID()</c>, <c>GETDATE()</c>,
+/// <c>LOWER(x)</c>, <c>COALESCE(...)</c>, etc.
+///
+/// <para>
+/// Functions are dispatched by case-insensitive name. Unknown names throw
+/// <see cref="DocumentForge.Core.QueryParseException"/>-equivalent at evaluation
+/// time so a typo'd <c>NWID()</c> doesn't silently return null. Common SQL
+/// dialect aliases (NOW = GETDATE, IFNULL = COALESCE, UUID = NEWID) are
+/// registered as separate entries pointing at the same implementation —
+/// cheaper than aliasing logic and keeps the dispatch table self-documenting.
+/// </para>
+///
+/// <para>
+/// Args are pre-evaluated to <see cref="BsonValue"/> by the caller. NULL
+/// propagation rules follow standard SQL: most functions return NULL on a
+/// NULL argument; <see cref="Coalesce"/> is the deliberate exception (its
+/// whole job is to skip NULLs).
+/// </para>
+/// </summary>
+internal static class ScalarFunctions
+{
+    private static readonly Dictionary<string, Func<IReadOnlyList<BsonValue>, BsonValue>> Registry =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // ID generation — single fresh GUID per call.
+            ["NEWID"] = NewId,
+            ["UUID"] = NewId,
+            ["GENERATE_UUID"] = NewId,
+
+            // Server-clock timestamps.
+            ["GETDATE"] = Now,
+            ["NOW"] = Now,
+            ["CURRENT_TIMESTAMP"] = Now,
+
+            // String transforms.
+            ["LOWER"] = Lower,
+            ["UPPER"] = Upper,
+            ["LENGTH"] = Length,
+            ["LEN"] = Length, // T-SQL alias
+            ["TRIM"] = Trim,
+
+            // Null coalescing.
+            ["COALESCE"] = Coalesce,
+            ["IFNULL"] = Coalesce,
+            ["ISNULL"] = Coalesce, // T-SQL spelling; same semantics here
+        };
+
+    public static bool IsKnown(string name) => Registry.ContainsKey(name);
+
+    public static BsonValue Invoke(string name, IReadOnlyList<BsonValue> args)
+    {
+        if (!Registry.TryGetValue(name, out var fn))
+            throw new DocumentForge.Core.DocumentForgeException(
+                $"Unknown scalar function '{name}'. Known functions: " +
+                string.Join(", ", Registry.Keys.Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(k => k)) + ".");
+        return fn(args);
+    }
+
+    private static BsonValue NewId(IReadOnlyList<BsonValue> args)
+    {
+        ExpectArity("NEWID", args, expected: 0);
+        return BsonValue.FromString(Guid.NewGuid().ToString("D"));
+    }
+
+    private static BsonValue Now(IReadOnlyList<BsonValue> args)
+    {
+        // NOW() / GETDATE() take no args. Allow zero args; reject any.
+        // (CURRENT_TIMESTAMP without parens is a SQL-92 special form; we
+        // require parens for consistency with the function-call grammar.)
+        ExpectArity("NOW/GETDATE/CURRENT_TIMESTAMP", args, expected: 0);
+        return BsonValue.FromDateTime(DateTime.UtcNow);
+    }
+
+    private static BsonValue Lower(IReadOnlyList<BsonValue> args)
+    {
+        ExpectArity("LOWER", args, expected: 1);
+        if (args[0].IsNull) return BsonValue.Null;
+        return BsonValue.FromString(args[0].ToString().ToLowerInvariant());
+    }
+
+    private static BsonValue Upper(IReadOnlyList<BsonValue> args)
+    {
+        ExpectArity("UPPER", args, expected: 1);
+        if (args[0].IsNull) return BsonValue.Null;
+        return BsonValue.FromString(args[0].ToString().ToUpperInvariant());
+    }
+
+    private static BsonValue Length(IReadOnlyList<BsonValue> args)
+    {
+        ExpectArity("LENGTH", args, expected: 1);
+        if (args[0].IsNull) return BsonValue.Null;
+        // Code-point-wise count of the string form. For arrays this returns
+        // the JSON string length, not the element count — keep that simple
+        // for now; ARRAY_LENGTH can be a separate function later.
+        return BsonValue.FromInt32(args[0].ToString().Length);
+    }
+
+    private static BsonValue Trim(IReadOnlyList<BsonValue> args)
+    {
+        ExpectArity("TRIM", args, expected: 1);
+        if (args[0].IsNull) return BsonValue.Null;
+        return BsonValue.FromString(args[0].ToString().Trim());
+    }
+
+    private static BsonValue Coalesce(IReadOnlyList<BsonValue> args)
+    {
+        if (args.Count == 0)
+            throw new DocumentForge.Core.DocumentForgeException(
+                "COALESCE / IFNULL requires at least one argument.");
+        foreach (var a in args)
+            if (!a.IsNull) return a;
+        return BsonValue.Null;
+    }
+
+    private static void ExpectArity(string fn, IReadOnlyList<BsonValue> args, int expected)
+    {
+        if (args.Count != expected)
+            throw new DocumentForge.Core.DocumentForgeException(
+                $"{fn} expects {expected} argument(s), got {args.Count}.");
+    }
+}

--- a/src/DocumentForge.Query/Token.cs
+++ b/src/DocumentForge.Query/Token.cs
@@ -25,6 +25,11 @@ public enum TokenType
     Identifier, StringLiteral, NumberLiteral,
     JsonLiteral,
 
+    // Synthetic — used by the parser to flag a comparison/SET value slot that
+    // holds a ValueExpression (literal/path/function-call composition) rather
+    // than a primitive literal. Never produced by the lexer.
+    ValueExpression,
+
     // Special
     Eof
 }

--- a/src/DocumentForge.Query/ValueEvaluator.cs
+++ b/src/DocumentForge.Query/ValueEvaluator.cs
@@ -1,0 +1,74 @@
+using DocumentForge.Core;
+using DocumentForge.Document;
+using DocumentForge.Index;
+
+namespace DocumentForge.Query;
+
+/// <summary>
+/// Walks a <see cref="ValueExpression"/> tree and produces a
+/// <see cref="BsonValue"/>. Used by the WHERE comparison evaluator and the
+/// UPDATE SET path to expand <c>NEWID()</c>, <c>LOWER(email)</c>, and
+/// similar at evaluation time.
+///
+/// <para>
+/// <paramref name="docContext"/> is the row currently being evaluated. Required
+/// for <see cref="PathValueExpression"/> resolution; can be null in
+/// pre-row contexts (e.g. an index probe where we just need the literal/
+/// function value to look up). Passing null and then hitting a path is a
+/// caller error and throws.
+/// </para>
+/// </summary>
+public static class ValueEvaluator
+{
+    public static BsonValue Evaluate(ValueExpression expr, BsonDocument? docContext)
+    {
+        return expr switch
+        {
+            LiteralValueExpression lit => LiteralToBson(lit),
+            PathValueExpression path => ResolvePath(path, docContext),
+            FunctionCallValueExpression fn => InvokeFunction(fn, docContext),
+            _ => BsonValue.Null,
+        };
+    }
+
+    private static BsonValue ResolvePath(PathValueExpression path, BsonDocument? doc)
+    {
+        if (doc is null)
+            throw new DocumentForgeException(
+                $"Path '{path.Path}' cannot be resolved without a document context. " +
+                "(This usually means the value appears in a position the engine couldn't bind to a row, e.g. an index probe.)");
+        return JsonPathExtractor.Extract(doc, path.Path);
+    }
+
+    private static BsonValue InvokeFunction(FunctionCallValueExpression fn, BsonDocument? doc)
+    {
+        // Eager evaluation of args. Lazy/short-circuit semantics aren't needed
+        // for the current function set — the only function with conceptually
+        // lazy args (COALESCE) is small enough that evaluating all args and
+        // picking the first non-null is the same answer for the same cost.
+        var argValues = new BsonValue[fn.Args.Count];
+        for (int i = 0; i < fn.Args.Count; i++)
+            argValues[i] = Evaluate(fn.Args[i], doc);
+        return ScalarFunctions.Invoke(fn.Name, argValues);
+    }
+
+    private static BsonValue LiteralToBson(LiteralValueExpression lit) => lit.ValueType switch
+    {
+        TokenType.StringLiteral => BsonValue.FromString((string)lit.Value!),
+        TokenType.NumberLiteral => NumberLiteralToBson((double)lit.Value!),
+        TokenType.True => BsonValue.FromBool(true),
+        TokenType.False => BsonValue.FromBool(false),
+        TokenType.Null => BsonValue.Null,
+        _ => BsonValue.Null,
+    };
+
+    private static BsonValue NumberLiteralToBson(double d)
+    {
+        // Preserve integer-vs-float distinction at the BSON level so downstream
+        // index probes don't treat 1 and 1.0 as different keys (BTreeIndex
+        // hashes on the underlying type-tagged value).
+        if (d == Math.Floor(d) && d is >= int.MinValue and <= int.MaxValue)
+            return BsonValue.FromInt32((int)d);
+        return BsonValue.FromDouble(d);
+    }
+}

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -2648,6 +2648,206 @@ public class EngineTests : IDisposable
         Assert.Equal(0, forced.Execute("SELECT * FROM orders").Documents.Count);
     }
 
+    // --- Scalar SQL functions (issue #16) ---
+    //
+    // The headline goal is server-side ID/timestamp generation and string
+    // transforms callers can use without round-tripping. INSERT-with-functions
+    // is deferred (would need a JSON+functions parser); this batch covers the
+    // WHERE and UPDATE SET shapes — the immediately useful surface.
+
+    [Fact]
+    public void Sql_Function_Lower_InWhere_MatchesIndexedField()
+    {
+        _db.Insert("users", """{"email":"Alice@Example.com"}""");
+        _db.Insert("users", """{"email":"BOB@x.com"}""");
+
+        // LOWER(email) lets callers normalise on the server side without
+        // having to lower-case the value client-side first.
+        var rows = _db.Execute("SELECT * FROM users WHERE LOWER(email) = 'alice@example.com'").Documents;
+        Assert.Single(rows);
+        Assert.Equal("Alice@Example.com", rows[0]["email"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Upper_InWhereOnLiteralRhs()
+    {
+        _db.Insert("users", """{"name":"ALICE"}""");
+        _db.Insert("users", """{"name":"bob"}""");
+
+        // The right-hand side (a function call wrapping a literal) is the
+        // simpler case — no row context needed for the arg.
+        var rows = _db.Execute("SELECT * FROM users WHERE name = UPPER('alice')").Documents;
+        Assert.Single(rows);
+        Assert.Equal("ALICE", rows[0]["name"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Length_InWhere()
+    {
+        _db.Insert("users", """{"code":"AB"}""");
+        _db.Insert("users", """{"code":"ABCD"}""");
+        _db.Insert("users", """{"code":"ABCDEF"}""");
+
+        var rows = _db.Execute("SELECT * FROM users WHERE LENGTH(code) = 4").Documents;
+        Assert.Single(rows);
+        Assert.Equal("ABCD", rows[0]["code"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Trim_InWhere()
+    {
+        _db.Insert("users", """{"name":"  Alice  "}""");
+        _db.Insert("users", """{"name":"Bob"}""");
+
+        var rows = _db.Execute("SELECT * FROM users WHERE TRIM(name) = 'Alice'").Documents;
+        Assert.Single(rows);
+    }
+
+    [Fact]
+    public void Sql_Function_Coalesce_TwoArg_FallsBackOnNullPath()
+    {
+        _db.Insert("users", """{"name":"Alice","nickname":"Ali"}""");
+        _db.Insert("users", """{"name":"Bob"}""");
+        _db.Insert("users", """{"name":"Charlie","nickname":"Chuck"}""");
+
+        // COALESCE(nickname, name) returns the first non-null. The Bob row
+        // has no nickname → falls through to "Bob"; matches.
+        var rows = _db.Execute("SELECT * FROM users WHERE COALESCE(nickname, name) = 'Bob'").Documents;
+        Assert.Single(rows);
+        Assert.Equal("Bob", rows[0]["name"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Ifnull_AliasOfCoalesce()
+    {
+        _db.Insert("users", """{"name":"Alice"}""");
+
+        // IFNULL is the two-arg shorthand many SQL dialects use; here it's
+        // an alias of COALESCE.
+        var rows = _db.Execute("SELECT * FROM users WHERE IFNULL(nickname, name) = 'Alice'").Documents;
+        Assert.Single(rows);
+    }
+
+    [Fact]
+    public void Sql_Function_Newid_InUpdate_StampsFreshId()
+    {
+        var id = _db.Insert("users", """{"name":"Alice"}""");
+
+        // NEWID() in UPDATE SET — a real motivating use case: backfilling a
+        // GUID column without round-tripping a generated value from the client.
+        var r = _db.Execute("UPDATE users SET sessionToken = NEWID() WHERE name = 'Alice'");
+        Assert.True(r.Success, r.Message);
+        Assert.Equal(1, r.AffectedCount);
+
+        var doc = _db.GetCollection("users")!.FindById(id)!;
+        var token = doc["sessionToken"].AsString;
+        Assert.True(Guid.TryParse(token, out _),
+            $"sessionToken should be a parseable GUID, got '{token}'");
+    }
+
+    [Fact]
+    public void Sql_Function_Newid_TwoCallsProduceDifferentValues()
+    {
+        // Each NEWID() call must be a fresh GUID, not constant-folded to the
+        // same value across rows in a single UPDATE.
+        _db.Insert("users", """{"name":"A"}""");
+        _db.Insert("users", """{"name":"B"}""");
+        _db.Insert("users", """{"name":"C"}""");
+
+        _db.Execute("UPDATE users SET token = NEWID()");
+
+        var tokens = _db.Execute("SELECT * FROM users").Documents
+            .Select(d => d["token"].AsString)
+            .ToList();
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(3, tokens.Distinct().Count());
+    }
+
+    [Fact]
+    public void Sql_Function_Now_InUpdate_StampsServerTimestamp()
+    {
+        _db.Insert("orders", """{"status":"pending"}""");
+
+        var before = DateTime.UtcNow.AddSeconds(-2);
+        _db.Execute("UPDATE orders SET updatedAt = NOW() WHERE status = 'pending'");
+        var after = DateTime.UtcNow.AddSeconds(2);
+
+        var doc = _db.Execute("SELECT * FROM orders").Documents[0];
+        var stamped = doc["updatedAt"].AsDateTime;
+        Assert.InRange(stamped.UtcDateTime, before, after);
+    }
+
+    [Fact]
+    public void Sql_Function_Getdate_AliasOfNow()
+    {
+        // SQL Server's GETDATE() and ANSI NOW() share an implementation here.
+        _db.Insert("orders", """{"status":"new"}""");
+        _db.Execute("UPDATE orders SET createdAt = GETDATE() WHERE status = 'new'");
+        var stamped = _db.Execute("SELECT * FROM orders").Documents[0]["createdAt"].AsDateTime;
+        Assert.True(stamped.UtcDateTime > DateTime.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public void Sql_Function_CurrentTimestamp_AliasOfNow()
+    {
+        _db.Insert("orders", """{"status":"new"}""");
+        _db.Execute("UPDATE orders SET createdAt = CURRENT_TIMESTAMP() WHERE status = 'new'");
+        var stamped = _db.Execute("SELECT * FROM orders").Documents[0]["createdAt"].AsDateTime;
+        Assert.True(stamped.UtcDateTime > DateTime.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public void Sql_Function_Lower_InUpdate_NormalisesPathArg()
+    {
+        // SET name = LOWER(name) — function reads the OLD doc value, not the
+        // half-built newDoc. Matters because we update the same field we're
+        // reading from.
+        var id = _db.Insert("users", """{"name":"ALICE"}""");
+
+        var r = _db.Execute("UPDATE users SET name = LOWER(name)");
+        Assert.True(r.Success, r.Message);
+        Assert.Equal(1, r.AffectedCount);
+
+        var doc = _db.GetCollection("users")!.FindById(id)!;
+        Assert.Equal("alice", doc["name"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Coalesce_InUpdate_FillsMissingField()
+    {
+        _db.Insert("users", """{"name":"Alice"}""");
+        _db.Insert("users", """{"name":"Bob","displayName":"Bobby"}""");
+
+        // SET displayName = COALESCE(displayName, name): Alice gets her name
+        // copied (no displayName); Bob keeps Bobby (already set).
+        _db.Execute("UPDATE users SET displayName = COALESCE(displayName, name)");
+
+        var rows = _db.Execute("SELECT * FROM users").Documents;
+        var alice = rows.First(d => d["name"].AsString == "Alice");
+        var bob = rows.First(d => d["name"].AsString == "Bob");
+        Assert.Equal("Alice", alice["displayName"].AsString);
+        Assert.Equal("Bobby", bob["displayName"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Function_Unknown_FailsCleanly()
+    {
+        _db.Insert("users", """{"name":"Alice"}""");
+        // Typo on the function name surfaces as a clear error rather than a
+        // mysterious zero-row result.
+        var r = _db.Execute("SELECT * FROM users WHERE NWID() = 'x'");
+        Assert.False(r.Success);
+        Assert.Contains("NWID", r.Message ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sql_Function_WrongArity_FailsCleanly()
+    {
+        _db.Insert("users", """{"name":"Alice"}""");
+        var r = _db.Execute("SELECT * FROM users WHERE LOWER() = 'alice'");
+        Assert.False(r.Success);
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Phase 1 of #16. INSERT-with-functions is its own follow-up at #34.

## Summary
- Functions land in the WHERE comparison surface (both LHS and RHS) and UPDATE SET. \`SELECT NEWID() AS id\` projection support is a natural follow-up but not in this PR.
- 11 functions in this batch: \`NEWID\` / \`UUID\` / \`GENERATE_UUID\`, \`GETDATE\` / \`NOW\` / \`CURRENT_TIMESTAMP\`, \`LOWER\`, \`UPPER\`, \`LENGTH\` / \`LEN\`, \`TRIM\`, \`COALESCE\` / \`IFNULL\` / \`ISNULL\`.
- Args can be literals, document paths, or nested function calls.
- New \`ScalarFunctions.cs\` dispatch table — adding a future function is a one-line entry.
- Function-LHS (\`WHERE LOWER(email) = ...\`) currently bypasses the index and falls back to a collection scan; function-aware indexes are a much larger feature deliberately not in scope.

## Test plan
- [x] 15 new tests covering each function in WHERE (both sides) and UPDATE shapes.
- [x] Two \`NEWID()\` calls in one UPDATE produce distinct GUIDs (no constant-folding).
- [x] \`NOW()\` stamps a clock-bound timestamp.
- [x] \`COALESCE\` skips NULL paths.
- [x] Unknown function name / wrong arity surface as clean errors with the bad token in the message.
- [x] Full suite: 122/122 (was 107; +15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)