### PR TITLE
feat(#34): INSERT INTO t (cols) VALUES (vals) — scalar functions in inserts

### DIFF
--- a/src/DocumentForge.Query/Ast.cs
+++ b/src/DocumentForge.Query/Ast.cs
@@ -43,7 +43,22 @@ public sealed class JoinClause
 public sealed class InsertStatement : Statement
 {
     public string Collection { get; set; } = "";
+
+    /// <summary>
+    /// Classic JSON form: <c>INSERT INTO users VALUES { "email": "..." }</c>.
+    /// When <see cref="Columns"/> is non-empty, this is empty and the
+    /// SQL-tuple form is used instead.
+    /// </summary>
     public string JsonDocument { get; set; } = "";
+
+    /// <summary>
+    /// SQL-tuple form: <c>INSERT INTO users (email, _id) VALUES ('a@b.com', NEWID())</c>.
+    /// <see cref="Columns"/> and <see cref="Values"/> are populated together
+    /// and have the same length; values can be literals, paths, or function
+    /// calls (composing with the #16 ValueExpression hierarchy).
+    /// </summary>
+    public List<string> Columns { get; set; } = new();
+    public List<ValueExpression> Values { get; set; } = new();
 }
 
 public sealed class UpdateStatement : Statement

--- a/src/DocumentForge.Query/Parser.cs
+++ b/src/DocumentForge.Query/Parser.cs
@@ -166,12 +166,55 @@ public sealed class Parser
         Expect(TokenType.Into);
         var collection = ReadIdentifierPath();
 
-        // Optional VALUES keyword
+        // Two shapes:
+        //   INSERT INTO t (col1, col2) VALUES (val1, val2)        -- tuple form
+        //   INSERT INTO t [VALUES] { "col1": v1, "col2": v2 }     -- JSON form
+        // The tuple form supports scalar functions in value positions
+        // (NEWID(), GETDATE(), LOWER('Alice')), the JSON form does not — its
+        // body is read by BsonDocument.FromJson which has no notion of
+        // function calls.
+        if (Current.Type == TokenType.LeftParen)
+        {
+            return ParseInsertTupleForm(collection);
+        }
+
+        // Optional VALUES keyword (JSON form)
         if (Current.Type == TokenType.Values)
             _pos++;
 
         var json = Expect(TokenType.JsonLiteral).Value;
         return new InsertStatement { Collection = collection, JsonDocument = json };
+    }
+
+    private InsertStatement ParseInsertTupleForm(string collection)
+    {
+        // Column list: (col1, col2, ...). Paths aren't allowed here — only
+        // top-level field names. (Nested-field assignment via dotted paths
+        // could be a follow-up, but UPDATE SET handles that need today.)
+        Expect(TokenType.LeftParen);
+        var columns = new List<string> { Expect(TokenType.Identifier).Value };
+        while (Match(TokenType.Comma))
+            columns.Add(Expect(TokenType.Identifier).Value);
+        Expect(TokenType.RightParen);
+
+        Expect(TokenType.Values);
+        Expect(TokenType.LeftParen);
+        var values = new List<ValueExpression> { ReadValueExpression() };
+        while (Match(TokenType.Comma))
+            values.Add(ReadValueExpression());
+        Expect(TokenType.RightParen);
+
+        if (columns.Count != values.Count)
+            throw new QueryParseException(
+                $"INSERT column/value count mismatch: {columns.Count} columns but {values.Count} values.",
+                Current.Position);
+
+        return new InsertStatement
+        {
+            Collection = collection,
+            Columns = columns,
+            Values = values,
+        };
     }
 
     private UpdateStatement ParseUpdate()

--- a/src/DocumentForge.Query/QueryExecutor.cs
+++ b/src/DocumentForge.Query/QueryExecutor.cs
@@ -694,8 +694,37 @@ public sealed class QueryExecutor
 
     private QueryResult ExecuteInsert(InsertStatement stmt)
     {
+        BsonDocument doc;
+        if (stmt.Columns.Count > 0)
+        {
+            // SQL-tuple form: build a fresh document by evaluating each
+            // ValueExpression. No row context (this is INSERT, there's no
+            // pre-existing row), so PathValueExpression args would throw —
+            // that's the right behaviour: `INSERT INTO t (x) VALUES (y.z)`
+            // is meaningless without a source row, and the parser doesn't
+            // accept it via SELECT-INTO yet.
+            doc = new BsonDocument();
+            for (int i = 0; i < stmt.Columns.Count; i++)
+            {
+                var val = ValueEvaluator.Evaluate(stmt.Values[i], docContext: null);
+                doc[stmt.Columns[i]] = val;
+            }
+        }
+        else
+        {
+            // Classic JSON-literal form. No function-call support here —
+            // BsonDocument.FromJson is a strict JSON parser and we don't
+            // pre-process its input.
+            doc = BsonDocument.FromJson(stmt.JsonDocument);
+        }
+
         var collection = _catalog.GetOrCreateCollection(stmt.Collection);
-        var doc = BsonDocument.FromJson(stmt.JsonDocument);
+        // Pre-validate uniqueness so a function-generated value (e.g. a NEWID
+        // collision against an existing _id, vanishingly rare but possible if
+        // someone used a fixed-seed RNG client-side and then NEWID() from
+        // server) doesn't half-commit. Mirrors the discipline DocumentForgeDb
+        // uses on its own Insert path.
+        _indexManager.ValidateUniqueInsert(stmt.Collection, doc);
         var id = collection.Insert(doc);
         _indexManager.OnDocumentInserted(stmt.Collection, id, doc);
         return QueryResult.Affected(1, $"Inserted document {id}");

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -2906,6 +2906,101 @@ public class EngineTests : IDisposable
         }
     }
 
