### PR TITLE
feat(#18): server-stamped ETag + If-Match optimistic concurrency

### DIFF
--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -277,6 +277,12 @@ public static class ServeCommand
 
         // Replace a document by internal _id. Body is the full new document
         // (the original _id is always preserved — you don't need to include it).
+        //
+        // Issue #18 — optimistic concurrency: if the request carries an
+        // `If-Match: <etag>` header, ReplaceIfEtag is used and a mismatch
+        // returns 412 Precondition Failed with the current ETag in both
+        // the response header and body. Without the header it's
+        // last-write-wins (back-compat with pre-#18 callers).
         app.MapPut("/collections/{name}/{id}", async (string name, string id, HttpRequest request) =>
         {
             if (!Guid.TryParse(id, out var guid))
@@ -289,6 +295,37 @@ public static class ServeCommand
             try
             {
                 var docId = new DocumentId(guid);
+                // ETag passed via the standard `If-Match` HTTP header. We
+                // accept both quoted (`"<etag>"`, RFC 9110 strict) and
+                // unquoted forms — clients hand-rolling the header often
+                // forget the quotes, and for an opaque-string token there's
+                // no semantic difference.
+                var ifMatch = NormaliseIfMatch(request.Headers["If-Match"].ToString());
+
+                if (!string.IsNullOrEmpty(ifMatch))
+                {
+                    string? newEtag;
+                    try { newEtag = db.ReplaceIfEtag(name, docId, json, ifMatch); }
+                    catch (EtagMismatchException ex)
+                    {
+                        return Results.Json(new
+                        {
+                            error = ex.Message,
+                            expected = ex.ExpectedEtag,
+                            actual = ex.ActualEtag,
+                        }, statusCode: StatusCodes.Status412PreconditionFailed);
+                    }
+                    if (newEtag is null) return Results.NotFound();
+                    return Results.Ok(new
+                    {
+                        success = true,
+                        id = docId.ToString(),
+                        collection = name,
+                        etag = newEtag,
+                    });
+                }
+
+                // Last-write-wins path.
                 var ok = db.Replace(name, docId, json);
                 if (!ok) return Results.NotFound();
                 return Results.Ok(new { success = true, id = docId.ToString(), collection = name });
@@ -332,8 +369,10 @@ public static class ServeCommand
             catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
-        // Find a single document by id
-        app.MapGet("/collections/{name}/{id}", (string name, string id) =>
+        // Find a single document by id. Issue #18: returns the current ETag
+        // in an `ETag:` response header so clients can store it and use it
+        // in a subsequent If-Match PUT.
+        app.MapGet("/collections/{name}/{id}", (string name, string id, HttpResponse response) =>
         {
             var coll = db.GetCollection(name);
             if (coll is null) return Results.NotFound();
@@ -341,6 +380,11 @@ public static class ServeCommand
                 return Results.BadRequest(new { error = "This endpoint expects DocumentForge's internal _id (a Guid-formatted 16-byte value returned from POST /collections/{name}). To look up by your own business key, use GET /collections/{name}/by/{field}/{value}." });
             var doc = coll.FindById(new DocumentId(guid));
             if (doc is null) return Results.NotFound();
+
+            var etag = doc.GetEtag();
+            if (!string.IsNullOrEmpty(etag))
+                response.Headers.ETag = $"\"{etag}\"";
+
             return Results.Ok(JsonDocument.Parse(doc.ToJson()).RootElement);
         });
 
@@ -952,6 +996,24 @@ public static class ServeCommand
 
     private static bool IsValidFieldPath(string field) =>
         !string.IsNullOrEmpty(field) && _fieldPathRegex.IsMatch(field);
+
+    /// <summary>
+    /// Normalise an HTTP If-Match header value. RFC 9110 says ETags are quoted
+    /// strong tokens (<c>"abc"</c>) or weak (<c>W/"abc"</c>); in practice
+    /// hand-rolled clients often send the raw token. We accept both, strip the
+    /// quotes / weak prefix, and let <see cref="EtagMismatchException"/> compare
+    /// the unwrapped opaque string.
+    /// </summary>
+    private static string NormaliseIfMatch(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return string.Empty;
+        var s = raw.Trim();
+        // Strip the weak-validator prefix.
+        if (s.StartsWith("W/", StringComparison.Ordinal)) s = s[2..];
+        // Strip surrounding quotes if present.
+        if (s.Length >= 2 && s[0] == '"' && s[^1] == '"') s = s[1..^1];
+        return s;
+    }
 }
 
 // ---- DTOs ----

--- a/src/DocumentForge.Core/Exceptions.cs
+++ b/src/DocumentForge.Core/Exceptions.cs
@@ -40,6 +40,23 @@ public class TransactionException : DocumentForgeException
 }
 
 /// <summary>
+/// Thrown by <c>ReplaceIfEtag</c> when the document's stored <c>_etag</c>
+/// doesn't match the value the caller asserted. The HTTP layer turns this
+/// into a 412 Precondition Failed (issue #18 — optimistic concurrency).
+/// </summary>
+public class EtagMismatchException : DocumentForgeException
+{
+    public string ExpectedEtag { get; }
+    public string ActualEtag { get; }
+    public EtagMismatchException(string expected, string actual)
+        : base($"ETag mismatch: caller asserted '{expected}', current is '{actual}'.")
+    {
+        ExpectedEtag = expected;
+        ActualEtag = actual;
+    }
+}
+
+/// <summary>
 /// Thrown when DocumentForgeDb.Open / Create cannot acquire the on-disk
 /// lock for the data file because another process is holding it. The
 /// message names the holder (pid + hostname + open time) so operators can

--- a/src/DocumentForge.Document/BsonDocument.cs
+++ b/src/DocumentForge.Document/BsonDocument.cs
@@ -52,6 +52,26 @@ public sealed class BsonDocument : IEnumerable<KeyValuePair<string, BsonValue>>
             SetId(DocumentId.NewId());
     }
 
+    /// <summary>The reserved <c>_etag</c> field name. Issue #18: server-stamped
+    /// optimistic-concurrency token, refreshed on every Insert and Replace.
+    /// Callers don't supply it; if they do, the engine overwrites.</summary>
+    public const string EtagField = "_etag";
+
+    /// <summary>Read the doc's current <c>_etag</c> as a string. Returns empty
+    /// when unset (a doc inserted before #18 landed, or a doc constructed
+    /// directly from JSON without going through the engine's Insert path).</summary>
+    public string GetEtag()
+    {
+        var v = this[EtagField];
+        return v.IsNull ? string.Empty : v.ToString();
+    }
+
+    /// <summary>Stamp a fresh GUID v4 string into <c>_etag</c>. Called by the
+    /// engine on Insert and at the head of every Replace so optimistic
+    /// concurrency clients can If-Match against the value last GET'd.</summary>
+    public void StampFreshEtag() =>
+        this[EtagField] = BsonValue.FromString(Guid.NewGuid().ToString("D"));
+
     public static BsonDocument FromJson(string json)
     {
         using var jsonDoc = JsonDocument.Parse(json);

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -304,6 +304,12 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         {
             var collection = _catalog.GetOrCreateCollection(collectionName);
             doc.EnsureId(); // ensure _id is set BEFORE we broadcast, so followers get the same id
+            // Stamp the optimistic-concurrency token. Issue #18: every doc the
+            // engine writes carries an `_etag`; clients use it for If-Match
+            // PUTs without inventing their own version field. Caller-supplied
+            // _etag values are intentionally overwritten — clients shouldn't
+            // forge them.
+            doc.StampFreshEtag();
 
             // Pre-validate uniqueness. If any unique index would reject the doc,
             // throw BEFORE the page write so the on-disk state is untouched.
@@ -388,6 +394,7 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
                 {
                     var doc = documents[i];
                     doc.EnsureId();
+                    doc.StampFreshEtag(); // issue #18 — same discipline as single Insert
                     // Validate before the page write so a unique-index conflict
                     // doesn't leave a stranded doc behind (issue #9).
                     _indexManager.ValidateUniqueInsert(collectionName, doc);
@@ -455,6 +462,9 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
 
             // Always preserve the original _id so the replacement is in place.
             newDoc["_id"] = oldDoc["_id"];
+            // Re-stamp the optimistic-concurrency token. Issue #18: every Replace
+            // mints a fresh _etag so subsequent If-Match clients see the change.
+            newDoc.StampFreshEtag();
 
             // Validate + apply index changes FIRST. If validation throws (e.g. a
             // unique-index collision with a different doc), the page is untouched -
@@ -486,6 +496,67 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
             _transactionManager.ReleaseWriteLock();
         }
     }
+
+    /// <summary>
+    /// Optimistic-concurrency replace. Reads the current document, compares
+    /// its <c>_etag</c> against <paramref name="expectedEtag"/>, and only
+    /// replaces if they match. Returns the new <c>_etag</c> on success;
+    /// throws <see cref="EtagMismatchException"/> on mismatch (the doc
+    /// changed since the caller GET'd it). Returns null on not-found —
+    /// distinguishable from mismatch because not-found doesn't throw.
+    ///
+    /// <para>
+    /// The check + write happens under a single write-lock window, so a
+    /// concurrent writer racing in between cannot create a TOCTOU window
+    /// that lets two If-Match clients both succeed against the same
+    /// pre-image. Issue #18.
+    /// </para>
+    /// </summary>
+    public string? ReplaceIfEtag(string collectionName, DocumentId id, BsonDocument newDoc, string expectedEtag)
+    {
+        ThrowIfReadOnly();
+        _transactionManager.AcquireWriteLock();
+        try
+        {
+            var collection = _catalog.GetCollection(collectionName);
+            if (collection is null) return null;
+            var oldDoc = collection.FindById(id);
+            if (oldDoc is null) return null;
+
+            var actualEtag = oldDoc.GetEtag();
+            if (!string.Equals(actualEtag, expectedEtag, StringComparison.Ordinal))
+                throw new EtagMismatchException(expectedEtag, actualEtag);
+
+            // Same as the unguarded Replace from here — preserve _id, stamp
+            // a fresh _etag, validate index transitions, write the page,
+            // broadcast.
+            newDoc["_id"] = oldDoc["_id"];
+            newDoc.StampFreshEtag();
+            _indexManager.OnDocumentUpdated(collectionName, id, oldDoc, newDoc);
+            if (!collection.Update(id, newDoc))
+            {
+                try { _indexManager.OnDocumentUpdated(collectionName, id, newDoc, oldDoc); } catch { }
+                return null;
+            }
+
+            if (_logicalServer is not null)
+            {
+                var oldBytes = BsonSerializer.Serialize(oldDoc);
+                _logicalServer.BroadcastNewOp(LogicalOpType.Delete, collectionName, oldBytes);
+                var newBytes = BsonSerializer.Serialize(newDoc);
+                _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, newBytes);
+            }
+            return newDoc.GetEtag();
+        }
+        finally
+        {
+            _transactionManager.ReleaseWriteLock();
+        }
+    }
+
+    /// <summary>JSON convenience overload of <see cref="ReplaceIfEtag(string, DocumentId, BsonDocument, string)"/>.</summary>
+    public string? ReplaceIfEtag(string collectionName, DocumentId id, string json, string expectedEtag) =>
+        ReplaceIfEtag(collectionName, id, BsonDocument.FromJson(json), expectedEtag);
 
     /// <summary>
     /// Convenience overload: parse JSON then replace.

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -3001,6 +3001,87 @@ public class EngineTests : IDisposable
         Assert.Single(rows);
     }
 
+    // --- Optimistic concurrency / ETag (issue #18) ---
+
+    [Fact]
+    public void Insert_StampsFreshEtag()
+    {
+        var id = _db.Insert("users", """{"email":"a@b.com"}""");
+        var doc = _db.GetCollection("users")!.FindById(id)!;
+        var etag = doc.GetEtag();
+        Assert.False(string.IsNullOrEmpty(etag));
+        Assert.True(Guid.TryParse(etag, out _),
+            $"ETag should be a parseable GUID, got '{etag}'");
+    }
+
+    [Fact]
+    public void Replace_RestampsEtag()
+    {
+        // Two consecutive replaces must mint two different etags so an
+        // If-Match client sees the change.
+        var id = _db.Insert("users", """{"email":"a@b.com","v":1}""");
+        var beforeEtag = _db.GetCollection("users")!.FindById(id)!.GetEtag();
+
+        _db.Replace("users", id, """{"email":"a@b.com","v":2}""");
+        var afterEtag = _db.GetCollection("users")!.FindById(id)!.GetEtag();
+
+        Assert.False(string.IsNullOrEmpty(afterEtag));
+        Assert.NotEqual(beforeEtag, afterEtag);
+    }
+
+    [Fact]
+    public void ReplaceIfEtag_MatchingEtag_AppliesAndReturnsNewEtag()
+    {
+        var id = _db.Insert("users", """{"email":"a@b.com","v":1}""");
+        var oldEtag = _db.GetCollection("users")!.FindById(id)!.GetEtag();
+
+        var newEtag = _db.ReplaceIfEtag("users", id, """{"email":"a@b.com","v":2}""", oldEtag);
+        Assert.NotNull(newEtag);
+        Assert.NotEqual(oldEtag, newEtag);
+
+        var doc = _db.GetCollection("users")!.FindById(id)!;
+        Assert.Equal(2, doc["v"].AsInt32);
+        Assert.Equal(newEtag, doc.GetEtag());
+    }
+
+    [Fact]
+    public void ReplaceIfEtag_StaleEtag_ThrowsAndDoesNotApply()
+    {
+        var id = _db.Insert("users", """{"email":"a@b.com","v":1}""");
+        var oldEtag = _db.GetCollection("users")!.FindById(id)!.GetEtag();
+
+        // Someone else updated the doc — etag changed.
+        _db.Replace("users", id, """{"email":"a@b.com","v":2}""");
+
+        // Our stale If-Match must throw and the v=2 row must be untouched.
+        var ex = Assert.Throws<EtagMismatchException>(() =>
+            _db.ReplaceIfEtag("users", id, """{"email":"a@b.com","v":99}""", oldEtag));
+        Assert.Equal(oldEtag, ex.ExpectedEtag);
+
+        var doc = _db.GetCollection("users")!.FindById(id)!;
+        Assert.Equal(2, doc["v"].AsInt32);
+    }
+
+    [Fact]
+    public void ReplaceIfEtag_NotFound_ReturnsNullWithoutThrowing()
+    {
+        var fakeId = new DocumentId(Guid.NewGuid());
+        var result = _db.ReplaceIfEtag("users", fakeId, """{"x":1}""", "any-etag");
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Replace_WithoutEtagCheck_StillWorksLastWriteWins()
+    {
+        // Pre-#18 callers using the unguarded Replace must see no
+        // behaviour change — they get last-write-wins, the etag rotates
+        // silently, and no exception fires.
+        var id = _db.Insert("users", """{"email":"a@b.com","v":1}""");
+        Assert.True(_db.Replace("users", id, """{"email":"a@b.com","v":2}"""));
+        Assert.True(_db.Replace("users", id, """{"email":"a@b.com","v":3}"""));
+        Assert.Equal(3, _db.GetCollection("users")!.FindById(id)!["v"].AsInt32);
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Closes #18.

## Summary
- Every doc the engine writes now carries an \`_etag\` (GUID v4), refreshed on every Insert / Replace.
- New \`db.ReplaceIfEtag(coll, id, doc, expectedEtag)\` does the read-compare-write under a single write-lock window — no TOCTOU between check and apply.
- HTTP: PUT honours \`If-Match: \"<etag>\"\` → 200 (with new etag in body) or 412 (with current etag in body); GET returns \`ETag:\` response header.
- Pre-#18 callers (no If-Match) see no behaviour change — last-write-wins, the etag rotates silently.

## Test plan
- [x] 6 new engine tests: stamping on Insert, restamp on Replace, ReplaceIfEtag match path, stale path throws + leaves doc untouched, not-found returns null without throwing, unguarded Replace still works.
- [x] End-to-end smoke against live \`dfdb serve\`: GET returns \`ETag:\`; matching PUT → 200; stale PUT → 412.
- [x] Full suite: 142/142 (was 136; +6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)