### PR TITLE
feat(#14 Phase D): PREPARE timeout self-abort (liveness fix)

### DIFF
--- a/src/DocumentForge.Engine/Cluster/DocumentForgeCluster.cs
+++ b/src/DocumentForge.Engine/Cluster/DocumentForgeCluster.cs
@@ -517,11 +517,18 @@ public sealed class DocumentForgeCluster : IDisposable
     internal void ExecuteOnShardForTx(int shardIndex, IReadOnlyList<ShardTxOp> ops) =>
         _shards[shardIndex].ExecuteTransaction(ops);
 
+    /// <summary>
+    /// Default per-tx PREPARE timeout used by <see cref="ClusterTransaction.Commit"/>.
+    /// Configurable; defaults to 30s. Phase D liveness fix: a participant
+    /// stuck in PREPARED past this deadline self-aborts.
+    /// </summary>
+    public TimeSpan PrepareTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
     // 2PC participant calls (Phase B.2). The cluster relays these straight
     // to the relevant shard's transport.
     internal string GetShardNameForTx(int shardIndex) => _shardNames[shardIndex];
     internal PrepareResult PrepareOnShardForTx(int shardIndex, string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
-        _shards[shardIndex].Prepare(txId, coordinatorShardId, ops);
+        _shards[shardIndex].Prepare(txId, coordinatorShardId, ops, PrepareTimeout);
     internal void CommitOnShardForTx(int shardIndex, string txId) =>
         _shards[shardIndex].CommitPrepared(txId);
     internal void RollbackOnShardForTx(int shardIndex, string txId) =>

--- a/src/DocumentForge.Engine/Cluster/HttpShardTransport.cs
+++ b/src/DocumentForge.Engine/Cluster/HttpShardTransport.cs
@@ -103,9 +103,12 @@ public sealed class HttpShardTransport : IShardTransport
         throw new NotSupportedException(
             $"[{ShardName}] HttpShardTransport.ExecuteTransaction is not implemented yet — cluster transactions over HTTP need a wire endpoint that hasn't shipped (issue #14).");
 
-    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
+    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout) =>
         throw new NotSupportedException(
             $"[{ShardName}] HttpShardTransport.Prepare is not implemented yet — cross-shard 2PC over HTTP needs a wire endpoint that hasn't shipped (issue #14).");
+
+    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
+        Prepare(txId, coordinatorShardId, ops, TimeSpan.FromSeconds(30));
 
     public void CommitPrepared(string txId) =>
         throw new NotSupportedException(

--- a/src/DocumentForge.Engine/Cluster/IShardTransport.cs
+++ b/src/DocumentForge.Engine/Cluster/IShardTransport.cs
@@ -40,8 +40,24 @@ public interface IShardTransport : IDisposable
     /// <see cref="RollbackPrepared"/>. Returns
     /// <see cref="PrepareVote.Prepared"/> on success or
     /// <see cref="PrepareVote.Aborted"/> with a reason on conflict.
+    ///
+    /// <para>
+    /// If <paramref name="timeout"/> elapses before COMMIT or ROLLBACK
+    /// arrives, the participant self-aborts: it releases the write lock
+    /// and writes a RESOLVED-aborted record to the prepared-tx log. A
+    /// late <see cref="CommitPrepared"/> for that txId then throws.
+    /// This is the Phase D liveness fix — without it, a coordinator
+    /// crash before broadcasting COMMIT would freeze the participant
+    /// indefinitely.
+    /// </para>
     /// </summary>
-    PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops);
+    PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout);
+
+    /// <summary>
+    /// Convenience overload using the default 30-second prepare timeout.
+    /// </summary>
+    PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
+        Prepare(txId, coordinatorShardId, ops, TimeSpan.FromSeconds(30));
 
     /// <summary>Phase 2 commit: apply the prepared ops on this shard and release the lock.</summary>
     void CommitPrepared(string txId);

--- a/src/DocumentForge.Engine/Cluster/InProcessShardTransport.cs
+++ b/src/DocumentForge.Engine/Cluster/InProcessShardTransport.cs
@@ -64,8 +64,12 @@ public sealed class InProcessShardTransport : IShardTransport
         tx.Commit();
     }
 
+    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout) =>
+        _db.PrepareTransaction(txId, coordinatorShardId, ops, timeout);
+
+    /// <summary>Convenience: Prepare with the default 30-second timeout.</summary>
     public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
