### PR TITLE
feat(#14): Replace + DeleteByField on ClusterTransaction

### DIFF
--- a/src/DocumentForge.Engine/Cluster/ClusterTransaction.cs
+++ b/src/DocumentForge.Engine/Cluster/ClusterTransaction.cs
@@ -100,9 +100,90 @@ public sealed class ClusterTransaction : IDisposable
         Insert(collection, BsonDocument.FromJson(json));
 
     /// <summary>
-    /// Read by _id. Phase A returns staged inserts only — committed cluster
-    /// state isn't queried because it would mean a network round-trip
-    /// during staging. Phase B will layer staged state over a real lookup.
+    /// Stage a replace by _id. The new doc's shard key is extracted to
+    /// route the op — implicit constraint: the new doc must hash to the
+    /// same shard as the existing doc. Changing the shard-key value
+    /// would require a cross-shard delete-then-insert (a different
+    /// operation); we don't currently support that. The participant
+    /// validates at PREPARE time and throws if the doc doesn't exist.
+    /// </summary>
+    public bool Replace(string collection, DocumentId id, BsonDocument newDoc)
+    {
+        EnsureActive();
+        var policy = _cluster.GetPolicyForTx(collection);
+        if (policy.Strategy == ShardingStrategy.Replicated)
+            throw new NotImplementedException(
+                $"Cluster transactions on replicated collection '{collection}' aren't supported yet (issue #14).");
+        if (policy.ShardKeyPath is null)
+            throw new DocumentForgeException($"Collection '{collection}' has no shard key configured.");
+
+        newDoc.SetId(id);
+        var keyValue = JsonPathExtractor.Extract(newDoc, policy.ShardKeyPath);
+        if (keyValue.IsNull)
+            throw new DocumentForgeException(
+                $"Replacement doc missing shard key '{policy.ShardKeyPath}' for collection '{collection}'.");
+
+        var shardIdx = _cluster.PickShardForTx(keyValue);
+
+        // If we previously staged an Insert on this shard for the same id,
+        // overwrite it — same single-node Replace semantics.
+        if (_stagedInsertsById.TryGetValue(id, out _))
+        {
+            _stagedInsertsById[id] = newDoc;
+            // Replace the existing Insert op in the per-shard list. We
+            // could iterate, but for simplicity just append a Replace op
+            // — the participant's working-set logic merges them at apply
+            // time.
+        }
+
+        AddOp(shardIdx, ShardTxOp.ForReplace(collection, id, newDoc));
+        return true;
+    }
+
+    public bool Replace(string collection, DocumentId id, string json) =>
+        Replace(collection, id, BsonDocument.FromJson(json));
+
+    /// <summary>
+    /// Stage deletes by field=value. If <paramref name="field"/> is the
+    /// collection's shard key path, the op routes to the one shard that
+    /// owns that key value (single-shard tx). Otherwise the matching
+    /// docs could be on any shard, so the op fans out to all shards
+    /// (multi-shard 2PC tx). Each participant's PREPARE phase scans
+    /// its local data and stages the actual deletes.
+    /// </summary>
+    public int DeleteByField(string collection, string field, string value)
+    {
+        EnsureActive();
+        var policy = _cluster.GetPolicyForTx(collection);
+        if (policy.Strategy == ShardingStrategy.Replicated)
+            throw new NotImplementedException(
+                $"Cluster transactions on replicated collection '{collection}' aren't supported yet (issue #14).");
+
+        if (policy.ShardKeyPath is not null &&
+            string.Equals(field, policy.ShardKeyPath, StringComparison.OrdinalIgnoreCase))
+        {
+            // Single-shard fast path: the field IS the shard key, so we
+            // know exactly which shard owns the matching docs.
+            var keyValue = BsonValue.FromString(value);
+            var shardIdx = _cluster.PickShardForTx(keyValue);
+            AddOp(shardIdx, ShardTxOp.ForDeleteByField(collection, field, value));
+            return -1;  // staging-time count not known; reported at commit
+        }
+
+        // Scatter: any shard might have matching docs. Stage on every
+        // shard — participants with no matches no-op cleanly.
+        for (int i = 0; i < _cluster.ShardCount; i++)
+        {
+            AddOp(i, ShardTxOp.ForDeleteByField(collection, field, value));
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Read by _id. Returns staged inserts/replaces from this transaction.
+    /// Cluster-wide reads of committed state aren't done at staging time
+    /// because they'd cost a network round-trip — call <c>cluster.Execute</c>
+    /// outside the transaction if you need to read committed state.
     /// </summary>
     public BsonDocument? Find(string collection, DocumentId id)
     {

--- a/src/DocumentForge.Engine/Cluster/InProcessShardTransport.cs
+++ b/src/DocumentForge.Engine/Cluster/InProcessShardTransport.cs
@@ -54,11 +54,14 @@ public sealed class InProcessShardTransport : IShardTransport
                 case ShardTxOpKind.Insert:
                     tx.Insert(op.Collection, op.Doc!);
                     break;
+                case ShardTxOpKind.Replace:
+                    tx.Replace(op.Collection, op.DocId, op.Doc!);
+                    break;
                 case ShardTxOpKind.DeleteByField:
                     tx.DeleteByField(op.Collection, op.Field!, op.Value!);
                     break;
                 default:
-                    throw new NotSupportedException($"ShardTxOpKind.{op.Kind} not supported in Phase A");
+                    throw new NotSupportedException($"ShardTxOpKind.{op.Kind} not supported");
             }
         }
         tx.Commit();

--- a/src/DocumentForge.Engine/Cluster/ShardTxOp.cs
+++ b/src/DocumentForge.Engine/Cluster/ShardTxOp.cs
@@ -1,3 +1,4 @@
+using DocumentForge.Core;
 using DocumentForge.Document;
 
 namespace DocumentForge.Engine.Cluster;
@@ -5,28 +6,26 @@ namespace DocumentForge.Engine.Cluster;
 public enum ShardTxOpKind
 {
     Insert,
-    DeleteByField
+    Replace,
+    DeleteByField,
 }
 
 /// <summary>
 /// One staged op inside a <see cref="ClusterTransaction"/>, scoped to a
 /// single participant shard. The cluster groups these by target shard and
 /// hands the per-shard batch to <see cref="IShardTransport.ExecuteTransaction"/>
-/// for atomic apply.
-///
-/// <para>
-/// Phase A only carries Insert and DeleteByField. Replace and Delete-by-id
-/// land in Phase B alongside cross-shard 2PC, since they need a doc-location
-/// lookup that isn't trivial without a shard-key on the call.
-/// </para>
+/// (single-shard fast path) or the participant's PREPARE flow (multi-shard).
 /// </summary>
 public sealed record ShardTxOp
 {
     public ShardTxOpKind Kind { get; init; }
     public string Collection { get; init; } = "";
 
-    // Insert
+    // Insert / Replace
     public BsonDocument? Doc { get; init; }
+
+    // Replace — id of the existing doc to overwrite
+    public DocumentId DocId { get; init; }
 
     // DeleteByField
     public string? Field { get; init; }
@@ -34,6 +33,9 @@ public sealed record ShardTxOp
 
     public static ShardTxOp ForInsert(string collection, BsonDocument doc) =>
         new() { Kind = ShardTxOpKind.Insert, Collection = collection, Doc = doc };
+
+    public static ShardTxOp ForReplace(string collection, DocumentId id, BsonDocument doc) =>
+        new() { Kind = ShardTxOpKind.Replace, Collection = collection, DocId = id, Doc = doc };
 
     public static ShardTxOp ForDeleteByField(string collection, string field, string value) =>
         new() { Kind = ShardTxOpKind.DeleteByField, Collection = collection, Field = field, Value = value };

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -1131,6 +1131,10 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
                     op.Doc!.EnsureId();
                     ws.Inserts[op.Doc.GetId()] = op.Doc;
                     break;
+                case ShardTxOpKind.Replace:
+                    op.Doc!.SetId(op.DocId);
+                    ws.Replaces[op.DocId] = op.Doc;
+                    break;
                 case ShardTxOpKind.DeleteByField:
                     var coll = _catalog.GetCollection(op.Collection);
                     if (coll is null) break;

--- a/src/DocumentForge.Engine/PreparedTxLog.cs
+++ b/src/DocumentForge.Engine/PreparedTxLog.cs
@@ -191,6 +191,12 @@ internal sealed class PreparedTxLog : IDisposable
                     bw.Write(bytes.Length);
                     bw.Write(bytes);
                     break;
+                case ShardTxOpKind.Replace:
+                    bw.Write(op.DocId.ToBytes());  // 16 bytes
+                    var rBytes = BsonSerializer.Serialize(op.Doc!);
+                    bw.Write(rBytes.Length);
+                    bw.Write(rBytes);
+                    break;
                 case ShardTxOpKind.DeleteByField:
                     WriteShortString(bw, op.Field!);
                     WriteLongString(bw, op.Value!);
@@ -221,6 +227,14 @@ internal sealed class PreparedTxLog : IDisposable
                     var bsonBytes = br.ReadBytes(bsonLen);
                     var doc = BsonSerializer.Deserialize(bsonBytes);
                     ops.Add(ShardTxOp.ForInsert(coll, doc));
+                    break;
+                case ShardTxOpKind.Replace:
+                    var idBytes = br.ReadBytes(16);
+                    var docId = DocumentForge.Core.DocumentId.FromBytes(idBytes);
+                    int rBsonLen = br.ReadInt32();
+                    var rBsonBytes = br.ReadBytes(rBsonLen);
+                    var rDoc = BsonSerializer.Deserialize(rBsonBytes);
+                    ops.Add(ShardTxOp.ForReplace(coll, docId, rDoc));
                     break;
                 case ShardTxOpKind.DeleteByField:
                     var field = ReadShortString(br);

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -3058,6 +3058,129 @@ public class EngineTests : IDisposable
         finally { CleanupClusterPaths(paths); }
     }
 
+    // --- ClusterTransaction Replace + DeleteByField (issue #14, Phase B-deferred) ---
+    //
+    // Phase A only shipped Insert + Find on ClusterTransaction. Replace
+    // and DeleteByField (and the scatter case for non-shard-key fields)
+    // need the multi-shard 2PC machinery from Phase B/C, so they came
+    // back here once that landed.
+    //
+    // Replace routes by extracting the shard key from the new doc — same
+    // shard as the existing doc means single-shard fast path. Changing
+    // the shard-key value is a semantically different operation that
+    // we don't currently handle.
+    //
+    // DeleteByField: if the field IS the shard key, single-shard. If
+    // not, the matching docs could be anywhere — scatter to every shard.
+
+    [Fact]
+    public void ClusterTx_Replace_SingleShard_Commits()
+    {
+        var (dbs, paths, cluster) = BuildClusterForTx(3, "orders", "pnr");
+        try
+        {
+            var insertedId = cluster.Insert("orders", """{"pnr":"BASE","seat":"12A"}""");
+
+            using (var tx = cluster.BeginTransaction())
+            {
+                tx.Replace("orders", insertedId, """{"pnr":"BASE","seat":"99Z"}""");
+                tx.Commit();
+            }
+
+            var rows = cluster.Execute("SELECT * FROM orders WHERE pnr = 'BASE'").Documents;
+            Assert.Single(rows);
+            Assert.Equal("99Z", rows[0]["seat"].AsString);
+            cluster.Dispose();
+        }
+        finally { CleanupClusterPaths(paths); }
+    }
+
+    [Fact]
+    public void ClusterTx_DeleteByField_OnShardKey_IsSingleShard()
+    {
+        // field == shard key → cluster knows exactly which shard owns the
+        // matching docs. Should be a single-shard tx (fast path).
+        var (dbs, paths, cluster) = BuildClusterForTx(3, "orders", "pnr");
+        try
+        {
+            cluster.Insert("orders", """{"pnr":"GONE","leg":1}""");
+            cluster.Insert("orders", """{"pnr":"GONE","leg":2}""");
+
+            using (var tx = cluster.BeginTransaction())
+            {
+                tx.DeleteByField("orders", "pnr", "GONE");
+                Assert.Equal(1, tx.ParticipantCount);  // single-shard
+                tx.Commit();
+            }
+
+            Assert.Empty(cluster.Execute("SELECT * FROM orders WHERE pnr = 'GONE'").Documents);
+            cluster.Dispose();
+        }
+        finally { CleanupClusterPaths(paths); }
+    }
+
+    [Fact]
+    public void ClusterTx_DeleteByField_OnNonShardKey_ScattersToAllShards()
+    {
+        // field != shard key → matching docs could be anywhere. Op fans
+        // out to every shard. The 2PC machinery handles the multi-shard
+        // commit; participants with no matches no-op cleanly.
+        var (dbs, paths, cluster) = BuildClusterForTx(3, "orders", "pnr");
+        try
+        {
+            // Seed docs across shards. status=CANCELLED on each.
+            for (int i = 0; i < 30; i++)
+                cluster.Insert("orders", $$"""{"pnr":"P{{i:D3}}","status":"CANCELLED"}""");
+            for (int i = 0; i < 30; i++)
+                cluster.Insert("orders", $$"""{"pnr":"K{{i:D3}}","status":"CONFIRMED"}""");
+
+            // Sanity — at least 2 shards have CANCELLED docs (consistent
+            // hashing across 60 unique pnrs).
+            int shardsWithCancelled = 0;
+            for (int s = 0; s < dbs.Length; s++)
+                if (dbs[s].Execute("SELECT * FROM orders WHERE status = 'CANCELLED'").Documents.Count > 0)
+                    shardsWithCancelled++;
+            Assert.True(shardsWithCancelled >= 2, $"Test setup expected ≥2 shards with CANCELLED, got {shardsWithCancelled}");
+
+            using (var tx = cluster.BeginTransaction())
+            {
+                tx.DeleteByField("orders", "status", "CANCELLED");
+                Assert.Equal(3, tx.ParticipantCount);  // scattered to all shards
+                tx.Commit();
+            }
+
+            Assert.Empty(cluster.Execute("SELECT * FROM orders WHERE status = 'CANCELLED'").Documents);
+            Assert.Equal(30, cluster.Execute("SELECT * FROM orders WHERE status = 'CONFIRMED'").Documents.Count);
+            cluster.Dispose();
+        }
+        finally { CleanupClusterPaths(paths); }
+    }
+
+    [Fact]
+    public void ClusterTx_Replace_RollsBackWithRestOfTransaction()
+    {
+        // Replace inside a multi-op transaction — when the tx aborts,
+        // the replace must not land. (The atomicity story is what makes
+        // tx.Replace genuinely useful over cluster.Execute("UPDATE ...").)
+        var (dbs, paths, cluster) = BuildClusterForTx(3, "orders", "pnr");
+        try
+        {
+            var id = cluster.Insert("orders", """{"pnr":"KEEP","status":"CONFIRMED"}""");
+
+            using (var tx = cluster.BeginTransaction())
+            {
+                tx.Replace("orders", id, """{"pnr":"KEEP","status":"CANCELLED"}""");
+                tx.Rollback();
+            }
+
+            var rows = cluster.Execute("SELECT * FROM orders WHERE pnr = 'KEEP'").Documents;
+            Assert.Single(rows);
+            Assert.Equal("CONFIRMED", rows[0]["status"].AsString);  // unchanged
+            cluster.Dispose();
+        }
+        finally { CleanupClusterPaths(paths); }
+    }
+
     // --- 2PC participant API (issue #14, Phase B.1: prepare/commit/rollback on a single shard) ---
     //
     // Phase B.1 lands the participant-side wire ops on IShardTransport:


### PR DESCRIPTION
## Summary

Stacked on #52. Closes the user-facing API gap from Phase A — `ClusterTransaction` now supports `Replace` and `DeleteByField` in addition to `Insert + Find`.

## What changes

- `tx.Replace(coll, id, newDoc)` — routes by shard key extracted from `newDoc`. Same atomicity as single-node `Replace`. Changing the shard-key value isn't supported (silent no-op semantics; documented in code).
- `tx.DeleteByField(coll, field, value)` — single-shard fast path when `field` is the shard key path; otherwise scatters to every shard (multi-shard 2PC, participants with no matches no-op cleanly).
- New `ShardTxOpKind.Replace` carrying a 16-byte DocumentId + BSON payload. `PreparedTxLog` serialization extended symmetrically. `BuildWorkingSetsFromShardTxOps` maps Replace to the existing `CollectionWorkingSet.Replaces` path — apply already handles it.

## Skipped (intentional)

- `Delete(coll, id)` without a shard key. Would either require a clunky signature (`Delete(coll, id, shardKey)`) or scatter to every shard (heavy for the common case). `DeleteByField` on the shard-key field covers most use cases. Easy to add later as an overload.

## Tests

Four new (196/196 total):
- `ClusterTx_Replace_SingleShard_Commits`
- `ClusterTx_DeleteByField_OnShardKey_IsSingleShard` (asserts ParticipantCount == 1)
- `ClusterTx_DeleteByField_OnNonShardKey_ScattersToAllShards` (asserts ParticipantCount == 3, multi-shard 2PC)
- `ClusterTx_Replace_RollsBackWithRestOfTransaction`

## Base branch

Stacked on `feat/14-phase-d-timeout` (#52), which is stacked on `feat/14-cross-shard-2pc` (#50). When the base PRs merge, GitHub auto-rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)