### PR TITLE
feat(#14 Phase E.2): operator manual-abort + 2PC metrics

### DIFF
--- a/samples/DocumentForge.Api/TransactionEndpoints.cs
+++ b/samples/DocumentForge.Api/TransactionEndpoints.cs
@@ -110,5 +110,48 @@ public static class TransactionEndpoints
                 Done = state.Done
             });
         });
+
+        // ---- POST /tx/{txId}/abort ----
+        // Operator-driven manual abort (Phase E.2). For the rare case where
+        // a participant is stuck PREPARED past the timeout (or the timeout
+        // is disabled) and the operator wants to free the lock manually.
+        //
+        // Safety guard: if THIS shard recorded COMMIT_DECISION for the tx
+        // (i.e. it's the coordinator and decided), refuse with 409 Conflict.
+        // Aborting after a COMMIT decision would make the cluster
+        // inconsistent — the operator should let recovery complete.
+        app.MapPost("/tx/{txId}/abort", (string txId) =>
+        {
+            var coordState = db.GetCoordinatorTxState(txId);
+            if (coordState?.Decided == true)
+            {
+                return Results.Conflict(new
+                {
+                    error = $"Cannot abort {txId}: this shard recorded COMMIT_DECISION. Let recovery complete the broadcast."
+                });
+            }
+            try
+            {
+                db.RollbackPreparedTransaction(txId);
+                return Results.Ok(new { success = true });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // ---- GET /tx/stats ----
+        // Operator-facing counters for participant-side 2PC activity.
+        app.MapGet("/tx/stats", () =>
+        {
+            var s = db.GetPreparedTxStats();
+            return Results.Ok(new
+            {
+                prepareTotal = s.PrepareTotal,
+                prepareAbortedTotal = s.PrepareAbortedTotal,
+                committedTotal = s.CommittedTotal,
+                rolledBackTotal = s.RolledBackTotal,
+                timedOutTotal = s.TimedOutTotal,
+                inFlightPrepared = s.InFlightPrepared
+            });
+        });
     }
 }

--- a/src/DocumentForge.Engine/Cluster/HttpShardTransport.cs
+++ b/src/DocumentForge.Engine/Cluster/HttpShardTransport.cs
@@ -190,6 +190,50 @@ public sealed class HttpShardTransport : IShardTransport
         throw new DocumentForgeException($"[{ShardName}] {opName} failed: HTTP {(int)response.StatusCode}: {body}");
     }
 