-        _db.PrepareTransaction(txId, coordinatorShardId, ops);
+        Prepare(txId, coordinatorShardId, ops, TimeSpan.FromSeconds(30));
 
     public void CommitPrepared(string txId) => _db.CommitPreparedTransaction(txId);
 

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -994,12 +994,21 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     /// <see cref="RollbackPreparedTransaction"/> arrives. Returns
     /// <see cref="PrepareVote.Prepared"/> on success or
     /// <see cref="PrepareVote.Aborted"/> with a reason on conflict.
+    ///
+    /// <para>
+    /// If <paramref name="timeout"/> elapses before the resolve arrives,
+    /// the participant self-aborts (Phase D). Default overload uses 30s.
+    /// </para>
     /// </summary>
-    public PrepareResult PrepareTransaction(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops)
+    public PrepareResult PrepareTransaction(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout)
     {
         ThrowIfReadOnly();
-        return EnsurePreparedTxCoordinator().Prepare(txId, coordinatorShardId, ops);
+        return EnsurePreparedTxCoordinator().Prepare(txId, coordinatorShardId, ops, timeout);
     }
+
+    /// <summary>Convenience: prepare with the default 30-second timeout.</summary>
+    public PrepareResult PrepareTransaction(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops) =>
+        PrepareTransaction(txId, coordinatorShardId, ops, TimeSpan.FromSeconds(30));
 
     /// <summary>Phase 2 commit: apply the prepared ops and release the lock.</summary>
     public void CommitPreparedTransaction(string txId)

--- a/src/DocumentForge.Engine/PreparedTxCoordinator.cs
+++ b/src/DocumentForge.Engine/PreparedTxCoordinator.cs
@@ -92,11 +92,11 @@ internal sealed class PreparedTxCoordinator : IDisposable
         }
     }
 
-    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops)
+    public PrepareResult Prepare(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout)
     {
         if (_disposed) throw new ObjectDisposedException(nameof(PreparedTxCoordinator));
         EnsureWorker();
-        var cmd = new PrepareCommand(txId, coordinatorShardId, ops);
+        var cmd = new PrepareCommand(txId, coordinatorShardId, ops, timeout);
         if (!_queue.Writer.TryWrite(cmd))
             throw new InvalidOperationException("Could not enqueue prepare command");
         return cmd.Result.Task.GetAwaiter().GetResult();
@@ -142,6 +142,9 @@ internal sealed class PreparedTxCoordinator : IDisposable
                             case ResolveCommand r:
                                 HandleResolve(r);
                                 break;
+                            case TimeoutCommand t:
+                                HandleTimeout(t);
+                                break;
                         }
                     }
                     catch (Exception ex)
