### PR TITLE
feat(#44): JOIN chains + compound ON (Phase B + part of C)

### DIFF
--- a/src/DocumentForge.Query/Ast.cs
+++ b/src/DocumentForge.Query/Ast.cs
@@ -10,7 +10,27 @@ public sealed class SelectStatement : Statement
     public List<AggregateField> Aggregates { get; set; } = new();
     public List<string> GroupByPaths { get; set; } = new();
     public string Collection { get; set; } = "";
-    public JoinClause? Join { get; set; }
+
+    /// <summary>
+    /// All JOINs in source order (left-deep). Empty when there's no JOIN.
+    /// Pre-#44 this was a single-valued <c>JoinClause? Join</c>; the property
+    /// below preserves that shape for callers that only ever want the first
+    /// join, but new code should walk <see cref="Joins"/>.
+    /// </summary>
+    public List<JoinClause> Joins { get; set; } = new();
+
+    /// <summary>Back-compat: the first join, or null. Setting this replaces
+    /// the entire <see cref="Joins"/> list.</summary>
+    public JoinClause? Join
+    {
+        get => Joins.Count > 0 ? Joins[0] : null;
+        set
+        {
+            Joins.Clear();
+            if (value is not null) Joins.Add(value);
+        }
+    }
+
     public Expression? Where { get; set; }
     public string? OrderByPath { get; set; }
     public bool OrderDescending { get; set; }
@@ -36,15 +56,34 @@ public sealed class AggregateField
 /// </summary>
 public enum JoinType { Inner, Left, Right, Cross }
 
+/// <summary>One equality predicate of a JOIN's ON clause: the path on the
+/// outer side and the path on the joined side. Multi-predicate ON
+/// (<c>a.x = b.x AND a.y = b.y</c>) carries multiple of these. Issue #44.</summary>
+public sealed class JoinPredicate
+{
+    public string LeftCollection { get; set; } = "";
+    public string LeftPath { get; set; } = "";
+    public string RightCollection { get; set; } = "";
+    public string RightPath { get; set; } = "";
+}
+
 public sealed class JoinClause
 {
     public string Collection { get; set; } = "";
     // Join condition: LeftPath (on outer collection) == RightPath (on joined collection)
     // e.g., "orders.flights[0].flightNumber" == "flights.flightNumber"
+    // Pre-#44 a single equality; now a list. The single-predicate properties
+    // below stay populated from Predicates[0] for the existing executor path.
     public string LeftPath { get; set; } = "";
     public string LeftCollection { get; set; } = "";
     public string RightPath { get; set; } = "";
     public string RightCollection { get; set; } = "";
+
+    /// <summary>All AND-ed equality predicates from the ON clause.
+    /// Single-predicate joins have one entry; CROSS joins have none.
+    /// Issue #44 Phase C: the executor hashes on the tuple of right-side
+    /// values when more than one predicate is present.</summary>
+    public List<JoinPredicate> Predicates { get; set; } = new();
 
     /// <summary>Inner by default — preserves the pre-#17 behaviour for callers
     /// that just write <c>JOIN</c>. CROSS is the only type that doesn't carry

--- a/src/DocumentForge.Query/Parser.cs
+++ b/src/DocumentForge.Query/Parser.cs
@@ -94,79 +94,18 @@ public sealed class Parser
 
         // JOIN family. Recognised shapes (issue #17 Phase A):
         //   JOIN t ON ...                   — INNER JOIN (default)
-        //   INNER JOIN t ON ...             — explicit INNER
+        //   INNER JOIN t ON ...             — explicit INNER (TODO if needed)
         //   LEFT [OUTER] JOIN t ON ...      — null-pad missing right rows
         //   RIGHT [OUTER] JOIN t ON ...     — null-pad missing left rows
         //   CROSS JOIN t                    — cartesian product, no ON clause
-        // Multi-join chaining (a JOIN b JOIN c) is Phase B; today we still
-        // allow only one JOIN. The parser exits cleanly after the first.
-        var joinType = JoinType.Inner;
-        bool hasJoin = false;
-        if (Current.Type == TokenType.Left)
-        {
-            _pos++;
-            if (Current.Type == TokenType.Outer) _pos++;
-            Expect(TokenType.Join);
-            joinType = JoinType.Left;
-            hasJoin = true;
-        }
-        else if (Current.Type == TokenType.Right)
-        {
-            _pos++;
-            if (Current.Type == TokenType.Outer) _pos++;
-            Expect(TokenType.Join);
-            joinType = JoinType.Right;
-            hasJoin = true;
-        }
-        else if (Current.Type == TokenType.Cross)
-        {
-            _pos++;
-            Expect(TokenType.Join);
-            joinType = JoinType.Cross;
-            hasJoin = true;
-        }
-        else if (Current.Type == TokenType.Join)
-        {
-            _pos++;
-            joinType = JoinType.Inner;
-            hasJoin = true;
-        }
-
-        if (hasJoin)
-        {
-            var joinCollection = ReadIdentifierPath();
-
-            if (joinType == JoinType.Cross)
-            {
-                // CROSS JOIN takes no ON — the join condition is "everything".
-                // Path fields stay empty; the executor recognises the type
-                // and switches to the nested-loop cartesian path.
-                stmt.Join = new JoinClause
-                {
-                    Collection = joinCollection,
-                    Type = joinType,
-                };
-            }
-            else
-            {
-                Expect(TokenType.On);
-                var leftFullPath = ReadIdentifierPath();
-                Expect(TokenType.Equals);
-                var rightFullPath = ReadIdentifierPath();
-                var (leftColl, leftPath) = SplitCollectionPath(leftFullPath, stmt.Collection, joinCollection);
-                var (rightColl, rightPath) = SplitCollectionPath(rightFullPath, stmt.Collection, joinCollection);
-
-                stmt.Join = new JoinClause
-                {
-                    Collection = joinCollection,
-                    LeftCollection = leftColl,
-                    LeftPath = leftPath,
-                    RightCollection = rightColl,
-                    RightPath = rightPath,
-                    Type = joinType,
-                };
-            }
-        }
+        // Phase B (#44): chains. `a JOIN b ON … JOIN c ON …` parses; each
+        // JOIN feeds the next left-deep, the executor evaluates them in
+        // source order.
+        // Phase C (#44): compound ON. `ON a.x = b.x AND a.y = b.y` produces a
+        // JoinClause with multiple Predicates; the hash-join executor keys
+        // on the tuple of right-side values.
+        while (TryParseOneJoin(stmt) is { } parsedJoin)
+            stmt.Joins.Add(parsedJoin);
 
         // WHERE
         if (Current.Type == TokenType.Where)
@@ -643,6 +582,97 @@ public sealed class Parser
         {
             stmt.Fields.Add(ReadIdentifierPath());
         }
+    }
+
+    /// <summary>
+    /// Parse a single JOIN clause if the current token starts one. Returns
+    /// the populated <see cref="JoinClause"/> or null if no join keyword is
+    /// next. Used in a loop by ParseSelect to chain multiple joins.
+    /// </summary>
+    private JoinClause? TryParseOneJoin(SelectStatement stmt)
+    {
+        JoinType type;
+        if (Current.Type == TokenType.Left)
+        {
+            _pos++;
+            if (Current.Type == TokenType.Outer) _pos++;
+            Expect(TokenType.Join);
+            type = JoinType.Left;
+        }
+        else if (Current.Type == TokenType.Right)
+        {
+            _pos++;
+            if (Current.Type == TokenType.Outer) _pos++;
+            Expect(TokenType.Join);
+            type = JoinType.Right;
+        }
+        else if (Current.Type == TokenType.Cross)
+        {
+            _pos++;
+            Expect(TokenType.Join);
+            type = JoinType.Cross;
+        }
+        else if (Current.Type == TokenType.Join)
+        {
+            _pos++;
+            type = JoinType.Inner;
+        }
+        else
+        {
+            return null;
+        }
+
+        var joinCollection = ReadIdentifierPath();
+
+        if (type == JoinType.Cross)
+        {
+            // CROSS JOIN takes no ON — cartesian product.
+            return new JoinClause { Collection = joinCollection, Type = type };
+        }
+
+        Expect(TokenType.On);
+
+        // Phase C: parse one or more `path = path` predicates joined by AND.
+        // Multi-predicate ON keys the hash-join on the tuple of right-side
+        // values; single-predicate is the cheap fast path. The single-pred
+        // legacy fields (LeftPath/RightPath/...) stay populated from
+        // Predicates[0] so the existing executor code keeps working
+        // unchanged for the common case.
+        var predicates = new List<JoinPredicate>();
+        predicates.Add(ReadJoinPredicate(stmt.Collection, joinCollection));
+        while (Current.Type == TokenType.And)
+        {
+            _pos++;
+            predicates.Add(ReadJoinPredicate(stmt.Collection, joinCollection));
+        }
+
+        var first = predicates[0];
+        return new JoinClause
+        {
+            Collection = joinCollection,
+            LeftCollection = first.LeftCollection,
+            LeftPath = first.LeftPath,
+            RightCollection = first.RightCollection,
+            RightPath = first.RightPath,
+            Predicates = predicates,
+            Type = type,
+        };
+    }
+
+    private JoinPredicate ReadJoinPredicate(string outerCollection, string joinCollection)
+    {
+        var leftFullPath = ReadIdentifierPath();
+        Expect(TokenType.Equals);
+        var rightFullPath = ReadIdentifierPath();
+        var (leftColl, leftPath) = SplitCollectionPath(leftFullPath, outerCollection, joinCollection);
+        var (rightColl, rightPath) = SplitCollectionPath(rightFullPath, outerCollection, joinCollection);
+        return new JoinPredicate
+        {
+            LeftCollection = leftColl,
+            LeftPath = leftPath,
+            RightCollection = rightColl,
+            RightPath = rightPath,
+        };
     }
 
     /// <summary>

--- a/src/DocumentForge.Query/QueryExecutor.cs
+++ b/src/DocumentForge.Query/QueryExecutor.cs
@@ -97,12 +97,19 @@ public sealed class QueryExecutor
             plan = "COLLECTION_SCAN";
         }
 