+    // --- Operator endpoints (Phase E.2) ---
+    // Not on IShardTransport — these are administrative, not routing.
+    // Available on the concrete HttpShardTransport for ergonomics; the
+    // C# API has equivalents on DocumentForgeDb directly.
+
+    /// <summary>
+    /// Operator-driven manual abort. For the rare case where a participant
+    /// is stuck PREPARED past the timeout and an operator wants to free
+    /// the lock manually. The server refuses (409 Conflict) if this shard
+    /// recorded COMMIT_DECISION for the tx — aborting after a decision
+    /// would make the cluster inconsistent.
+    /// </summary>
+    public void OperatorAbort(string txId)
+    {
+        var response = _client.PostAsync($"/tx/{txId}/abort", null).GetAwaiter().GetResult();
+        if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+        {
+            var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+            throw new DocumentForgeException($"[{ShardName}] OperatorAbort refused: {body}");
+        }
+        ThrowIfNotSuccess(response, nameof(OperatorAbort));
+    }
+
+    /// <summary>Operator-facing snapshot of participant-side 2PC counters.</summary>
+    public PreparedTxStats GetStats()
+    {
+        var response = _client.GetAsync("/tx/stats").GetAwaiter().GetResult();
+        var body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        if (!response.IsSuccessStatusCode)
+            throw new DocumentForgeException($"[{ShardName}] GetStats failed: HTTP {(int)response.StatusCode}: {body}");
+        using var json = JsonDocument.Parse(body);
+        var root = json.RootElement;
+        long Read(string name) => root.TryGetProperty(name, out var p) && p.ValueKind == JsonValueKind.Number ? p.GetInt64() : 0;
+        return new PreparedTxStats
+        {
+            PrepareTotal = Read("prepareTotal"),
+            PrepareAbortedTotal = Read("prepareAbortedTotal"),
+            CommittedTotal = Read("committedTotal"),
+            RolledBackTotal = Read("rolledBackTotal"),
+            TimedOutTotal = Read("timedOutTotal"),
+            InFlightPrepared = Read("inFlightPrepared")
+        };
+    }
+
     public DatabaseStatistics GetStatistics()
     {
         var response = _client.GetAsync("/stats").GetAwaiter().GetResult();

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -965,6 +965,7 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     private PreparedTxLog? _preparedTxLog;
     private PreparedTxCoordinator? _preparedTxCoordinator;
     private readonly object _preparedTxInitLock = new();
+    private readonly PreparedTxStats _preparedTxStats = new();
 
     // Phase C.1 — coordinator decision log. Only non-null on a shard that's
     // actually been asked to coordinate a cluster tx; lazy-initialized on
@@ -982,7 +983,7 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
             if (_preparedTxCoordinator is not null) return _preparedTxCoordinator;
             ThrowIfReadOnly();
             _preparedTxLog = new PreparedTxLog(FilePath + ".prepared.log");
-            _preparedTxCoordinator = new PreparedTxCoordinator(this, _transactionManager, _preparedTxLog);
+            _preparedTxCoordinator = new PreparedTxCoordinator(this, _transactionManager, _preparedTxLog, _preparedTxStats);
             return _preparedTxCoordinator;
         }
     }
@@ -1089,6 +1090,14 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
         using var transient = new PreparedTxLog(path);
         return transient.ScanInFlight();
     }
+
+    /// <summary>
+    /// Snapshot of the participant-side 2PC counters for this shard.
+    /// Returns zero-valued stats on a DB that has never participated in
+    /// a prepared tx. Phase E.2 — fed by the HTTP <c>GET /tx/stats</c>
+    /// endpoint for operator dashboards.
+    /// </summary>
+    public PreparedTxStats GetPreparedTxStats() => _preparedTxStats.Snapshot();
 
     /// <summary>
     /// Coordinator-side: what does this shard's coord log say about

--- a/src/DocumentForge.Engine/PreparedTxCoordinator.cs
+++ b/src/DocumentForge.Engine/PreparedTxCoordinator.cs
@@ -54,6 +54,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
     private readonly DocumentForgeDb _db;
     private readonly TransactionManager _txManager;
     private readonly PreparedTxLog _log;
+    private readonly PreparedTxStats _stats;
     private readonly Channel<PreparedTxCommand> _queue;
     private Thread? _worker;
     private readonly object _startLock = new();
@@ -65,11 +66,12 @@ internal sealed class PreparedTxCoordinator : IDisposable
     // hold the write lock for writes only, not reads).
     private InFlightTx? _active;
 