@@ -155,10 +158,13 @@ internal sealed class PreparedTxCoordinator : IDisposable
         finally
         {
             // If we're shutting down with an active prepared tx, release its
-            // lock so the engine can dispose cleanly. The on-disk record stays
-            // (recovery in Phase C decides what to do with it).
+            // lock + cancel its timeout so the engine can dispose cleanly.
+            // The on-disk PREPARED record stays (Recover decides what to
+            // do with it on the next Open).
             if (_active is not null)
             {
+                try { _active.TimeoutCts?.Cancel(); } catch { }
+                try { _active.TimeoutCts?.Dispose(); } catch { }
                 try { _txManager.ReleaseWriteLock(); } catch { }
                 _active = null;
             }
@@ -193,10 +199,25 @@ internal sealed class PreparedTxCoordinator : IDisposable
             // point of the durability fence.
             _log.AppendPrepared(cmd.TxId, cmd.CoordinatorShardId, cmd.Ops);
 
-            _active = new InFlightTx(cmd.TxId, cmd.CoordinatorShardId, cmd.Ops, workingSets);
+            // Set up the Phase D self-abort timer. The CTS is canceled by
+            // HandleResolve on a clean commit/rollback so we don't leak the
+            // pending Task.Delay. If the deadline fires first, the
+            // continuation enqueues a TimeoutCommand that the worker reads
+            // and self-aborts on.
+            var timeoutCts = new CancellationTokenSource();
+            _active = new InFlightTx(cmd.TxId, cmd.CoordinatorShardId, cmd.Ops, workingSets, timeoutCts);
             cmd.Result.SetResult(PrepareResult.Yes());
-            // Lock stays held — released by HandleResolve.
+            // Lock stays held — released by HandleResolve or HandleTimeout.
             lockHeld = false; // mark to avoid release in catch
+
+            var capturedTxId = cmd.TxId;
+            var capturedTimeout = cmd.Timeout;
+            _ = Task.Delay(capturedTimeout, timeoutCts.Token).ContinueWith(t =>
+            {
+                if (t.IsCanceled) return;
+                if (_disposed) return;
+                _queue.Writer.TryWrite(new TimeoutCommand(capturedTxId));
+            }, TaskScheduler.Default);
         }
         catch (Exception ex)
         {
@@ -265,6 +286,45 @@ internal sealed class PreparedTxCoordinator : IDisposable
         }
         finally
         {
+            // Cancel the pending timeout so we don't leak a Task.Delay or
+            // process a stale TimeoutCommand for a tx that's already
+            // resolved.
+            try { _active?.TimeoutCts?.Cancel(); } catch { }
+            try { _active?.TimeoutCts?.Dispose(); } catch { }
+            try { _txManager.ReleaseWriteLock(); } catch { }
+            _active = null;
+        }
+    }
+
+    /// <summary>
+    /// Phase D self-abort: the prepare timeout fired before COMMIT or
+    /// ROLLBACK arrived. Treat as ABORT — release the lock, write a
+    /// RESOLVED-aborted record, drop _active. A late CommitPrepared for
+    /// this txId then throws "no prepared tx" (the log scan won't find an
+    /// in-flight record because we just RESOLVED it).
+    /// </summary>
+    private void HandleTimeout(TimeoutCommand cmd)
+    {
+        if (_active is null || _active.TxId != cmd.TxId)
+        {
+            // Resolve raced and won; nothing to do.
+            return;
+        }
+
+        try
+        {
+            _log.AppendResolved(_active.TxId, committed: false);
+        }
+        catch
+        {
+            // Log write failed; we still have to release the lock to avoid
+            // wedging the participant. Recovery on next open will scan the
+            // log and notice the PREPARED-without-RESOLVED — and either
+            // resolve correctly via the coord log or abort.
+        }
+        finally
+        {
+            try { _active?.TimeoutCts?.Dispose(); } catch { }
             try { _txManager.ReleaseWriteLock(); } catch { }
             _active = null;
         }
@@ -288,17 +348,26 @@ internal sealed class PreparedTxCoordinator : IDisposable
         public string TxId { get; }
         public string CoordinatorShardId { get; }
         public IReadOnlyList<ShardTxOp> Ops { get; }
+        public TimeSpan Timeout { get; }
         public TaskCompletionSource<PrepareResult> Result { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public PrepareCommand(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops)
+        public PrepareCommand(string txId, string coordinatorShardId, IReadOnlyList<ShardTxOp> ops, TimeSpan timeout)
         {
             TxId = txId;
             CoordinatorShardId = coordinatorShardId;
             Ops = ops;
+            Timeout = timeout;
         }
 
         public override void Fail(Exception ex) => Result.TrySetException(ex);
+    }
+
+    private sealed class TimeoutCommand : PreparedTxCommand
+    {
+        public string TxId { get; }
+        public TimeoutCommand(string txId) { TxId = txId; }
+        public override void Fail(Exception ex) { /* internal — nobody waiting on this */ }
     }
 
     private sealed class ResolveCommand : PreparedTxCommand
@@ -321,5 +390,8 @@ internal sealed class PreparedTxCoordinator : IDisposable
         string TxId,
         string CoordinatorShardId,
         IReadOnlyList<ShardTxOp> Ops,
-        IReadOnlyDictionary<string, DocumentForge.Transactions.CollectionWorkingSet> WorkingSets);
+        IReadOnlyDictionary<string, DocumentForge.Transactions.CollectionWorkingSet> WorkingSets,
+        // Null when this in-flight state was rebuilt during a Recover sweep
+        // — recovery resolves immediately so no timer is set.
+        CancellationTokenSource? TimeoutCts = null);
 }

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -3269,6 +3269,150 @@ public class EngineTests : IDisposable
         }
     }
 
