### PR TITLE
fix(#59): CreateIndex auto-creates the collection (parity with Insert/BulkInsert)

### DIFF
--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -886,9 +886,12 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     {
         indexName ??= $"idx_{collectionName}_{jsonPath.Replace('.', '_').Replace('[', '_').Replace("]", "")}";
 
-        var collection = _catalog.GetCollection(collectionName);
-        if (collection is null)
-            throw new CollectionNotFoundException(collectionName);
+        // Auto-create the collection if it doesn't exist yet — matches Insert /
+        // BulkInsert / BulkInsertTracked, which all go through GetOrCreateCollection.
+        // Issue #59: pre-fix CreateIndex was the odd one out, forcing the bootstrap
+        // pattern to call GetOrCreateCollection on every collection just to satisfy
+        // the index DDL that follows.
+        var collection = _catalog.GetOrCreateCollection(collectionName);
 
         var definition = new IndexDefinition
         {

--- a/tests/DocumentForge.Tests/EngineTests.cs
+++ b/tests/DocumentForge.Tests/EngineTests.cs
@@ -4687,6 +4687,37 @@ public class EngineTests : IDisposable
         }
     }
 
+    [Fact]
+    public void CreateIndex_OnFreshCollection_AutoCreates_Issue59()
+    {
+        // Issue #59: CreateIndex used to throw CollectionNotFoundException on a
+        // collection that didn't exist yet, even though Insert / BulkInsert /
+        // BulkInsertTracked all auto-create. The bootstrap-pattern caller had to
+        // remember to call GetOrCreateCollection for every collection before
+        // declaring its indexes — easy to forget, ugly when forgotten.
+        _db.CreateIndex("flights", "flightNumber", "idx_flights_number");
+
+        // Index is usable immediately and the collection is real:
+        _db.Insert("flights", """{"flightNumber":"AA123","origin":"JFK"}""");
+        _db.Insert("flights", """{"flightNumber":"AA456","origin":"LAX"}""");
+        var result = _db.Execute("SELECT * FROM flights WHERE flightNumber = 'AA123'");
+        Assert.True(result.Success);
+        Assert.Single(result.Documents);
+        Assert.Contains("INDEX_SCAN", result.QueryPlan!);
+    }
+
+    [Fact]
+    public void CreateIndex_UniqueOnFreshCollection_AutoCreates_Issue59()
+    {
+        // Same path under unique=true — the unique-validator runs against a
+        // freshly created (and therefore empty) collection, no rows to validate.
+        _db.CreateIndex("widgets", "sku", "idx_widget_sku", unique: true);
+
+        _db.Insert("widgets", """{"sku":"W-001"}""");
+        Assert.Throws<DuplicateKeyException>(() =>
+            _db.Insert("widgets", """{"sku":"W-001"}"""));
+    }
+
     public void Dispose()
     {
         // Test fixtures occasionally call _db.Dispose() themselves (e.g. lock


### PR DESCRIPTION
Closes #59.

## Summary

- `CreateIndex` was the odd one out in the engine API. `Insert` / `BulkInsert` / `BulkInsertTracked` all call `_catalog.GetOrCreateCollection(...)` internally, but `CreateIndex` demanded the collection already exist and threw `CollectionNotFoundException` otherwise.
- Bootstrap callers (declare-schema-on-every-boot pattern) had to remember to `GetOrCreateCollection` every distinct collection before iterating their index list — easy to forget, and the failure mode was "first index throws on a freshly-created database."
- One-line behavior change: `_catalog.GetCollection(...)` → `_catalog.GetOrCreateCollection(...)`. No new API surface.

`CollectionNotFoundException` stays defined in `DocumentForge.Core/Exceptions.cs` (it's public; removal would be a breaking change for downstream consumers). It just isn't thrown by `CreateIndex` anymore — there were no other throws or catches anywhere in the repo.

## Performance contract

The four hot paths called out in the cluster-tx work — single-node `Insert`, single-node `BeginTransaction.Commit`, cluster `Insert`/`Execute` (non-tx), cluster `BeginTransaction` touching exactly one shard — do not pass through `CreateIndex`. Index DDL is a startup-bootstrap path, not a hot path. No measurable impact.

## Test plan

- [x] `CreateIndex_OnFreshCollection_AutoCreates_Issue59` — basic
- [x] `CreateIndex_UniqueOnFreshCollection_AutoCreates_Issue59` — `unique: true` path
- [x] Full DocumentForge.Tests suite — 214 / 214 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)