### PR TITLE
fix(#25): fail-fast on storage I/O failure (HealthStatus + degraded /health)

### DIFF
--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -722,14 +722,30 @@ public static class ServeCommand
     private static void MapAdminEndpoints(WebApplication app, DocumentForgeDb db, NodeConfig config)
     {
         // Liveness + identity
-        app.MapGet("/health", () => Results.Ok(new
+        app.MapGet("/health", () =>
         {
-            status = "ok",
-            node = config.NodeName,
-            version = "0.1.0",
-            readOnly = db.IsReadOnly,
-            uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1)
-        }));
+            // Issue #25: surface engine-wide health status. A Failed engine
+            // returns 503 so load balancers / orchestrators (Render, k8s,
+            // Docker HEALTHCHECK) take it out of rotation while the operator
+            // restarts it (which runs recovery-log replay).
+            bool healthy = db.HealthStatus == DocumentForge.Core.DatabaseHealthStatus.Healthy;
+            var body = new
+            {
+                status = healthy ? "ok" : "degraded",
+                node = config.NodeName,
+                version = "0.1.0",
+                readOnly = db.IsReadOnly,
+                uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1),
+                health = healthy ? null : new
+                {
+                    state = db.HealthStatus.ToString(),
+                    lastFailure = db.LastHealthFailure?.Message,
+                },
+            };
+            return healthy
+                ? Results.Ok(body)
+                : Results.Json(body, statusCode: StatusCodes.Status503ServiceUnavailable);
+        });
 
         // Build-identification info — returns the SHA, build timestamp, and
         // (when running in a container) the image identifier so deploy

--- a/src/DocumentForge.Core/Exceptions.cs
+++ b/src/DocumentForge.Core/Exceptions.cs
@@ -40,6 +40,34 @@ public class TransactionException : DocumentForgeException
 }
 
 /// <summary>
+/// Engine-wide health state. <see cref="Healthy"/> is the normal mode.
+/// <see cref="Failed"/> means a prior write hit an IOException (full disk,
+/// transient I/O error, networked-filesystem hiccup) and the on-disk state
+/// may be inconsistent in a way the engine can't safely continue past.
+/// New writes throw <see cref="DatabaseHealthException"/>; the only recovery
+/// is Dispose + Open, which runs the recovery-log replay and resets state.
+/// Issue #25.
+/// </summary>
+public enum DatabaseHealthStatus
+{
+    Healthy,
+    Failed,
+}
+
+/// <summary>
+/// Thrown when a write is attempted against an engine that's flipped to
+/// <see cref="DatabaseHealthStatus.Failed"/> by an earlier IOException.
+/// Failing fast prevents the engine from continuing into a corrupted state;
+/// the caller should Dispose and Open fresh, which lets the recovery log
+/// repair anything torn.
+/// </summary>
+public class DatabaseHealthException : DocumentForgeException
+{
+    public DatabaseHealthException(string message) : base(message) { }
+    public DatabaseHealthException(string message, Exception inner) : base(message, inner) { }
+}
+
+/// <summary>
 /// Thrown by <c>ReplaceIfEtag</c> when the document's stored <c>_etag</c>
 /// doesn't match the value the caller asserted. The HTTP layer turns this
 /// into a 412 Precondition Failed (issue #18 — optimistic concurrency).

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -296,37 +296,102 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         if (IsReadOnly) throw new DocumentForgeException("Database is in read-only mode (planned handover in progress).");
     }
 