+    // --- INSERT tuple form with scalar functions (issue #34) ---
+
+    [Fact]
+    public void Sql_Insert_TupleForm_AcceptsLiteralsAndFunctions()
+    {
+        // The headline use case from #16: NEWID() + GETDATE() server-side
+        // at insert time. Pre-fix this was the WORKAROUND callers reached
+        // for — generate a Guid client-side, format the JSON, send it up.
+        var r = _db.Execute(
+            "INSERT INTO users (_id, email, createdAt) VALUES (NEWID(), 'a@b.com', GETDATE())");
+        Assert.True(r.Success, r.Message);
+        Assert.Equal(1, r.AffectedCount);
+
+        var rows = _db.Execute("SELECT * FROM users").Documents;
+        Assert.Single(rows);
+        var doc = rows[0];
+
+        // _id is a fresh GUID — parses as one and isn't the empty Guid.
+        Assert.True(Guid.TryParse(doc["_id"].ToString(), out var idGuid));
+        Assert.NotEqual(Guid.Empty, idGuid);
+
+        Assert.Equal("a@b.com", doc["email"].AsString);
+
+        // createdAt was stamped by the server's clock — we can't pin the
+        // exact value, just bracket it.
+        var createdAt = doc["createdAt"].AsDateTime;
+        Assert.True(createdAt.UtcDateTime > DateTime.UtcNow.AddMinutes(-1));
+    }
+
+    [Fact]
+    public void Sql_Insert_TupleForm_NewIdEachCallIsUnique()
+    {
+        // Two consecutive INSERTs with NEWID() must produce different ids —
+        // not constant-folded across calls.
+        _db.Execute("INSERT INTO users (_id, name) VALUES (NEWID(), 'A')");
+        _db.Execute("INSERT INTO users (_id, name) VALUES (NEWID(), 'B')");
+        var ids = _db.Execute("SELECT * FROM users").Documents
+            .Select(d => d["_id"].ToString()).ToList();
+        Assert.Equal(2, ids.Count);
+        Assert.Equal(2, ids.Distinct().Count());
+    }
+
+    [Fact]
+    public void Sql_Insert_TupleForm_NestedFunctionCall()
+    {
+        // LOWER('Alice') as a value — function args nest down through the
+        // ValueExpression tree the same way they do in WHERE / UPDATE SET.
+        var r = _db.Execute("INSERT INTO users (name) VALUES (LOWER('Alice'))");
+        Assert.True(r.Success, r.Message);
+        var doc = _db.Execute("SELECT * FROM users").Documents[0];
+        Assert.Equal("alice", doc["name"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Insert_TupleForm_ColumnValueCountMismatch_FailsCleanly()
+    {
+        var r = _db.Execute("INSERT INTO users (a, b, c) VALUES ('x', 'y')");
+        Assert.False(r.Success);
+        Assert.Contains("mismatch", r.Message ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Sql_Insert_JsonForm_StillWorks()
+    {
+        // The classic JSON form has to keep working unchanged — anything
+        // that broke it would silently regress every pre-#34 caller.
+        var r = _db.Execute("""INSERT INTO orders VALUES { "pnr": "ABC", "seat": "12A" }""");
+        Assert.True(r.Success, r.Message);
+        var rows = _db.Execute("SELECT * FROM orders").Documents;
+        Assert.Single(rows);
+        Assert.Equal("ABC", rows[0]["pnr"].AsString);
+        Assert.Equal("12A", rows[0]["seat"].AsString);
+    }
+
+    [Fact]
+    public void Sql_Insert_TupleForm_HonoursUniqueIndex()
+    {
+        _db.Insert("users", """{"email":"existing@x.com"}""");
+        _db.CreateIndex("users", "email", "idx_users_email", unique: true);
+
+        // A function-generated _id colliding with literal-uniqueness on email
+        // — the pre-flight ValidateUniqueInsert in ExecuteInsert catches it
+        // before the row hits storage.
+        var r = _db.Execute(
+            "INSERT INTO users (_id, email) VALUES (NEWID(), 'existing@x.com')");
+        Assert.False(r.Success);
+        Assert.Contains("Duplicate key", r.Message ?? "", StringComparison.OrdinalIgnoreCase);
+
+        // Pre-fix was a real risk: the doc would have been stranded on disk
+        // if uniqueness fired AFTER the page write. Confirm the failed row
+        // didn't leak.
+        var rows = _db.Execute("SELECT * FROM users").Documents;
+        Assert.Single(rows);
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Closes #34. Completes the #16 story.

## Summary
- New ANSI-SQL tuple INSERT form: \`INSERT INTO users (_id, email, createdAt) VALUES (NEWID(), 'a@b.com', GETDATE())\`.
- Parser disambiguates by lookahead — \`(\` after the collection name means tuple form; anything else (VALUES keyword or \`{\`) means classic JSON form.
- Both shapes coexist indefinitely; existing JSON-form callers unaffected.
- Pre-flight uniqueness check before the page write — a function-generated \`_id\` colliding with a unique index doesn't strand a half-committed row.

## Test plan
- [x] 6 new tests: \`NEWID() + GETDATE()\` roundtripping, two \`NEWID()\`s in two INSERTs produce distinct GUIDs, nested function-call args, column/value mismatch fails cleanly, classic JSON form unaffected, unique-index conflict caught before commit.
- [x] Full suite: 131/131 (was 125; +6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)