+    // --- 2PC PREPARE timeout (issue #14, Phase D) ---
+    //
+    // Without timeouts, a coordinator that dies before broadcasting COMMIT
+    // would leave participants PREPARED with their write lock held until
+    // someone runs cluster.Recover() manually. Phase D adds a per-tx
+    // deadline: the participant's worker thread schedules a Task.Delay
+    // that, on expiry, posts a TimeoutCommand to its own queue and self-
+    // aborts (releases the lock, writes a RESOLVED-aborted record).
+    // A late CommitPrepared for that txId then throws.
+
+    [Fact]
+    public void Participant_PreparedTimeout_SelfAborts()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"part_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            using var db = DocumentForgeDb.Create(path);
+            var shard = new DocumentForge.Engine.Cluster.InProcessShardTransport("A", db);
+
+            var ops = new List<DocumentForge.Engine.Cluster.ShardTxOp>
+            {
+                DocumentForge.Engine.Cluster.ShardTxOp.ForInsert("orders",
+                    DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"WILL-EXPIRE"}""")),
+            };
+
+            // 100ms timeout. Don't resolve — let the timer fire.
+            Assert.Equal(PrepareVote.Prepared,
+                shard.Prepare("tx-timeout", "A", ops, TimeSpan.FromMilliseconds(100)).Vote);
+
+            // Wait long enough for the timeout to fire and the abort to
+            // propagate through the worker queue.
+            Thread.Sleep(500);
+
+            // The abort should have released the write lock — a fresh
+            // PREPARE on a new tx must succeed.
+            var ops2 = new List<DocumentForge.Engine.Cluster.ShardTxOp>
+            {
+                DocumentForge.Engine.Cluster.ShardTxOp.ForInsert("orders",
+                    DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"AFTER"}""")),
+            };
+            var second = shard.Prepare("tx-after-timeout", "A", ops2, TimeSpan.FromSeconds(30));
+            Assert.Equal(PrepareVote.Prepared, second.Vote);
+            shard.CommitPrepared("tx-after-timeout");
+
+            // The expired tx never landed.
+            Assert.Single(db.Execute("SELECT * FROM orders").Documents);
+            Assert.Empty(db.Execute("SELECT * FROM orders WHERE pnr = 'WILL-EXPIRE'").Documents);
+        }
+        finally
+        {
+            try { File.Delete(path); File.Delete(path + ".wal"); File.Delete(path + ".recovery"); File.Delete(path + ".prepared.log"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Participant_LateCommitAfterTimeout_Throws()
+    {
+        // Coordinator decided COMMIT and called CommitPrepared, but the
+        // participant's timeout had already fired. The late commit must
+        // fail — the participant already wrote RESOLVED-aborted to its
+        // log. (In a real cluster this would surface as a tx failure on
+        // the coordinator-side broadcast loop; the next Recover would
+        // then see no in-flight on this shard and confirm aborted.)
+        var path = Path.Combine(Path.GetTempPath(), $"part_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            using var db = DocumentForgeDb.Create(path);
+            var shard = new DocumentForge.Engine.Cluster.InProcessShardTransport("A", db);
+
+            var ops = new List<DocumentForge.Engine.Cluster.ShardTxOp>
+            {
+                DocumentForge.Engine.Cluster.ShardTxOp.ForInsert("orders",
+                    DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"X"}""")),
+            };
+
+            Assert.Equal(PrepareVote.Prepared,
+                shard.Prepare("tx-late", "A", ops, TimeSpan.FromMilliseconds(100)).Vote);
+            Thread.Sleep(500);  // let the timeout fire and abort
+
+            Assert.ThrowsAny<Exception>(() => shard.CommitPrepared("tx-late"));
+        }
+        finally
+        {
+            try { File.Delete(path); File.Delete(path + ".wal"); File.Delete(path + ".recovery"); File.Delete(path + ".prepared.log"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Participant_FastResolveBeforeTimeout_NoAbort()
+    {
+        // Sanity: a timeout that's far enough out doesn't fire if
+        // we resolve quickly. The CTS cancellation should cleanly
+        // dispose the pending Task.Delay.
+        var path = Path.Combine(Path.GetTempPath(), $"part_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            using var db = DocumentForgeDb.Create(path);
+            var shard = new DocumentForge.Engine.Cluster.InProcessShardTransport("A", db);
+
+            var ops = new List<DocumentForge.Engine.Cluster.ShardTxOp>
+            {
+                DocumentForge.Engine.Cluster.ShardTxOp.ForInsert("orders",
+                    DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"FAST"}""")),
+            };
+
+            Assert.Equal(PrepareVote.Prepared,
+                shard.Prepare("tx-fast", "A", ops, TimeSpan.FromSeconds(30)).Vote);
+            shard.CommitPrepared("tx-fast");
+
+            // Wait briefly to make sure no stale TimeoutCommand fires.
+            Thread.Sleep(200);
+
+            // Doc visible from the commit.
+            Assert.Single(db.Execute("SELECT * FROM orders").Documents);
+
+            // A second Prepare/Commit cycle should still work cleanly
+            // (no stale state from the first tx's timeout machinery).
+            var ops2 = new List<DocumentForge.Engine.Cluster.ShardTxOp>
+            {
+                DocumentForge.Engine.Cluster.ShardTxOp.ForInsert("orders",
+                    DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"SECOND"}""")),
+            };
+            Assert.Equal(PrepareVote.Prepared,
+                shard.Prepare("tx-fast-2", "A", ops2, TimeSpan.FromSeconds(30)).Vote);
+            shard.CommitPrepared("tx-fast-2");
+            Assert.Equal(2, db.Execute("SELECT * FROM orders").Documents.Count);
+        }
+        finally
+        {
+            try { File.Delete(path); File.Delete(path + ".wal"); File.Delete(path + ".recovery"); File.Delete(path + ".prepared.log"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void ClusterTx_PrepareTimeout_PropertyHasReasonableDefault()
+    {
+        // The cluster exposes a configurable per-tx timeout. Default 30s,
+        // matching the issue's design decision.
+        using var cluster = new DocumentForge.Engine.Cluster.DocumentForgeCluster();
+        Assert.Equal(TimeSpan.FromSeconds(30), cluster.PrepareTimeout);
+        cluster.PrepareTimeout = TimeSpan.FromSeconds(5);
+        Assert.Equal(TimeSpan.FromSeconds(5), cluster.PrepareTimeout);
+    }
+
     // --- Index catalog: multi-page support (issue #22) ---
 
     [Fact]


### PR DESCRIPTION
## Summary

Stacked on top of #50. Adds the liveness fix from issue #14's plan: a participant that's PREPARED but hasn't heard COMMIT/ROLLBACK from the coordinator self-aborts after a configurable timeout (default 30s), releasing its write lock.

Without this, a coordinator crash before broadcasting decision left the participant wedged until someone ran \`cluster.Recover()\` manually.

## What changes

- \`IShardTransport.Prepare\` takes a \`TimeSpan timeout\` parameter. Existing 3-arg callers default to 30s via a kept-for-back-compat overload on each impl.
- \`DocumentForgeCluster.PrepareTimeout\` property (default 30s, mutable) — \`ClusterTransaction.Commit\` passes it to each \`Prepare\`.
- The participant's worker thread schedules a \`Task.Delay(timeout)\` after \`_active\` is set; when it fires, a \`TimeoutCommand\` goes on the queue and the worker self-aborts. A clean resolve cancels the pending delay via a \`CancellationTokenSource\` so it doesn't leak.
- Recovery-rebuild path (when \`_active\` comes from a C.2 sweep) is timeout-free — recovery resolves immediately.

## Tests

Four new (192/192 total):
- `Participant_PreparedTimeout_SelfAborts` — 100ms timeout, wait, verify lock released by running another Prepare/Commit; expired tx's insert never lands.
- `Participant_LateCommitAfterTimeout_Throws` — late CommitPrepared for an aborted-by-timeout tx fails.
- `Participant_FastResolveBeforeTimeout_NoAbort` — fast resolves don't trigger the timeout path; back-to-back tx work cleanly afterwards.
- `ClusterTx_PrepareTimeout_PropertyHasReasonableDefault` — property defaults to 30s and is mutable.

## Test plan

- [ ] CI green
- [ ] Manual sanity: spin up a 2-shard cluster, lower \`cluster.PrepareTimeout = TimeSpan.FromSeconds(2)\`, kill the coordinator-side process between PREPARE and COMMIT, observe participant self-abort.

## Base branch

This PR is stacked on `feat/14-cross-shard-2pc` (#50). When that merges, GitHub will auto-rebase this PR onto master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)