+    // --- Engine health (issue #25) ---
+    //
+    // Pre-fix an IOException out of WritePage / FlushAll propagated unhandled
+    // through the public Insert/Replace/Delete/Execute surface. The engine
+    // happily kept accepting more writes against a possibly-corrupt page
+    // cache, hoping subsequent writes would succeed — instead they could
+    // silently overwrite earlier-failed pages with new data, masking the
+    // original failure and producing inconsistent state.
+    //
+    // Now: any IOException out of the storage layer flips _health to Failed.
+    // Subsequent writes throw DatabaseHealthException immediately. The only
+    // recovery is Dispose + Open, which runs the recovery-log replay and
+    // restores the on-disk state to a consistent point.
+
+    private DatabaseHealthStatus _health = DatabaseHealthStatus.Healthy;
+
+    /// <summary>Current engine health. <see cref="DatabaseHealthStatus.Failed"/>
+    /// after any IOException out of the storage layer; new writes are rejected
+    /// until Dispose + Open. Surfaces as <c>"degraded"</c> in <c>/health</c>.</summary>
+    public DatabaseHealthStatus HealthStatus => _health;
+
+    /// <summary>The IOException that flipped <see cref="HealthStatus"/> to
+    /// Failed, or null if still healthy. Useful for telemetry / operator
+    /// diagnostics.</summary>
+    public Exception? LastHealthFailure { get; private set; }
+
+    private void EnsureHealthy()
+    {
+        if (_health == DatabaseHealthStatus.Failed)
+            throw new DatabaseHealthException(
+                $"Database '{FilePath}' is in Failed state from an earlier I/O error " +
+                $"({LastHealthFailure?.GetType().Name}: {LastHealthFailure?.Message}). " +
+                "Dispose and Open the database to recover (the recovery log will replay).");
+    }
+
+    /// <summary>Run a write under health tracking: any IOException flips the
+    /// engine to Failed and the original exception re-throws. Read-only ops
+    /// don't go through this — they're allowed to fail without poisoning the
+    /// engine state.</summary>
+    private T TrackHealth<T>(Func<T> op)
+    {
+        try { return op(); }
+        catch (IOException ex)
+        {
+            _health = DatabaseHealthStatus.Failed;
+            LastHealthFailure = ex;
+            throw;
+        }
+    }
+
+    private void TrackHealth(Action op)
+    {
+        try { op(); }
+        catch (IOException ex)
+        {
+            _health = DatabaseHealthStatus.Failed;
+            LastHealthFailure = ex;
+            throw;
+        }
+    }
+
     public DocumentId Insert(string collectionName, BsonDocument doc)
     {
         ThrowIfReadOnly();
+        EnsureHealthy();
         _transactionManager.AcquireWriteLock();
         try
         {
-            var collection = _catalog.GetOrCreateCollection(collectionName);
-            doc.EnsureId(); // ensure _id is set BEFORE we broadcast, so followers get the same id
-            // Stamp the optimistic-concurrency token. Issue #18: every doc the
-            // engine writes carries an `_etag`; clients use it for If-Match
-            // PUTs without inventing their own version field. Caller-supplied
-            // _etag values are intentionally overwritten — clients shouldn't
-            // forge them.
-            doc.StampFreshEtag();
-
-            // Pre-validate uniqueness. If any unique index would reject the doc,
-            // throw BEFORE the page write so the on-disk state is untouched.
-            // Pre-fix this happened in the wrong order: page wrote, index threw,
-            // doc stranded on disk. (issue #9)
-            _indexManager.ValidateUniqueInsert(collectionName, doc);
-
-            var id = collection.Insert(doc);
-            _indexManager.OnDocumentInserted(collectionName, id, doc);
-
-            // Broadcast to read-only followers (with sequence number assignment)
-            if (_logicalServer is not null)
+            return TrackHealth(() =>
             {
-                var bytes = BsonSerializer.Serialize(doc);
-                _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, bytes);
-            }
-            return id;
+                var collection = _catalog.GetOrCreateCollection(collectionName);
+                doc.EnsureId(); // ensure _id is set BEFORE we broadcast, so followers get the same id
+                // Stamp the optimistic-concurrency token. Issue #18: every doc the
+                // engine writes carries an `_etag`; clients use it for If-Match
+                // PUTs without inventing their own version field. Caller-supplied
+                // _etag values are intentionally overwritten — clients shouldn't
+                // forge them.
+                doc.StampFreshEtag();
+
+                // Pre-validate uniqueness. If any unique index would reject the doc,
+                // throw BEFORE the page write so the on-disk state is untouched.
+                // Pre-fix this happened in the wrong order: page wrote, index threw,
+                // doc stranded on disk. (issue #9)
+                _indexManager.ValidateUniqueInsert(collectionName, doc);
+
+                var id = collection.Insert(doc);
+                _indexManager.OnDocumentInserted(collectionName, id, doc);
+
+                // Broadcast to read-only followers (with sequence number assignment)
+                if (_logicalServer is not null)
+                {
+                    var bytes = BsonSerializer.Serialize(doc);
+                    _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, bytes);
+                }
+                return id;
+            });
         }
         finally
         {
@@ -453,43 +518,47 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     public bool Replace(string collectionName, DocumentId id, BsonDocument newDoc)
     {
         ThrowIfReadOnly();
+        EnsureHealthy();
         _transactionManager.AcquireWriteLock();
         try
         {
-            var collection = _catalog.GetOrCreateCollection(collectionName);
-            var oldDoc = collection.FindById(id);
-            if (oldDoc is null) return false;
-
-            // Always preserve the original _id so the replacement is in place.
-            newDoc["_id"] = oldDoc["_id"];
-            // Re-stamp the optimistic-concurrency token. Issue #18: every Replace
-            // mints a fresh _etag so subsequent If-Match clients see the change.
-            newDoc.StampFreshEtag();
-
-            // Validate + apply index changes FIRST. If validation throws (e.g. a
-            // unique-index collision with a different doc), the page is untouched -
-            // no half-commits. Only if the index transition succeeds do we commit
-            // the page.
-            _indexManager.OnDocumentUpdated(collectionName, id, oldDoc, newDoc);
-
-            if (!collection.Update(id, newDoc))
+            return TrackHealth(() =>
             {
-                // Page write failed for an unexpected reason - try to put the index
-                // back where it was. Best-effort: validation already passed for the
-                // forward direction, so the reverse should too.
-                try { _indexManager.OnDocumentUpdated(collectionName, id, newDoc, oldDoc); } catch { }
-                return false;
-            }
+                var collection = _catalog.GetOrCreateCollection(collectionName);
+                var oldDoc = collection.FindById(id);
+                if (oldDoc is null) return false;
 
-            // Replicate as delete + insert (LogicalOpType.Update is on the roadmap).
-            if (_logicalServer is not null)
-            {
-                var oldBytes = BsonSerializer.Serialize(oldDoc);
-                _logicalServer.BroadcastNewOp(LogicalOpType.Delete, collectionName, oldBytes);
-                var newBytes = BsonSerializer.Serialize(newDoc);
-                _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, newBytes);
-            }
-            return true;
+                // Always preserve the original _id so the replacement is in place.
+                newDoc["_id"] = oldDoc["_id"];
+                // Re-stamp the optimistic-concurrency token. Issue #18: every Replace
+                // mints a fresh _etag so subsequent If-Match clients see the change.
+                newDoc.StampFreshEtag();
+
+                // Validate + apply index changes FIRST. If validation throws (e.g. a
+                // unique-index collision with a different doc), the page is untouched -
+                // no half-commits. Only if the index transition succeeds do we commit
+                // the page.
+                _indexManager.OnDocumentUpdated(collectionName, id, oldDoc, newDoc);
+
+                if (!collection.Update(id, newDoc))
+                {
+                    // Page write failed for an unexpected reason - try to put the index
+                    // back where it was. Best-effort: validation already passed for the
+                    // forward direction, so the reverse should too.
+                    try { _indexManager.OnDocumentUpdated(collectionName, id, newDoc, oldDoc); } catch { }
+                    return false;
+                }
+
+                // Replicate as delete + insert (LogicalOpType.Update is on the roadmap).
+                if (_logicalServer is not null)
+                {
+                    var oldBytes = BsonSerializer.Serialize(oldDoc);
+                    _logicalServer.BroadcastNewOp(LogicalOpType.Delete, collectionName, oldBytes);
+                    var newBytes = BsonSerializer.Serialize(newDoc);
+                    _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, newBytes);
+                }
+                return true;
+            });
         }
         finally
         {
@@ -515,6 +584,7 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     public string? ReplaceIfEtag(string collectionName, DocumentId id, BsonDocument newDoc, string expectedEtag)
     {
         ThrowIfReadOnly();
+        EnsureHealthy();
         _transactionManager.AcquireWriteLock();
         try
         {
@@ -739,8 +809,9 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         if (isWrite)
         {
             ThrowIfReadOnly();
+            EnsureHealthy();
             _transactionManager.AcquireWriteLock();
-            try { return _queryExecutor.Execute(query); }
+            try { return TrackHealth(() => _queryExecutor.Execute(query)); }
             finally { _transactionManager.ReleaseWriteLock(); }
         }
         else
@@ -1361,7 +1432,12 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
 
     public void Flush()
     {
-        _pageCache.FlushAll();
+        // Health check is intentionally NOT here: a Failed engine should still
+        // be Flushable (the recovery log replay on next Open is the path back
+        // to Healthy, but until then a manual Flush attempt is allowed and
+        // simply re-throws if the underlying I/O is still broken). Wrap in
+        // TrackHealth so a fresh failure flips the state.
+        TrackHealth(() => _pageCache.FlushAll());
     }
 
     /// <summary>

--- a/tests/DocumentForge.Tests/CrashInjectionTests.cs
+++ b/tests/DocumentForge.Tests/CrashInjectionTests.cs
@@ -1,6 +1,7 @@
 using DocumentForge.Core;
 using DocumentForge.Engine;
 using DocumentForge.Storage;
+using DocumentForge.Document;
 using Xunit;
 
 namespace DocumentForge.Tests;
@@ -202,6 +203,120 @@ public sealed class CrashInjectionTests
             using var reopened = DocumentForgeDb.Open(path);
             var r = reopened.Execute("SELECT * FROM orders");
             Assert.True(r.Success, $"Reopen failed to query after tx fault: {r.Message}");
+        }
+        finally { Cleanup(path); }
+    }
+
+    // --- Issue #25: fail-fast on storage I/O failure ---
+
+    [Fact]
+    public void HealthStatus_FlipsToFailed_AfterIOExceptionDuringFlush()
+    {
+        // Pre-fix the IOException out of FlushAll just propagated through
+        // Insert/Replace/Execute and the engine kept accepting more writes
+        // against a possibly-corrupt cache. Now: any IOException flips
+        // HealthStatus to Failed and subsequent writes throw
+        // DatabaseHealthException up front.
+        var path = FreshPath("healthflip");
+        try
+        {
+            using var underlying = OpenOrCreateDataFile(path);
+            var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+            using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+            db.Insert("orders", """{"pnr":"X"}""");
+            Assert.Equal(DatabaseHealthStatus.Healthy, db.HealthStatus);
+
+            // Flush throws — the IOException flips _health to Failed.
+            Assert.Throws<IOException>(() => db.Flush());
+            Assert.Equal(DatabaseHealthStatus.Failed, db.HealthStatus);
+            Assert.NotNull(db.LastHealthFailure);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void Writes_AreRejected_WhileHealthStatusIsFailed()
+    {
+        // Once Failed, every subsequent write API must throw immediately
+        // with DatabaseHealthException — not silently retry into a
+        // possibly-corrupt cache. Insert, Execute("INSERT..."), Replace,
+        // ReplaceIfEtag all share the EnsureHealthy guard.
+        var path = FreshPath("rejectfailed");
+        try
+        {
+            using var underlying = OpenOrCreateDataFile(path);
+            var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+            using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+            var id = db.Insert("orders", """{"pnr":"X"}""");
+            try { db.Flush(); } catch (IOException) { /* expected — flips to Failed */ }
+            Assert.Equal(DatabaseHealthStatus.Failed, db.HealthStatus);
+
+            Assert.Throws<DatabaseHealthException>(() =>
+                db.Insert("orders", """{"pnr":"Y"}"""));
+            Assert.Throws<DatabaseHealthException>(() =>
+                db.Replace("orders", id, """{"pnr":"Z"}"""));
+            Assert.Throws<DatabaseHealthException>(() =>
+                db.Execute("INSERT INTO orders (pnr) VALUES ('W')"));
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void ReadsStillWork_WhileHealthStatusIsFailed()
+    {
+        // Reads don't touch storage in a way that risks the failure mode —
+        // they return whatever's in cache. The contract is "writes fail,
+        // reads degrade to last-known". Useful so admin UIs can still
+        // diagnose what's there before the operator restarts.
+        var path = FreshPath("readsdegrade");
+        try
+        {
+            using var underlying = OpenOrCreateDataFile(path);
+            var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+            using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+
+            db.Insert("orders", """{"pnr":"X"}""");
+            try { db.Flush(); } catch (IOException) { /* expected */ }
+
+            // Read should still work — the in-cache state is still readable.
+            var rows = db.Execute("SELECT * FROM orders").Documents;
+            Assert.Single(rows);
+            Assert.Equal("X", rows[0]["pnr"].AsString);
+        }
+        finally { Cleanup(path); }
+    }
+
+    [Fact]
+    public void DisposeAndReopen_RecoversFromFailedState()
+    {
+        // The documented escape hatch: Dispose + Open replays the recovery
+        // log and re-establishes a Healthy engine. The process can keep
+        // running without restarting itself.
+        var path = FreshPath("recoverhealth");
+        try
+        {
+            using (var underlying = OpenOrCreateDataFile(path))
+            {
+                var faulty = new FaultyDataFile(underlying) { ThrowOnNextFlush = true };
+                using var db = DocumentForgeDb.OpenWithDataFile(path, faulty);
+                db.Insert("orders", """{"pnr":"X"}""");
+                try { db.Flush(); } catch (IOException) { /* expected */ }
+                Assert.Equal(DatabaseHealthStatus.Failed, db.HealthStatus);
+                // db disposes — the wrapper returns IOException out of Dispose
+                // which we catch in the using → swallowed by the outer using
+                // since the engine's Dispose now defers + re-throws.
+                try { db.Dispose(); } catch (IOException) { /* expected */ }
+            }
+
+            using var reopened = DocumentForgeDb.Open(path);
+            Assert.Equal(DatabaseHealthStatus.Healthy, reopened.HealthStatus);
+            // Smoke: writes work again. The pre-fault Insert may or may not
+            // have made it depending on whether the recovery log captured it;
+            // what we ENFORCE is that the engine is functional.
+            reopened.Insert("orders", """{"pnr":"AFTER"}""");
+            Assert.True(reopened.Execute("SELECT * FROM orders").Documents.Count >= 1);
         }
         finally { Cleanup(path); }
     }


### PR DESCRIPTION
Closes #25.

## Summary
- New engine-wide \`HealthStatus { Healthy, Failed }\` and \`DatabaseHealthException\`. Any \`IOException\` out of storage flips to Failed; subsequent writes throw immediately with a clear error.
- Reads degrade gracefully — cached state remains queryable so admin UIs can diagnose before the operator restarts.
- \`/health\` returns 503 with \`{ status: \"degraded\", health: { state, lastFailure } }\` when Failed — load balancers / k8s / Docker HEALTHCHECK take the node out of rotation automatically.
- Dispose + Open replays the recovery log and re-establishes Healthy state.

## Test plan
- [x] 4 new crash-injection regression tests using the #28 harness.
- [x] Pre-#28 these tests would have been impossible without modifying production code.
- [x] Full suite: 146/146 (was 142; +4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)