### PR TITLE
feat(#13): replicate multi-doc tx as a single TxBatch wire op

### DIFF
--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -1064,32 +1064,43 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
             throw;
         }
 
-        // Replicate as individual ops for now; logical-replication follower
-        // ordering already preserves intra-write-lock atomicity. Phase 2
-        // upgrades this to a single transactional batch.
+        // Issue #13: replicate the transaction as a single TxBatch so
+        // followers apply all sub-ops under one write lock and can never
+        // observe a partial mid-tx state. Pre-fix this loop broadcast each
+        // op individually — followers applied them with separate locks, so
+        // a read on the follower between two ops of the same tx saw a
+        // half-committed state (e.g. the delete of a delete-then-insert
+        // upsert briefly visible).
         if (_logicalServer is not null)
         {
+            var subOps = new List<TxBatchPayload.SubOp>();
             foreach (var (collectionName, ws) in tx.WorkingSets)
             {
+                // Order matches the apply order so followers see the same
+                // semantics: deletes, replaces, inserts.
                 foreach (var id in ws.Deletes)
                 {
-                    // We've already deleted from storage; reconstruct the doc
-                    // from the staged delete list isn't possible here, so we
-                    // broadcast a delete-by-id surrogate. Followers replay by
-                    // _id, which is enough for index maintenance + storage.
                     var idBytes = System.Text.Encoding.UTF8.GetBytes(id.ToString());
-                    _logicalServer.BroadcastNewOp(LogicalOpType.Delete, collectionName, idBytes);
+                    subOps.Add(new TxBatchPayload.SubOp(LogicalOpType.Delete, collectionName, idBytes));
                 }
                 foreach (var (_, newDoc) in ws.Replaces)
                 {
                     var bytes = BsonSerializer.Serialize(newDoc);
-                    _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, bytes);
+                    subOps.Add(new TxBatchPayload.SubOp(LogicalOpType.Insert, collectionName, bytes));
                 }
                 foreach (var (_, doc) in ws.Inserts)
                 {
                     var bytes = BsonSerializer.Serialize(doc);
-                    _logicalServer.BroadcastNewOp(LogicalOpType.Insert, collectionName, bytes);
+                    subOps.Add(new TxBatchPayload.SubOp(LogicalOpType.Insert, collectionName, bytes));
                 }
+            }
+            if (subOps.Count > 0)
+            {
+                var payload = TxBatchPayload.Serialize(subOps);
+                // Empty collection field — TxBatch is engine-wide, not
+                // per-collection. The follower routes each sub-op by its own
+                // Collection field.
+                _logicalServer.BroadcastNewOp(LogicalOpType.TxBatch, "", payload);
             }
         }
     }
@@ -1280,25 +1291,88 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         var seqFilePath = FilePath + ".followerseq";
         _logicalFollower = new LogicalReplicationFollower(host, port, seqFilePath, op =>
         {
-            switch (op.OpType)
-            {
-                case LogicalOpType.Insert:
-                    var doc = BsonSerializer.Deserialize(op.Data);
-                    // Use Insert directly; it acquires write lock internally.
-                    // The doc's _id is already set, so EnsureId is a no-op and we preserve the leader's id.
-                    InsertOnFollower(op.Collection, doc);
-                    break;
-                case LogicalOpType.Delete:
-                    var docId = DocumentId.FromBytes(op.Data);
-                    DeleteOnFollower(op.Collection, docId);
-                    break;
-                case LogicalOpType.CreateIndex:
-                    var (name, path, unique) = DeserializeIndexDefinition(op.Data);
-                    try { CreateIndex(op.Collection, path, name, unique); } catch { /* already exists */ }
-                    break;
-            }
+            ApplyFollowerOp(op);
         }, secret: sharedSecret);
         _logicalFollower.Start();