-    public PreparedTxCoordinator(DocumentForgeDb db, TransactionManager txManager, PreparedTxLog log)
+    public PreparedTxCoordinator(DocumentForgeDb db, TransactionManager txManager, PreparedTxLog log, PreparedTxStats stats)
     {
         _db = db;
         _txManager = txManager;
         _log = log;
+        _stats = stats;
         _queue = Channel.CreateUnbounded<PreparedTxCommand>(new UnboundedChannelOptions
         {
             SingleReader = true,
@@ -173,8 +175,11 @@ internal sealed class PreparedTxCoordinator : IDisposable
 
     private void HandlePrepare(PrepareCommand cmd)
     {
+        Interlocked.Increment(ref _stats.PrepareTotal);
+
         if (_active is not null)
         {
+            Interlocked.Increment(ref _stats.PrepareAbortedTotal);
             cmd.Result.SetResult(PrepareResult.No(
                 $"another tx is already prepared on this shard ({_active.TxId})"));
             return;
@@ -206,6 +211,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
             // and self-aborts on.
             var timeoutCts = new CancellationTokenSource();
             _active = new InFlightTx(cmd.TxId, cmd.CoordinatorShardId, cmd.Ops, workingSets, timeoutCts);
+            Interlocked.Increment(ref _stats.InFlightPrepared);
             cmd.Result.SetResult(PrepareResult.Yes());
             // Lock stays held — released by HandleResolve or HandleTimeout.
             lockHeld = false; // mark to avoid release in catch
@@ -221,6 +227,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
         }
         catch (Exception ex)
         {
+            Interlocked.Increment(ref _stats.PrepareAbortedTotal);
             cmd.Result.SetResult(PrepareResult.No(ex.Message));
         }
         finally
@@ -252,6 +259,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
             {
                 var workingSets = _db.BuildWorkingSetsFromShardTxOps(rec.Ops);
                 _active = new InFlightTx(rec.TxId, rec.CoordinatorShardId, rec.Ops, workingSets);
+                Interlocked.Increment(ref _stats.InFlightPrepared);
                 reacquiredFresh = true;
             }
             catch
@@ -271,29 +279,37 @@ internal sealed class PreparedTxCoordinator : IDisposable
             return;
         }
 
+        Exception? failure = null;
         try
         {
             if (cmd.Commit)
             {
                 _db.ApplyWorkingSetsLocked(_active.WorkingSets);
+                Interlocked.Increment(ref _stats.CommittedTotal);
+            }
+            else
+            {
+                Interlocked.Increment(ref _stats.RolledBackTotal);
             }
             _log.AppendResolved(_active.TxId, cmd.Commit);
-            cmd.Done.SetResult(null);
         }
-        catch (Exception ex)
-        {
-            cmd.Done.SetException(ex);
-        }
-        finally
-        {
-            // Cancel the pending timeout so we don't leak a Task.Delay or
-            // process a stale TimeoutCommand for a tx that's already
-            // resolved.
-            try { _active?.TimeoutCts?.Cancel(); } catch { }
-            try { _active?.TimeoutCts?.Dispose(); } catch { }
-            try { _txManager.ReleaseWriteLock(); } catch { }
-            _active = null;
-        }
+        catch (Exception ex) { failure = ex; }
+
+        // Cleanup BEFORE signaling the caller. With
+        // RunContinuationsAsynchronously the awaiter can resume on a
+        // different thread the instant SetResult is called — if cleanup
+        // ran in finally, an observer's GetPreparedTxStats() could race
+        // and see InFlightPrepared still at 1 even though the resolve
+        // returned. Cleaning up first means the observed state matches
+        // the API contract.
+        try { _active?.TimeoutCts?.Cancel(); } catch { }
+        try { _active?.TimeoutCts?.Dispose(); } catch { }
+        try { _txManager.ReleaseWriteLock(); } catch { }
+        _active = null;
+        Interlocked.Decrement(ref _stats.InFlightPrepared);
+
+        if (failure is not null) cmd.Done.SetException(failure);
+        else cmd.Done.SetResult(null);
     }
 
     /// <summary>
@@ -314,6 +330,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
         try
         {
             _log.AppendResolved(_active.TxId, committed: false);
+            Interlocked.Increment(ref _stats.TimedOutTotal);
         }
         catch
         {
@@ -327,6 +344,7 @@ internal sealed class PreparedTxCoordinator : IDisposable
             try { _active?.TimeoutCts?.Dispose(); } catch { }
             try { _txManager.ReleaseWriteLock(); } catch { }
             _active = null;
+            Interlocked.Decrement(ref _stats.InFlightPrepared);
         }
     }
 

--- a/src/DocumentForge.Engine/PreparedTxStats.cs
+++ b/src/DocumentForge.Engine/PreparedTxStats.cs
@@ -1,0 +1,45 @@
+namespace DocumentForge.Engine;
+
+/// <summary>
+/// In-process counters for the participant-side 2PC machinery on a single
+/// shard. Read via <see cref="DocumentForgeDb.GetPreparedTxStats"/>; the
+/// HTTP endpoint <c>GET /tx/stats</c> exposes them so an operator dashboard
+/// (or a Prometheus textfile collector) can scrape them.
+///
+/// <para>
+/// Phase E.2 keeps this deliberately simple — long counters incremented
+/// via <see cref="System.Threading.Interlocked"/> on the worker thread's
+/// transitions. Phase F could swap in an OpenTelemetry meter or histogram
+/// if production needs it.
+/// </para>
+/// </summary>
+public sealed class PreparedTxStats
+{
+    /// <summary>Every PREPARE message the participant has accepted on the wire (PREPARED + ABORTED votes both counted here).</summary>
+    public long PrepareTotal;
+    /// <summary>PREPARE that returned ABORT — validation conflict, busy slot, or other failure before the lock-hold.</summary>
+    public long PrepareAbortedTotal;
+    /// <summary>PREPARED tx that was finalized via COMMIT.</summary>
+    public long CommittedTotal;
+    /// <summary>PREPARED tx that was finalized via ROLLBACK (coordinator-initiated or operator-driven).</summary>
+    public long RolledBackTotal;
+    /// <summary>PREPARED tx that self-aborted because the PREPARE timeout elapsed (Phase D).</summary>
+    public long TimedOutTotal;
+
+    /// <summary>
+    /// Currently PREPARED tx on this shard. Phase B's invariant is at-most-
+    /// one, so this is 0 or 1; gauges allow operators to alert on stuck
+    /// PREPARED states (a value of 1 for &gt;30s is suspicious).
+    /// </summary>
+    public long InFlightPrepared;
+
+    public PreparedTxStats Snapshot() => new()
+    {
+        PrepareTotal = Interlocked.Read(ref PrepareTotal),
+        PrepareAbortedTotal = Interlocked.Read(ref PrepareAbortedTotal),
+        CommittedTotal = Interlocked.Read(ref CommittedTotal),
+        RolledBackTotal = Interlocked.Read(ref RolledBackTotal),
+        TimedOutTotal = Interlocked.Read(ref TimedOutTotal),
+        InFlightPrepared = Interlocked.Read(ref InFlightPrepared),
+    };
+}

--- a/tests/DocumentForge.Tests/HttpShardTransportTests.cs
+++ b/tests/DocumentForge.Tests/HttpShardTransportTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using DocumentForge.Api;
+using DocumentForge.Core;
 using DocumentForge.Engine;
 using DocumentForge.Engine.Cluster;
 using Microsoft.AspNetCore.Builder;
@@ -241,6 +242,145 @@ public class HttpShardTransportTests : IDisposable
         var totalB = second.db.Execute("SELECT * FROM orders").Documents.Count;
         Assert.Equal(1, totalA);
         Assert.Equal(1, totalB);
+    }
+
+    // --- Phase E.2: operator endpoints + metrics ---
+
+    [Fact]
+    public void Stats_TrackPrepareCommitRollbackTransitions()
+    {
+        // Direct C# API (no HTTP) — quickest way to assert the counters
+        // increment on each transition without wire overhead.
+        var path = Path.Combine(Path.GetTempPath(), $"stats_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            using var db = DocumentForgeDb.Create(path);
+            var ops = new List<ShardTxOp>
+            {
+                ShardTxOp.ForInsert("orders", DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"S1"}""")),
+            };
+
+            // Initial counters all zero.
+            var s0 = db.GetPreparedTxStats();
+            Assert.Equal(0, s0.PrepareTotal);
+            Assert.Equal(0, s0.CommittedTotal);
+
+            // Prepare + Commit cycle.
+            db.PrepareTransaction("tx-s1", "self", ops, TimeSpan.FromSeconds(30));
+            db.CommitPreparedTransaction("tx-s1");
+
+            var s1 = db.GetPreparedTxStats();
+            Assert.Equal(1, s1.PrepareTotal);
+            Assert.Equal(1, s1.CommittedTotal);
+            Assert.Equal(0, s1.RolledBackTotal);
+            Assert.Equal(0, s1.InFlightPrepared);
+
+            // Prepare + Rollback cycle.
+            db.PrepareTransaction("tx-s2", "self", ops, TimeSpan.FromSeconds(30));
+            db.RollbackPreparedTransaction("tx-s2");
+
+            var s2 = db.GetPreparedTxStats();
+            Assert.Equal(2, s2.PrepareTotal);
+            Assert.Equal(1, s2.CommittedTotal);
+            Assert.Equal(1, s2.RolledBackTotal);
+            Assert.Equal(0, s2.InFlightPrepared);
+        }
+        finally
+        {
+            try { File.Delete(path); File.Delete(path + ".wal"); File.Delete(path + ".recovery"); File.Delete(path + ".prepared.log"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void Stats_TrackTimedOutAbort()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"stats_{Guid.NewGuid():N}.dfdb");
+        try
+        {
+            using var db = DocumentForgeDb.Create(path);
+            var ops = new List<ShardTxOp>
+            {
+                ShardTxOp.ForInsert("orders", DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"T1"}""")),
+            };
+
+            db.PrepareTransaction("tx-timeout-stat", "self", ops, TimeSpan.FromMilliseconds(100));
+            Thread.Sleep(500);  // let the timeout fire
+
+            var stats = db.GetPreparedTxStats();
+            Assert.Equal(1, stats.PrepareTotal);
+            Assert.Equal(1, stats.TimedOutTotal);
+            Assert.Equal(0, stats.CommittedTotal);
+            Assert.Equal(0, stats.InFlightPrepared);
+        }
+        finally
+        {
+            try { File.Delete(path); File.Delete(path + ".wal"); File.Delete(path + ".recovery"); File.Delete(path + ".prepared.log"); } catch { }
+        }
+    }
+
+    [Fact]
+    public void OperatorAbort_OverHttp_FreesLock()
+    {
+        // Operator hits POST /tx/{id}/abort to force-resolve a stuck
+        // PREPARED tx. After the abort, the participant must accept new
+        // PREPAREs again.
+        var (db, _, transport, _) = BootServer();
+
+        var ops = new List<ShardTxOp>
+        {
+            ShardTxOp.ForInsert("orders", DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"STUCK"}""")),
+        };
+
+        Assert.Equal(PrepareVote.Prepared, transport.Prepare("tx-stuck", "self", ops, TimeSpan.FromSeconds(30)).Vote);
+
+        // Operator force-aborts.
+        transport.OperatorAbort("tx-stuck");
+
+        // Lock released — a new Prepare succeeds and commits.
+        Assert.Equal(PrepareVote.Prepared, transport.Prepare("tx-after-abort", "self", ops, TimeSpan.FromSeconds(30)).Vote);
+        transport.CommitPrepared("tx-after-abort");
+
+        // The aborted tx never landed; only the post-abort one did.
+        var rows = db.Execute("SELECT * FROM orders").Documents;
+        Assert.Single(rows);
+    }
+
+    [Fact]
+    public void OperatorAbort_RefusedWhenCoordinatorDecided()
+    {
+        // Safety guard: if THIS shard recorded COMMIT_DECISION for the tx
+        // (it's the coordinator and decided), refuse the abort. Aborting
+        // after a decision would diverge from what the cluster committed.
+        var (_, _, transport, _) = BootServer();
+
+        // Simulate "this shard is the coordinator and decided COMMIT" by
+        // calling RecordCoordinatorDecision directly.
+        transport.RecordCoordinatorDecision("tx-decided", commit: true);
+
+        var ex = Assert.Throws<DocumentForgeException>(() => transport.OperatorAbort("tx-decided"));
+        Assert.Contains("COMMIT_DECISION", ex.Message);
+    }
+
+    [Fact]
+    public void Stats_OverHttp_RoundTrips()
+    {
+        var (_, _, transport, _) = BootServer();
+
+        var initial = transport.GetStats();
+        Assert.Equal(0, initial.PrepareTotal);
+
+        var ops = new List<ShardTxOp>
+        {
+            ShardTxOp.ForInsert("orders", DocumentForge.Document.BsonDocument.FromJson("""{"pnr":"H-STAT"}""")),
+        };
+
+        Assert.Equal(PrepareVote.Prepared, transport.Prepare("tx-http-stat", "self", ops, TimeSpan.FromSeconds(30)).Vote);
+        transport.CommitPrepared("tx-http-stat");
+
+        var after = transport.GetStats();
+        Assert.Equal(1, after.PrepareTotal);
+        Assert.Equal(1, after.CommittedTotal);
+        Assert.Equal(0, after.InFlightPrepared);
     }
 
     private sealed class HostStopper : IDisposable


### PR DESCRIPTION
## Summary

Stacked on #54. Two pieces of production hardening:

### Operator manual-abort

\`POST /tx/{txId}/abort\` force-resolves a stuck PREPARED tx by releasing the participant's write lock and writing a RESOLVED-aborted record. **Safety guard**: refuses with 409 Conflict if this shard recorded \`COMMIT_DECISION\` for the txId (i.e. it's the coordinator and decided) — aborting after a decision would diverge from what the cluster committed.

Useful when the participant is stuck PREPARED past the timeout (or timeout is disabled) and an operator needs to free the lock manually.

### Metrics

\`PreparedTxStats\` counters on each shard, exposed via \`db.GetPreparedTxStats()\` and \`GET /tx/stats\`:

| Counter | What |
|---|---|
| \`PrepareTotal\` | Every PREPARE the participant accepted (PREPARED + ABORTED both counted) |
| \`PrepareAbortedTotal\` | Vote-ABORT on PREPARE (validation conflict, busy slot) |
| \`CommittedTotal\` | Resolved via COMMIT |
| \`RolledBackTotal\` | Resolved via ROLLBACK (coord or operator) |
| \`TimedOutTotal\` | Self-aborted via the Phase D timeout |
| \`InFlightPrepared\` | Gauge: 0 or 1 |

Incremented via \`Interlocked\` on the worker-thread transitions. \`HttpShardTransport\` gains \`OperatorAbort\` + \`GetStats\` concrete helpers (not on \`IShardTransport\` — operator-level, not routing-level).

## Race fix

\`HandleResolve\` previously fired \`cmd.Done.SetResult\` inside the try block, before the finally that decremented \`InFlightPrepared\`. With \`RunContinuationsAsynchronously\` the awaiter could resume on a different thread the instant \`SetResult\` was called and read stats before the decrement landed. Restructured to do all cleanup first, signal the caller last. (The first version of \`Stats_TrackPrepareCommitRollbackTransitions\` caught this in CI.)

## Tests

5 new (208/208 total):
- \`Stats_TrackPrepareCommitRollbackTransitions\` — direct API
- \`Stats_TrackTimedOutAbort\` — Phase D timeout counter
- \`OperatorAbort_OverHttp_FreesLock\` — abort releases the lock; new prepare succeeds
- \`OperatorAbort_RefusedWhenCoordinatorDecided\` — safety guard fires with 409
- \`Stats_OverHttp_RoundTrips\`

## Base branch

Stacked on \`feat/14-phase-e-http\` (#54). When the chain merges, GitHub auto-rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)