### PR TITLE
feat(#28): crash-injection harness + Dispose-on-flush-fault fix

### DIFF
--- a/src/DocumentForge.Engine/DocumentForge.Engine.csproj
+++ b/src/DocumentForge.Engine/DocumentForge.Engine.csproj
@@ -12,4 +12,14 @@
     <ProjectReference Include="..\DocumentForge.Query\DocumentForge.Query.csproj" />
     <ProjectReference Include="..\DocumentForge.Transactions\DocumentForge.Transactions.csproj" />
   </ItemGroup>
+
+  <!--
+    Open the engine's `internal` test seams (`OpenWithDataFile`) to the test
+    project so the crash-injection harness (issue #28) can inject a faulty
+    IDataFile around a real DataFile without leaking that surface to public
+    API consumers.
+  -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="DocumentForge.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -10,7 +10,7 @@ namespace DocumentForge.Engine;
 public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.ITransactionScope
 {
     private readonly DatabaseLock _lock;
-    private readonly DataFile _dataFile;
+    private readonly IDataFile _dataFile;
     private readonly PageCache _pageCache;
     private readonly PageAllocator _allocator;
     private readonly CollectionCatalog _catalog;
@@ -29,7 +29,7 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
 
     public string FilePath { get; }
 
-    private DocumentForgeDb(string filePath, DataFile dataFile, DatabaseLock lockHandle, DatabaseOptions options)
+    private DocumentForgeDb(string filePath, IDataFile dataFile, DatabaseLock lockHandle, DatabaseOptions options)
     {
         FilePath = filePath;
         _lock = lockHandle;
@@ -168,6 +168,39 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         if (File.Exists(filePath))
             return Open(filePath, options);
         return Create(filePath, options);
+    }
+
+    /// <summary>
+    /// Test seam: open a DB backed by a caller-supplied <see cref="IDataFile"/>
+    /// instead of the standard <c>DataFile.Open(filePath)</c>. Used by the
+    /// crash-injection harness (issue #28) to wrap the real data file in a
+    /// fault-injecting decorator. Skips recovery-log replay so the test can
+    /// drive its own state.
+    ///
+    /// <para>
+    /// <c>internal</c> on purpose — this surface is for verifying engine
+    /// invariants under simulated I/O failure, not a public extension point.
+    /// Production callers go through <see cref="Open"/> / <see cref="Create"/>.
+    /// </para>
+    /// </summary>
+    internal static DocumentForgeDb OpenWithDataFile(string filePath, IDataFile dataFile, DatabaseOptions? options = null)
+    {
+        options ??= new DatabaseOptions();
+        var lockHandle = DatabaseLock.Acquire(filePath, options.ForceUnlock);
+        try
+        {
+            var db = new DocumentForgeDb(filePath, dataFile, lockHandle, options);
+            db._catalog.Load();
+            db._indexManager.LoadFromCatalog();
+            foreach (var collName in db._catalog.GetCollectionNames())
+                db._catalog.GetCollection(collName)?.BuildLocationMap();
+            return db;
+        }
+        catch
+        {
+            lockHandle.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
@@ -1310,25 +1343,49 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
 
     public void Dispose()
     {
-        if (!_disposed)
+        if (_disposed) return;
+
+        // Critical-cleanup discipline: the on-disk lock and the data file
+        // handle MUST be released even if FlushAll throws (full disk, fsync
+        // failure, injected fault). Pre-fix a FlushAll throw skipped every
+        // subsequent step including _lock.Dispose, leaving the lock file
+        // held by this process — the next Open in the same process couldn't
+        // reclaim it (FileShare.None) and threw DatabaseLockedException.
+        // Discovered by the crash-injection harness (issue #28).
+        //
+        // Surfacing the FlushAll error to the caller is still the right
+        // behaviour (silent durability loss is the worst outcome), so we
+        // re-throw at the end. But cleanup runs unconditionally first.
+        Exception? deferredFlushError = null;
+        try
         {
             DisableAutoFailover();
-            _replicationServer?.Dispose();
-            _replicationFollower?.Dispose();
-            _logicalServer?.Dispose();
-            _logicalFollower?.Dispose();
-            _pageCache.FlushAll(); // this also truncates the recovery log
-            _walWriter?.Dispose();
-            _recoveryLog?.Dispose();
-            _dataFile.Dispose();
+            try { _replicationServer?.Dispose(); } catch { }
+            try { _replicationFollower?.Dispose(); } catch { }
+            try { _logicalServer?.Dispose(); } catch { }
+            try { _logicalFollower?.Dispose(); } catch { }
+            try { _pageCache.FlushAll(); } // also truncates the recovery log
+            catch (Exception ex) { deferredFlushError = ex; }
+            try { _walWriter?.Dispose(); } catch { }
+            try { _recoveryLog?.Dispose(); } catch { }
+        }
+        finally
+        {
+            // The handles below are load-bearing for the next Open. Always
+            // close them, even when something earlier threw.
+            try { _dataFile.Dispose(); } catch { }
             var recoveryPath = FilePath + ".recovery";
             try { if (File.Exists(recoveryPath) && new FileInfo(recoveryPath).Length == 0) File.Delete(recoveryPath); } catch { }
-            // Release the on-disk lock LAST so a crash mid-shutdown still leaves
-            // the lock visible. Releasing earlier would briefly let a second
-            // opener race in while we're still flushing/closing.
-            _lock.Dispose();
+            // Release the on-disk lock LAST so a clean shutdown still has
+            // the file visible up through the data-file close. Releasing
+            // earlier would briefly let a second opener race in while we're
+            // still closing.
+            try { _lock.Dispose(); } catch { }
             _disposed = true;
         }
+
+        if (deferredFlushError is not null)
+            throw deferredFlushError;
     }
 }
 

--- a/src/DocumentForge.Storage/DataFile.cs
+++ b/src/DocumentForge.Storage/DataFile.cs
@@ -9,6 +9,15 @@ public interface IDataFile : IDisposable
     uint PageCount { get; }
     PageId AllocateNewPage();
     void Flush();
+
+    /// <summary>Read the index catalog root page pointer from the file header.
+    /// Returns <see cref="PageId.Invalid"/> if never set.</summary>
+    PageId GetIndexCatalogPage();
+
+    /// <summary>Write the index catalog root page pointer to the file header
+    /// and fsync. Decorators (e.g. the crash-injection harness) can intercept
+    /// this for fault testing.</summary>
+    void SetIndexCatalogPage(PageId pageId);
 }
 
 public sealed class DataFile : IDataFile

--- a/tests/DocumentForge.Tests/CrashInjectionTests.cs
+++ b/tests/DocumentForge.Tests/CrashInjectionTests.cs
@@ -1,0 +1,232 @@
+using DocumentForge.Core;
+using DocumentForge.Engine;
+using DocumentForge.Storage;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Crash-injection regression tests (issue #28). Each test:
+///
+/// <list type="number">
+///   <item>Builds a real DB through <see cref="FaultyDataFile"/>.</item>
+///   <item>Drives a workload that triggers the failure mode under test.</item>
+///   <item>Disposes (lock released, recovery log written/preserved).</item>
+///   <item>Re-opens through the standard <see cref="DocumentForgeDb.Open"/>
+///         path — the engine's actual recovery semantics — and asserts the
+///         observed state matches what the contract claims.</item>
+/// </list>
+///
+/// <para>
+/// Each test owns its own data file path and cleans up in a finally block.
+/// The artifacts (.dfdb, .wal, .recovery, .lock, .followerseq) need explicit
+/// removal so failures don't pollute the next run.
+/// </para>
+///
+/// <para>
+/// What's NOT tested here yet (and shouldn't be — they need their own fixes
+/// first): genuine eviction-under-fault recovery (#24 parts 2-3 — Evict
+/// doesn't fsync today), disk-full handling (#25 — engine doesn't fail-fast
+/// yet), and tx partial-rollback (#23 — needs the shadow-buffer model).
+/// Those tests will land in their respective PRs alongside the fix; the
+/// harness here is the foundation that makes them feasible.
+/// </para>
+/// </summary>
+public sealed class CrashInjectionTests
+{
+    private static string FreshPath(string label) =>
+        Path.Combine(Path.GetTempPath(), $"crash_{label}_{Guid.NewGuid():N}.dfdb");
+
+    private static void Cleanup(string path)
+    {
+        foreach (var ext in new[] { "", ".wal", ".recovery", ".lock", ".followerseq" })
+            try { File.Delete(path + ext); } catch { }
+    }
+
+    /// <summary>DataFile has no built-in OpenOrCreate; the engine wraps it in
+    /// DocumentForgeDb.OpenOrCreate. Tests bypass that wrapper so we synthesise
+    /// the same logic here.</summary>
+    private static DataFile OpenOrCreateDataFile(string path) =>
+        File.Exists(path) ? DataFile.Open(path) : DataFile.Create(path);
+
+    [Fact]
+    public void RecoveryLog_ReplayedOnReopen_AfterFsyncFault()
+    {
+        // The whole point of the recovery log: if the fsync at the end of
+        // FlushAll fails (full disk, networked filesystem hiccup), the data
+        // file's writes may or may not be on disk — but the recovery log
+        // captured the pages BEFORE the data-file writes started, and
+        // wasn't truncated because Phase 4 (`OnAfterFlushComplete`) didn't
+        // run. Next Open replays from the log and the state is whole.
+        //
+        // Pre-recovery-log this scenario silently lost data; the test
+        // pins the contract that's been promised since the WAL landed.
+        var path = FreshPath("recoverylog");
+        try
+        {
+            using (var underlying = OpenOrCreateDataFile(path))
+            {
+                var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+                using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+                for (int i = 0; i < 20; i++)
+                    db.Insert("orders", $$"""{"pnr":"PNR{{i:D3}}"}""");
+
+                // The injected fsync failure surfaces as IOException out of
+                // FlushAll. Caller must observe and react.
+                Assert.Throws<IOException>(() => db.Flush());
+            }
+
+            // Reopen via the standard path. ReplayRecoveryLog runs as part
+            // of Open. Every committed insert from before the fault must
+            // be observable.
+            using var reopened = DocumentForgeDb.Open(path);
+            var rows = reopened.Execute("SELECT * FROM orders").Documents;
+            Assert.Equal(20, rows.Count);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void IndexCatalogPagePointer_FaultDoesNotProduceStaleStateOnReopen()
+    {
+        // PR #29's Flush(true) fix in SetIndexCatalogPage. Without it, a
+        // crash between the 4-byte header write and the next FlushAll would
+        // leave the data file with the catalog page allocated but the
+        // header pointer never persisted — index orphaned on disk.
+        //
+        // Here we inject a failure ON the SetIndexCatalogPage call itself.
+        // The CreateIndex op throws, no inconsistent claim is made about an
+        // index existing, and the next Open sees a coherent state.
+        var path = FreshPath("idxcatfsync");
+        try
+        {
+            using (var underlying = OpenOrCreateDataFile(path))
+            {
+                var faulty = new FaultyDataFile(underlying)
+                {
+                    ThrowOnNextSetIndexCatalogPage = true,
+                };
+                using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+                db.Insert("users", """{"email":"a@b.com"}""");
+
+                // CreateIndex internally calls SetIndexCatalogPage; the
+                // injected throw propagates as IOException.
+                Assert.Throws<IOException>(() =>
+                    db.CreateIndex("users", "email", "idx_users_email", unique: true));
+            }
+
+            // The doc itself is fine — it was written before the index op.
+            using var reopened = DocumentForgeDb.Open(path);
+            var rows = reopened.Execute("SELECT * FROM users").Documents;
+            Assert.Single(rows);
+
+            // Indexes shouldn't be claimed when their catalog write failed.
+            // The catalog page may exist on disk but the header pointer
+            // wasn't persisted (it failed) so GetIndexCatalogPage returns
+            // Invalid and LoadFromCatalog finds nothing.
+            Assert.Empty(reopened.GetIndexes("users"));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void Reopen_AfterFault_DoesNotDeadlockOnLock()
+    {
+        // The lock file (PR #31) is released LAST in Dispose so a crash
+        // mid-shutdown leaves it visible for diagnostics. Here we crash
+        // BEFORE Dispose (an exception during Insert / Flush). The lock
+        // file is left behind; next Open's stale-lock detector should
+        // reclaim it (same host, dead pid) and proceed.
+        var path = FreshPath("lockreclaim");
+        try
+        {
+            DocumentForgeDb? leaked = null;
+            try
+            {
+                using var underlying = OpenOrCreateDataFile(path);
+                var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+                leaked = DocumentForgeDb.OpenWithDataFile(path, faulty);
+                leaked.Insert("orders", """{"pnr":"X"}""");
+
+                Assert.Throws<IOException>(() => leaked.Dispose());
+                leaked = null;
+            }
+            finally
+            {
+                try { leaked?.Dispose(); } catch { }
+            }
+
+            // Reopen must succeed despite the leftover lock from the
+            // crashed prior session.
+            using var reopened = DocumentForgeDb.Open(path);
+            // Smoke: a real op proves the engine is functional.
+            _ = reopened.Execute("SELECT * FROM orders");
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void TransactionalCommit_FaultMidApply_DoesNotBlockNextOpen()
+    {
+        // Ground-truth check on the Phase 1 partial-commit gap (issue #23).
+        // A multi-doc tx where ApplyTransactionLocked hits an I/O failure
+        // mid-batch may leave partial state today — but the next Open must
+        // still succeed and produce a coherent (even if partial) state. The
+        // shadow-buffer fix in #23 will tighten this; for now we verify the
+        // engine doesn't get wedged.
+        var path = FreshPath("txfault");
+        try
+        {
+            using (var underlying = OpenOrCreateDataFile(path))
+            {
+                var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+                using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+                using var tx = db.BeginTransaction();
+                for (int i = 0; i < 10; i++)
+                    tx.Insert("orders", $$"""{"pnr":"PNR{{i}}"}""");
+
+                // Commit may or may not throw depending on whether Apply
+                // hits Flush before returning. We catch on purpose; the test
+                // is about post-fault recovery, not propagation.
+                try { tx.Commit(); } catch (IOException) { /* expected */ }
+
+                // The Dispose at scope end will also try to flush and may
+                // throw; absorb so the test cleanup runs.
+                try { db.Dispose(); } catch (IOException) { /* expected */ }
+            }
+
+            // Reopen. The state may be empty, partial, or full — what we
+            // ENFORCE is that the engine comes up cleanly and SELECTs respond.
+            using var reopened = DocumentForgeDb.Open(path);
+            var r = reopened.Execute("SELECT * FROM orders");
+            Assert.True(r.Success, $"Reopen failed to query after tx fault: {r.Message}");
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void FaultyDataFile_RecordsInjectedFaultForAssertions()
+    {
+        // Smoke test on the harness itself — confirms the test infrastructure
+        // does what the README claims. Without this, a future change that
+        // accidentally swallows the throw inside FaultyDataFile would let
+        // every other test silently lie.
+        var path = FreshPath("harness");
+        try
+        {
+            using var underlying = OpenOrCreateDataFile(path);
+            var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+            using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+            db.Insert("orders", """{"pnr":"X"}""");
+            try { db.Flush(); } catch (IOException) { /* expected */ }
+
+            Assert.NotNull(faulty.LastInjectedFault);
+            Assert.Contains("flush", faulty.LastInjectedFault!.Message,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Cleanup(path); }
+    }
+}

--- a/tests/DocumentForge.Tests/FaultyDataFile.cs
+++ b/tests/DocumentForge.Tests/FaultyDataFile.cs
@@ -1,0 +1,122 @@
+using DocumentForge.Core;
+using DocumentForge.Storage;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Test-only <see cref="IDataFile"/> decorator that wraps a real
+/// <see cref="DataFile"/> and injects failures at chosen points. The point of
+/// the harness (issue #28) is to verify that the engine's claimed recovery
+/// invariants — recovery log replay, page-checksum corruption detection,
+/// fsync discipline — actually survive realistic failure modes.
+///
+/// <para>
+/// The harness is in the test project rather than the main library because the
+/// faults it injects (controlled <see cref="IOException"/> on a specific page
+/// write, mid-operation crash) have no production use. The seam that lets it
+/// reach the engine is <see cref="DocumentForge.Engine.DocumentForgeDb.OpenWithDataFile"/>,
+/// which is <c>internal</c> and exposed via <c>InternalsVisibleTo</c>.
+/// </para>
+///
+/// <para>
+/// Usage:
+/// <code>
+/// using var underlying = DataFile.Open(path);
+/// var faulty = new FaultyDataFile(underlying)
+/// {
+///     ThrowOnNthWrite = 5, // fail the 5th WritePage call
+/// };
+/// using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+/// // ... drive a workload, expect the failure, then re-open with a real
+/// // DataFile and verify recovery left the state consistent.
+/// </code>
+/// </para>
+/// </summary>
+internal sealed class FaultyDataFile : IDataFile
+{
+    private readonly IDataFile _inner;
+    private int _writeCount;
+
+    public FaultyDataFile(IDataFile inner) => _inner = inner;
+
+    /// <summary>
+    /// Throw a synthetic <see cref="IOException"/> on the Nth call to
+    /// <see cref="WritePage"/>. Default 0 = no injection. The throw happens
+    /// BEFORE the underlying write, so the data file is in the state it
+    /// would be after N-1 successful writes — same as a power loss would
+    /// leave behind.
+    /// </summary>
+    public int ThrowOnNthWrite { get; init; }
+
+    /// <summary>
+    /// Throw on any write to a specific page. Useful for "what if the index
+    /// catalog page write fails" scenarios. Default Invalid = no injection.
+    /// </summary>
+    public PageId ThrowAtPageId { get; init; } = PageId.Invalid;
+
+    /// <summary>
+    /// Throw on the next call to <see cref="Flush"/>. Simulates an fsync
+    /// failure (rare but real on networked filesystems and full disks).
+    /// Resets to false after the throw.
+    /// </summary>
+    public bool ThrowOnNextFlush { get; set; }
+
+    /// <summary>
+    /// Throw on the next call to <see cref="SetIndexCatalogPage"/>. The
+    /// failure mode for the original #24 fsync gap: header pointer in the
+    /// OS write cache when power dies.
+    /// </summary>
+    public bool ThrowOnNextSetIndexCatalogPage { get; set; }
+
+    /// <summary>Number of successful WritePage calls (for assertions about
+    /// "the harness fired exactly when it should").</summary>
+    public int SuccessfulWriteCount { get; private set; }
+
+    /// <summary>Last exception synthesised. Tests can assert on the type / msg.</summary>
+    public IOException? LastInjectedFault { get; private set; }
+
+    public byte[] ReadPage(PageId pageId) => _inner.ReadPage(pageId);
+    public uint PageCount => _inner.PageCount;
+    public PageId AllocateNewPage() => _inner.AllocateNewPage();
+    public PageId GetIndexCatalogPage() => _inner.GetIndexCatalogPage();
+
+    public void WritePage(PageId pageId, byte[] data)
+    {
+        _writeCount++;
+        if (ThrowOnNthWrite > 0 && _writeCount == ThrowOnNthWrite)
+            throw Inject($"injected: write #{_writeCount} (pageId {pageId})");
+        if (ThrowAtPageId.IsValid && pageId.Value == ThrowAtPageId.Value)
+            throw Inject($"injected: page {pageId} write");
+        _inner.WritePage(pageId, data);
+        SuccessfulWriteCount++;
+    }
+
+    public void Flush()
+    {
+        if (ThrowOnNextFlush)
+        {
+            ThrowOnNextFlush = false;
+            throw Inject("injected: flush");
+        }
+        _inner.Flush();
+    }
+
+    public void SetIndexCatalogPage(PageId pageId)
+    {
+        if (ThrowOnNextSetIndexCatalogPage)
+        {
+            ThrowOnNextSetIndexCatalogPage = false;
+            throw Inject($"injected: set index catalog page {pageId}");
+        }
+        _inner.SetIndexCatalogPage(pageId);
+    }
+
+    public void Dispose() => _inner.Dispose();
+
+    private IOException Inject(string detail)
+    {
+        var ex = new IOException($"[FaultyDataFile] {detail}");
+        LastInjectedFault = ex;
+        return ex;
+    }
+}


### PR DESCRIPTION
Closes #28.

## Summary
- Three pieces: \`IDataFile\` expansion to cover the engine's full surface, an \`internal\` \`DocumentForgeDb.OpenWithDataFile\` test seam (exposed via \`InternalsVisibleTo\`), and a \`FaultyDataFile\` decorator with four injection knobs (\`ThrowOnNthWrite\`, \`ThrowAtPageId\`, \`ThrowOnNextFlush\`, \`ThrowOnNextSetIndexCatalogPage\`).
- 5 regression tests pin the recovery-log replay contract, the #29 \`Flush(true)\` fix, the lock-file release on faulty Dispose, the Phase 1 partial-commit cleanup, and harness-self-correctness.
- **Real bug uncovered**: \`DocumentForgeDb.Dispose\` called \`_pageCache.FlushAll()\` unguarded, so any throw skipped every later step including \`_lock.Dispose()\`. Process kept the lock file held; next \`Open\` in the same process threw \`DatabaseLockedException\`. Fixed via try/finally — cleanup always runs, FlushAll error is deferred and re-thrown at the end so silent durability loss isn't possible.

## What this unlocks

Every remaining durability fix (#23 tx partial-rollback, #24 parts 2-3 eviction/allocation fsync, #25 disk-full handling) can now ship with a regression test that injects exactly the failure mode it claims to handle. No more "reviewed-by-eye" durability work.

## Test plan
- [x] 5 new crash-injection tests, all passing.
- [x] The Dispose-on-flush-fault fix is itself proved by the lock-reclaim test (it failed on first run, fix landed, now passes).
- [x] Full suite: 136/136 (was 131; +5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)