+    }
+
+    private void ApplyFollowerOp(LogicalOp op)
+    {
+        switch (op.OpType)
+        {
+            case LogicalOpType.Insert:
+                var doc = BsonSerializer.Deserialize(op.Data);
+                // Use Insert directly; it acquires write lock internally.
+                // The doc's _id is already set, so EnsureId is a no-op and we preserve the leader's id.
+                InsertOnFollower(op.Collection, doc);
+                break;
+            case LogicalOpType.Delete:
+                var docId = DocumentId.FromBytes(op.Data);
+                DeleteOnFollower(op.Collection, docId);
+                break;
+            case LogicalOpType.CreateIndex:
+                var (name, path, unique) = DeserializeIndexDefinition(op.Data);
+                try { CreateIndex(op.Collection, path, name, unique); } catch { /* already exists */ }
+                break;
+            case LogicalOpType.TxBatch:
+                ApplyTxBatchOnFollower(op.Data);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Apply a TxBatch's serialized sub-ops atomically — single write lock,
+    /// all sub-ops, then release. Issue #13. Pre-fix the leader broadcast each
+    /// sub-op as a separate LogicalOp, the follower applied each under its own
+    /// lock, and a read on the follower between sub-ops saw a mid-tx state.
+    /// </summary>
+    private void ApplyTxBatchOnFollower(byte[] payload)
+    {
+        var subOps = TxBatchPayload.Deserialize(payload);
+        _transactionManager.AcquireWriteLock();
+        try
+        {
+            foreach (var sub in subOps)
+            {
+                switch (sub.OpType)
+                {
+                    case LogicalOpType.Insert:
+                        var doc = BsonSerializer.Deserialize(sub.Data);
+                        // Bypass the public Insert/Delete (which would re-acquire
+                        // the lock); use the locked-internal helpers.
+                        InsertOnFollowerLocked(sub.Collection, doc);
+                        break;
+                    case LogicalOpType.Delete:
+                        var docId = DocumentId.FromBytes(sub.Data);
+                        DeleteOnFollowerLocked(sub.Collection, docId);
+                        break;
+                    // CreateIndex / DropIndex aren't expected in tx batches today
+                    // (transactions only stage Insert/Replace/Delete) but the
+                    // dispatch is here for future symmetry.
+                }
+            }
+        }
+        finally
+        {
+            _transactionManager.ReleaseWriteLock();
+        }
+    }
+
+    private void InsertOnFollowerLocked(string collectionName, BsonDocument doc)
+    {
+        var collection = _catalog.GetOrCreateCollection(collectionName);
+        var id = collection.Insert(doc);
+        _indexManager.OnDocumentInserted(collectionName, id, doc);
+    }
+
+    private void DeleteOnFollowerLocked(string collectionName, DocumentId docId)
+    {
+        var collection = _catalog.GetCollection(collectionName);
+        if (collection is null) return;
+        var doc = collection.FindById(docId);
+        if (doc is null) return;
+        collection.Delete(docId);
+        _indexManager.OnDocumentDeleted(collectionName, docId, doc);
     }
 
     public long LogicallyReplicatedOps() => _logicalFollower?.OpsApplied ?? 0;

--- a/src/DocumentForge.Transactions/LogicalReplication.cs
+++ b/src/DocumentForge.Transactions/LogicalReplication.cs
@@ -10,8 +10,67 @@ public enum LogicalOpType : byte
     Delete = 0x02,
     CreateIndex = 0x03,
     DropIndex = 0x04,
+    /// <summary>
+    /// A multi-doc transaction broadcast as a single atomic batch. The Data
+    /// payload is a length-prefixed list of sub-ops; followers deserialize
+    /// and apply them all under one write lock. Issue #13 — pre-fix
+    /// transactions were broadcast as individual ops, so followers could
+    /// observe a partial mid-tx state.
+    /// </summary>
+    TxBatch = 0x05,
     Heartbeat = 0xFE,
     Handshake = 0xFF,
+}
+
+/// <summary>
+/// Serialization helpers for the <see cref="LogicalOpType.TxBatch"/> payload.
+/// On-disk layout:
+/// <code>
+///   [SubOpCount:4]
+///   for each:
+///     [SubOpType:1][CollLen:2][CollBytes][DataLen:4][DataBytes]
+/// </code>
+/// Mirrors the per-op wire framing so the follower can reuse the same
+/// dispatch logic on each sub-op.
+/// </summary>
+public static class TxBatchPayload
+{
+    public sealed record SubOp(LogicalOpType OpType, string Collection, byte[] Data);
+
+    public static byte[] Serialize(IReadOnlyList<SubOp> ops)
+    {
+        using var ms = new MemoryStream();
+        using var w = new BinaryWriter(ms);
+        w.Write(ops.Count);
+        foreach (var op in ops)
+        {
+            w.Write((byte)op.OpType);
+            var cb = System.Text.Encoding.UTF8.GetBytes(op.Collection);
+            w.Write((short)cb.Length);
+            w.Write(cb);
+            w.Write(op.Data.Length);
+            w.Write(op.Data);
+        }
+        return ms.ToArray();
+    }
+
+    public static List<SubOp> Deserialize(byte[] payload)
+    {
+        using var ms = new MemoryStream(payload);
+        using var r = new BinaryReader(ms);
+        int count = r.ReadInt32();
+        var list = new List<SubOp>(count);
+        for (int i = 0; i < count; i++)
+        {
+            var opType = (LogicalOpType)r.ReadByte();
+            int collLen = r.ReadInt16();
+            var collBytes = r.ReadBytes(collLen);
+            int dataLen = r.ReadInt32();
+            var data = r.ReadBytes(dataLen);
+            list.Add(new SubOp(opType, System.Text.Encoding.UTF8.GetString(collBytes), data));
+        }
+        return list;
+    }
 }
 
 /// <summary>A single logical operation with monotonic sequence number.</summary>

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -3248,6 +3248,104 @@ public class EngineTests : IDisposable
         Assert.Equal(0, r.Documents[0]["products"].AsDocument.Count);
     }
 