-        // JOIN: combine with another collection using hash join
-        if (stmt.Join is not null)
+        // JOINs: chain left-deep (issue #44 Phase B). The result of each
+        // join feeds the next as the outer side. The "outer collection
+        // name" only matters for the FIRST join's path-prefix splitting;
+        // subsequent joins resolve against the running result set, where
+        // both nested collections are present.
+        if (stmt.Joins.Count > 0)
         {
-            var (joined, joinPlan) = ExecuteHashJoin(stmt, results);
-            results = joined;
-            plan = $"{plan} + {joinPlan}";
+            foreach (var join in stmt.Joins)
+            {
+                var (joined, joinPlan) = ExecuteHashJoin(stmt, join, results);
+                results = joined;
+                plan = $"{plan} + {joinPlan}";
+            }
 
             // Apply WHERE to the combined documents (now that prefixed paths resolve correctly)
             if (stmt.Where is not null)
@@ -468,14 +475,12 @@ public sealed class QueryExecutor
     /// Hash join: build a hash map of the join collection keyed by the ON column,
     /// then for each outer document, look up matches and combine.
     /// </summary>
-    private (List<BsonDocument> docs, string plan) ExecuteHashJoin(SelectStatement stmt, List<BsonDocument> outerDocs)
+    private (List<BsonDocument> docs, string plan) ExecuteHashJoin(SelectStatement stmt, JoinClause join, List<BsonDocument> outerDocs)
     {
-        var join = stmt.Join!;
-
         // CROSS JOIN bypasses the hash-join apparatus entirely — it's a
         // pure cartesian product with no key extraction or null padding.
         if (join.Type == JoinType.Cross)
-            return ExecuteCrossJoin(stmt, outerDocs);
+            return ExecuteCrossJoin(stmt, join, outerDocs);
 
         var joinCollection = _catalog.GetCollection(join.Collection);
         if (joinCollection is null)
@@ -494,28 +499,43 @@ public sealed class QueryExecutor
             return (new List<BsonDocument>(), $"{JoinPlanLabel(join.Type)}({join.Collection}:missing)");
         }
 
-        // Determine which side is the outer (the one we already have) vs inner (the one we need to look up)
-        bool outerIsLeft = string.Equals(join.LeftCollection, stmt.Collection, StringComparison.OrdinalIgnoreCase);
-        string outerPath = outerIsLeft ? join.LeftPath : join.RightPath;
-        string innerPath = outerIsLeft ? join.RightPath : join.LeftPath;
-
-        // Build hash map of inner collection: key (from innerPath) -> list of inner docs
-        // Use index if available for the inner path
-        var innerIndex = _indexManager.FindIndexForPath(join.Collection, innerPath);
-        string joinStrategy;
-        Dictionary<BsonValue, List<BsonDocument>> innerMap;
-
-        if (innerIndex is not null)
+        // For each predicate determine which side resolves against the
+        // outer doc (the running result set) vs the inner (the new
+        // collection being joined in). The outer-side path is taken from
+        // whichever side does NOT match join.Collection — either the
+        // source collection (first join) or a previously-joined collection
+        // (chained — its prefixed path "<coll>.<path>" still resolves on
+        // the combined doc thanks to JsonPathExtractor's dotted-path
+        // support).
+        var preds = join.Predicates.Count > 0 ? join.Predicates : new List<JoinPredicate>
         {
-            // We have an index - use it to build the hash map faster (or look up on-demand)
-            // For now, just build a full hash map from the collection (simpler)
-            innerMap = BuildHashMap(joinCollection, innerPath);
-            joinStrategy = $"{JoinPlanLabel(join.Type)}(using idx:{innerIndex.Definition.Name})";
+            // Back-compat for callers that populated only the legacy single-
+            // predicate fields without going through the parser.
+            new() { LeftCollection = join.LeftCollection, LeftPath = join.LeftPath,
+                    RightCollection = join.RightCollection, RightPath = join.RightPath }
+        };
+        var (outerPaths, innerPaths) = SplitOuterInnerPaths(preds, join.Collection);
+
+        // Build the inner hash map — single-key Dictionary<BsonValue, ...>
+        // for the simple case, multi-key (tuple) for compound ON. Index
+        // hint applies to single-key only; compound queries fall back to
+        // full collection scan today (an "indexed compound join" is its
+        // own much larger feature).
+        Dictionary<object, List<BsonDocument>> innerMap;
+        string joinStrategy;
+        if (innerPaths.Length == 1)
+        {
+            var single = BuildHashMap(joinCollection, innerPaths[0]);
+            innerMap = single.ToDictionary(kvp => (object)kvp.Key, kvp => kvp.Value);
+            var innerIndex = _indexManager.FindIndexForPath(join.Collection, innerPaths[0]);
+            joinStrategy = innerIndex is not null
+                ? $"{JoinPlanLabel(join.Type)}(using idx:{innerIndex.Definition.Name})"
+                : $"{JoinPlanLabel(join.Type)}({join.Collection})";
         }
         else
         {
-            innerMap = BuildHashMap(joinCollection, innerPath);
-            joinStrategy = $"{JoinPlanLabel(join.Type)}({join.Collection})";
+            innerMap = BuildCompositeHashMap(joinCollection, innerPaths);
+            joinStrategy = $"{JoinPlanLabel(join.Type)}({join.Collection}, compound:{innerPaths.Length})";
         }
 
         // Phase A semantics:
@@ -531,11 +551,9 @@ public sealed class QueryExecutor
 
         foreach (var outerDoc in outerDocs)
         {
-            var outerKey = JsonPathExtractor.Extract(outerDoc, outerPath);
-            if (outerKey.IsNull)
+            var outerKey = ExtractKey(outerDoc, outerPaths);
+            if (outerKey is null)
             {
-                // Null outer key never matches. LEFT still emits the outer
-                // with null-padded inner; INNER and RIGHT skip.
                 if (join.Type == JoinType.Left)
                     results.Add(CombineDocuments(outerDoc, EmptyDoc, stmt.Collection, join.Collection));
                 continue;
@@ -551,14 +569,12 @@ public sealed class QueryExecutor
             }
             else if (join.Type == JoinType.Left)
             {
-                // LEFT: emit the outer with no inner.
                 results.Add(CombineDocuments(outerDoc, EmptyDoc, stmt.Collection, join.Collection));
             }
         }
 
         if (join.Type == JoinType.Right)
         {
-            // Sweep unmatched inner rows and null-pad the outer side.
             foreach (var innerDocs in innerMap.Values)
                 foreach (var innerDoc in innerDocs)
                     if (!matchedInner!.Contains(innerDoc))
@@ -568,9 +584,111 @@ public sealed class QueryExecutor
         return (results, joinStrategy);
     }
 
-    private (List<BsonDocument> docs, string plan) ExecuteCrossJoin(SelectStatement stmt, List<BsonDocument> outerDocs)
+    /// <summary>
+    /// Pull the outer-side and inner-side paths out of a predicate list.
+    /// The "inner side" is whichever path's collection matches the join's
+    /// new collection; the "outer side" is the other (could be the source
+    /// collection or a previously-joined one). Returns parallel arrays so
+    /// the caller can extract paired tuples.
+    /// </summary>
+    private static (string[] outerPaths, string[] innerPaths) SplitOuterInnerPaths(
+        List<JoinPredicate> preds, string innerCollection)
     {
-        var join = stmt.Join!;
+        var outers = new string[preds.Count];
+        var inners = new string[preds.Count];
+        for (int i = 0; i < preds.Count; i++)
+        {
+            var p = preds[i];
+            bool rightIsInner = string.Equals(p.RightCollection, innerCollection, StringComparison.OrdinalIgnoreCase);
+            if (rightIsInner)
+            {
+                inners[i] = p.RightPath;
+                // Outer-side path may be prefixed with its collection name
+                // when the doc is a chained-combined doc; we re-attach the
+                // prefix here so JsonPathExtractor.Extract finds it either
+                // way (bare collection docs have the bare path; combined
+                // docs have the prefixed path).
+                outers[i] = string.IsNullOrEmpty(p.LeftCollection)
+                    ? p.LeftPath
+                    : $"{p.LeftCollection}.{p.LeftPath}";
+            }
+            else
+            {
+                inners[i] = p.LeftPath;
+                outers[i] = string.IsNullOrEmpty(p.RightCollection)
+                    ? p.RightPath
+                    : $"{p.RightCollection}.{p.RightPath}";
+            }
+        }
+        return (outers, inners);
+    }
+
+    /// <summary>Resolve a key from a doc using one or more paths. Returns
+    /// null if any single path yields a null value (a NULL component never
+    /// matches in SQL semantics). Single-path returns the BsonValue itself;
+    /// multi-path returns a string tuple key (cheap and equality-correct).
+    ///
+    /// <para>
+    /// Each path may be prefixed (<c>"orders.flightNumber"</c>) for chained
+    /// joins where the doc is combined, or bare (<c>"flightNumber"</c>) for
+    /// the first join's bare outer rows. We try the path as-given first;
+    /// if null, fall back to the suffix after the first dot. That handles
+    /// both shapes cleanly without the executor having to track which
+    /// position in the join chain it's at.
+    /// </para>
+    /// </summary>
+    private static object? ExtractKey(BsonDocument doc, string[] paths)
+    {
+        if (paths.Length == 1)
+            return ExtractOne(doc, paths[0]) ?? (object?)null;
+
+        var parts = new BsonValue[paths.Length];
+        for (int i = 0; i < paths.Length; i++)
+        {
+            var v = ExtractOne(doc, paths[i]);
+            if (v is null) return null;
+            parts[i] = v;
+        }
+        return string.Join("\x1f", parts.Select(p => p.ToString()));
+    }
+
+    private static BsonValue? ExtractOne(BsonDocument doc, string path)
+    {
+        var v = JsonPathExtractor.Extract(doc, path);
+        if (!v.IsNull) return v;
+
+        // Fall back: strip the first dotted segment. Handles "orders.x" on
+        // a bare orders row (where the bare path "x" is what's actually there).
+        int dot = path.IndexOf('.');
+        if (dot > 0 && dot < path.Length - 1)
+        {
+            var bare = path[(dot + 1)..];
+            var v2 = JsonPathExtractor.Extract(doc, bare);
+            if (!v2.IsNull) return v2;
+        }
+        return null;
+    }
+
+    private static Dictionary<object, List<BsonDocument>> BuildCompositeHashMap(
+        Collection collection, string[] paths)
+    {
+        var map = new Dictionary<object, List<BsonDocument>>();
+        foreach (var doc in collection.FindAll())
+        {
+            var key = ExtractKey(doc, paths);
+            if (key is null) continue;
+            if (!map.TryGetValue(key, out var list))
+            {
+                list = new List<BsonDocument>();
+                map[key] = list;
+            }
+            list.Add(doc);
+        }
+        return map;
+    }
+
+    private (List<BsonDocument> docs, string plan) ExecuteCrossJoin(SelectStatement stmt, JoinClause join, List<BsonDocument> outerDocs)
+    {
         var joinCollection = _catalog.GetCollection(join.Collection);
         if (joinCollection is null)
             return (new List<BsonDocument>(), $"CROSS_JOIN({join.Collection}:missing)");
@@ -729,8 +847,23 @@ public sealed class QueryExecutor
     private static BsonDocument CombineDocuments(BsonDocument outerDoc, BsonDocument innerDoc,
         string outerCollection, string innerCollection)
     {
+        // Chained joins (#44 Phase B): the second join's outer is already a
+        // combined doc {a: ..., b: ...} from join #1. We detect this by
+        // checking whether outerDoc already has outerCollection as a field —
+        // if yes, copy its existing fields through (preserving a, b, ...)
+        // and just add the new inner. If no, wrap both as before.
         var combined = new BsonDocument();
-        combined[outerCollection] = BsonValue.FromDocument(outerDoc);
+        if (outerDoc.ContainsKey(outerCollection))
+        {
+            // Already-combined outer: copy each top-level (collection-named)
+            // field through, then add the new inner collection alongside.
+            foreach (var key in outerDoc.Keys)
+                combined[key] = outerDoc[key];
+        }
+        else
+        {
+            combined[outerCollection] = BsonValue.FromDocument(outerDoc);
+        }
         combined[innerCollection] = BsonValue.FromDocument(innerDoc);
         return combined;
     }

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -3168,6 +3168,86 @@ public class EngineTests : IDisposable
         Assert.Equal("Alice", rows[0]["users"].AsDocument["name"].AsString);
     }
 
+    // --- JOIN Phase B+C: multi-join chains + compound ON (issue #44) ---
+
+    [Fact]
+    public void Sql_MultiJoin_ChainOfThree()
+    {
+        // a JOIN b ON ... JOIN c ON ...
+        // Pre-#44 the parser exited after the first JOIN; the second one
+        // produced a parse error. Now joins chain left-deep and the
+        // executor walks all of them in source order.
+        _db.Insert("users", """{"id":"u1","name":"Alice"}""");
+        _db.Insert("users", """{"id":"u2","name":"Bob"}""");
+        _db.Insert("orders", """{"userId":"u1","sku":"sku-A"}""");
+        _db.Insert("orders", """{"userId":"u2","sku":"sku-B"}""");
+        _db.Insert("products", """{"sku":"sku-A","name":"Widget"}""");
+        _db.Insert("products", """{"sku":"sku-B","name":"Gadget"}""");
+
+        var r = _db.Execute(
+            "SELECT * FROM users " +
+            "JOIN orders ON users.id = orders.userId " +
+            "JOIN products ON orders.sku = products.sku");
+        Assert.True(r.Success, r.Message);
+        Assert.Equal(2, r.Documents.Count);
+
+        // Each result should carry all three sub-docs (users, orders, products).
+        foreach (var doc in r.Documents)
+        {
+            Assert.True(doc.ContainsKey("users"));
+            Assert.True(doc.ContainsKey("orders"));
+            Assert.True(doc.ContainsKey("products"));
+        }
+    }
+
+    [Fact]
+    public void Sql_CompoundOn_TwoEqualitiesAndedTogether()
+    {
+        // ON a.x = b.x AND a.y = b.y
+        // Composite-key joins are common with surrogate keys and date/version
+        // partitioning. Pre-#44 the parser only accepted a single equality.
+        _db.Insert("orders", """{"region":"US","sku":"A","qty":10}""");
+        _db.Insert("orders", """{"region":"US","sku":"B","qty":5}""");
+        _db.Insert("orders", """{"region":"EU","sku":"A","qty":3}""");
+        _db.Insert("inventory", """{"region":"US","sku":"A","onHand":100}""");
+        _db.Insert("inventory", """{"region":"EU","sku":"A","onHand":50}""");
+        // Note: no inventory row for (US, B) — that order shouldn't match.
+
+        var r = _db.Execute(
+            "SELECT * FROM orders JOIN inventory " +
+            "ON orders.region = inventory.region AND orders.sku = inventory.sku");
+        Assert.True(r.Success, r.Message);
+        Assert.Equal(2, r.Documents.Count);
+
+        // Verify the matched pairs are the right ones.
+        foreach (var doc in r.Documents)
+        {
+            var orderRegion = doc["orders"].AsDocument["region"].AsString;
+            var orderSku = doc["orders"].AsDocument["sku"].AsString;
+            var invRegion = doc["inventory"].AsDocument["region"].AsString;
+            var invSku = doc["inventory"].AsDocument["sku"].AsString;
+            Assert.Equal(orderRegion, invRegion);
+            Assert.Equal(orderSku, invSku);
+        }
+    }
+
+    [Fact]
+    public void Sql_LeftJoin_ChainedAfterInner()
+    {
+        // INNER then LEFT — the LEFT's null-padding should still work after
+        // the chain handed it a combined doc as the outer.
+        _db.Insert("users", """{"id":"u1","name":"Alice"}""");
+        _db.Insert("orders", """{"userId":"u1","sku":"sku-A"}""");
+        // No products at all — LEFT JOIN should null-pad every row.
+        var r = _db.Execute(
+            "SELECT * FROM users " +
+            "JOIN orders ON users.id = orders.userId " +
+            "LEFT JOIN products ON orders.sku = products.sku");
+        Assert.True(r.Success, r.Message);
+        Assert.Single(r.Documents);
+        Assert.Equal(0, r.Documents[0]["products"].AsDocument.Count);
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Closes #44 (Phase B fully; Phase C compound-equality only — non-equality ON deferred).

## Summary
- Multi-join chaining: \`SELECT * FROM a JOIN b ON a.k = b.k JOIN c ON b.k = c.k\` parses and executes left-deep.
- Compound ON: \`a.x = b.x AND a.y = b.y\` parses; executor hashes on the tuple of right-side values.
- \`SelectStatement.Joins\` is now a list; \`Join\` stays as a singular back-compat facade.
- Path resolution falls back from prefixed → bare so first-join (bare outer) and chained-join (combined outer) shapes both work.

## What's deferred
- Non-equality ON (\`>\`, \`<\`) would need a nested-loop fallback. File separately if there's a consumer.
- Indexed compound joins. Single-predicate joins still use index hints; compound goes through full collection scan.

## Test plan
- [x] Chain of 3 INNER joins.
- [x] 2-predicate compound ON with mixed match coverage.
- [x] INNER then LEFT in one chain — null-padding still works mid-chain.
- [x] All Phase A (#17) tests still pass.
- [x] Full suite: 157/157 (was 154; +3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)