+    // --- Replication-aware transactions (issue #13) ---
+
+    [Fact]
+    public async System.Threading.Tasks.Task LogicalReplication_MultiDocTx_ReplicatesAsAtomicBatch()
+    {
+        // The whole reason for #13: pre-fix the leader broadcast each
+        // sub-op of a transaction as a separate logical op, so a follower
+        // applying them with separate write locks could be observed in a
+        // mid-tx state by a concurrent reader. Now the leader sends a
+        // single TxBatch op carrying every sub-op, and the follower
+        // applies them all under one write lock — atomic from any
+        // observer's perspective.
+        int port = 5900 + System.Random.Shared.Next(100);
+        var leaderPath = Path.Combine(Path.GetTempPath(), $"txrepleader_{Guid.NewGuid():N}.dfdb");
+        var followerPath = Path.Combine(Path.GetTempPath(), $"txrepfollower_{Guid.NewGuid():N}.dfdb");
+
+        try
+        {
+            using var leader = DocumentForgeDb.Create(leaderPath);
+            leader.StartLogicalReplicationServer(port);
+            await System.Threading.Tasks.Task.Delay(150);
+
+            using var follower = DocumentForgeDb.Create(followerPath);
+            follower.StartLogicalReplicationFollower("localhost", port);
+
+            for (int i = 0; i < 30 && leader.GetLogicalFollowerCount() < 1; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+            Assert.Equal(1, leader.GetLogicalFollowerCount());
+
+            // Run a multi-doc tx: 3 inserts in one transaction. Pre-fix this
+            // would broadcast as 3 separate ops; post-fix as 1 TxBatch.
+            using (var tx = leader.BeginTransaction())
+            {
+                tx.Insert("orders", """{"pnr":"A"}""");
+                tx.Insert("orders", """{"pnr":"B"}""");
+                tx.Insert("orders", """{"pnr":"C"}""");
+                tx.Commit();
+            }
+
+            // Wait for the follower to apply the batch. opsApplied counts
+            // INDIVIDUAL apply calls — pre-fix this would be 3; post-fix
+            // it's 1 (the TxBatch counts as one applied op even though it
+            // contains 3 sub-ops).
+            for (int i = 0; i < 30 && follower.LogicallyReplicatedOps() < 1; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+
+            // The actual data should be there — all 3 docs.
+            var rows = follower.Execute("SELECT * FROM orders").Documents;
+            Assert.Equal(3, rows.Count);
+
+            // Wire-level assertion: follower applied exactly ONE op (the batch),
+            // not three. Pre-fix would have been 3.
+            Assert.Equal(1, follower.LogicallyReplicatedOps());
+        }
+        finally
+        {
+            try { File.Delete(leaderPath); File.Delete(leaderPath + ".wal"); File.Delete(leaderPath + ".recovery"); File.Delete(leaderPath + ".lock"); } catch { }
+            try { File.Delete(followerPath); File.Delete(followerPath + ".wal"); File.Delete(followerPath + ".recovery"); File.Delete(followerPath + ".followerseq"); File.Delete(followerPath + ".lock"); } catch { }
+        }
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task LogicalReplication_NonTxInserts_StillBroadcastIndividually()
+    {
+        // Single-doc operations (non-tx) keep the per-op broadcast — TxBatch
+        // is opt-in via BeginTransaction. Verify a sequence of three plain
+        // db.Insert calls produces three follower ops.
+        int port = 6000 + System.Random.Shared.Next(100);
+        var leaderPath = Path.Combine(Path.GetTempPath(), $"singleleader_{Guid.NewGuid():N}.dfdb");
+        var followerPath = Path.Combine(Path.GetTempPath(), $"singlefollower_{Guid.NewGuid():N}.dfdb");
+
+        try
+        {
+            using var leader = DocumentForgeDb.Create(leaderPath);
+            leader.StartLogicalReplicationServer(port);
+            await System.Threading.Tasks.Task.Delay(150);
+            using var follower = DocumentForgeDb.Create(followerPath);
+            follower.StartLogicalReplicationFollower("localhost", port);
+            for (int i = 0; i < 30 && leader.GetLogicalFollowerCount() < 1; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+
+            leader.Insert("orders", """{"pnr":"X"}""");
+            leader.Insert("orders", """{"pnr":"Y"}""");
+            leader.Insert("orders", """{"pnr":"Z"}""");
+
+            for (int i = 0; i < 30 && follower.LogicallyReplicatedOps() < 3; i++)
+                await System.Threading.Tasks.Task.Delay(100);
+
+            Assert.Equal(3, follower.Execute("SELECT * FROM orders").Documents.Count);
+            Assert.Equal(3, follower.LogicallyReplicatedOps());
+        }
+        finally
+        {
+            try { File.Delete(leaderPath); File.Delete(leaderPath + ".wal"); File.Delete(leaderPath + ".recovery"); File.Delete(leaderPath + ".lock"); } catch { }
+            try { File.Delete(followerPath); File.Delete(followerPath + ".wal"); File.Delete(followerPath + ".recovery"); File.Delete(followerPath + ".followerseq"); File.Delete(followerPath + ".lock"); } catch { }
+        }
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Closes #13.

## Summary
- New \`LogicalOpType.TxBatch\` carries every sub-op of a multi-doc transaction as one atomic wire-level message.
- Leader broadcasts a single TxBatch instead of N individual ops; follower applies under one write lock so a concurrent reader never sees a mid-tx state.
- Single-doc operations (non-tx \`db.Insert\` / \`db.Delete\`) keep the per-op broadcast path. TxBatch is opt-in via \`BeginTransaction\`.

## Test plan
- [x] Multi-doc tx replicates as 1 op containing 3 inserts (atomic).
- [x] Non-tx inserts still produce 3 separate ops (backwards-compat).
- [x] Full suite: 159/159 (was 157; +2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)