### PR TITLE
feat(#66): multi-database hosting + cluster router (Phases 1-6b end-to-end)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,160 @@
+# DocumentForge — In-flight status
+
+Last updated: 2026-05-19 · branch `feat/66-multi-db-phase1-registry` · PR [#67](https://github.com/aerotoysio/documentforge/pull/67)
+
+This file is a pickup point — clone the repo on a different machine, `git pull`, read this, and you should know exactly where to continue.
+
+---
+
+## TL;DR
+
+Issue #66 (multi-database hosting) is feature-complete from the ground up to the cluster router. One service can host N attached DBs; Studio manages the whole lifecycle (create / drop / detach / configure replication / spawn sibling services / spawn cluster routers) visually. The cross-service topology view groups services by shard and supports drag-to-wire replication.
+
+The remaining big rocks are: a visual cluster meta-node in the topology canvas (Phase 6c), production-readiness work (lazy open, per-DB quotas, auth scopes — Phase 3b + 4), and the developer portal (#68).
+
+---
+
+## What's done (current branch, all pushed)
+
+```
+Phase 1   — DatabaseRegistry (registry of N attached engines)               ✅
+Phase 2   — /databases REST + Studio databases page                        ✅
+Phase 2.5 — Scoped /db/{name}/replication/* routes                         ✅
+Phase 2.6 — react-flow Topology page (within-service graph)                ✅
+Phase 3a  — Scoped /db/{name}/query + Studio per-tab DB picker             ✅
+Phase 5a  — Spawn child dfdb serve from Studio (ServiceManager)            ✅
+Phase 5b  — Across-services topology view (cross-connection graph)         ✅
+Phase 5c  — Shard frame grouping in topology                               ✅
+Phase 5d  — Drag-to-wire replication + drag-to-reshard                     ✅
+Phase 6   — dfdb router (stateless cluster gateway)                        ✅
+Phase 6b  — Collections tab + Spawn router from Studio (with editor)       ✅
+```
+
+Independent fix on its own branch:
+```
+fix/64-index-catalog-self-heal — PR #65 (self-heal corrupt catalog)        ✅
+```
+
+## What's queued (in priority order)
+
+| Phase | Description | Estimated effort |
+|---|---|---|
+| **6c** | Cluster meta-node in topology canvas + drag-to-claim-rings + visual config builder + export cluster.json | 1 day |
+| **3b** | Lazy open + per-DB quotas + idle eviction (for hosting 50+ DBs per process) | 1 day |
+| **4** | Bearer auth scopes (`db:foo`) + per-request DB scoping for prod multi-tenancy | 1-2 days |
+| **#68** | Developer portal (Nextra + API reference + guides) | 3-4 days |
+
+## To resume tomorrow
+
+```bash
+git clone https://github.com/aerotoysio/documentforge
+cd documentforge
+git checkout feat/66-multi-db-phase1-registry
+dotnet build
+dotnet test                                            # 280/281 (one known flaky LogicalReplication test)
+cd admin-ui && npm install                             # Studio deps
+```
+
+To run the full stack locally:
+
+```bash
+# Terminal A — host service (Studio connects here)
+dotnet src/DocumentForge.Cli/bin/Release/net9.0/dfdb.dll serve --data-dir /tmp/dfdb_dev --port 5099
+
+# Terminal B — Studio
+cd admin-ui
+NEXT_PUBLIC_DFDB_URL=http://localhost:5099 npx next dev -p 3000
+
+# Browser
+http://localhost:3000/topology     # the swarm canvas
+http://localhost:3000/connections  # add connections + spawn services/routers
+http://localhost:3000/studio       # SQL editor with per-tab DB picker
+```
+
+To spin up a router via the new endpoint:
+
+```bash
+curl -X POST -H "Content-Type: application/json" -d @- http://localhost:5099/routers <<EOF
+{
+  "name": "demo",
+  "clusterConfigJson": "{
+    \"shards\": [
+      { \"name\": \"ring-a\", \"leader\": { \"baseUrl\": \"http://localhost:5099\", \"database\": \"ring_a\" } },
+      { \"name\": \"ring-b\", \"leader\": { \"baseUrl\": \"http://localhost:5099\", \"database\": \"ring_b\" } }
+    ],
+    \"collections\": [
+      { \"name\": \"orders\", \"strategy\": \"hash\", \"shardKeyPath\": \"pnr\" },
+      { \"name\": \"lookup\", \"strategy\": \"replicated\" }
+    ]
+  }"
+}
+EOF
+```
+
+…or just hit "Spawn cluster router" on the Connections page with the "↺ Build starter config" button.
+
+---
+
+## Key files added today (Phase 5 + 6 surface)
+
+```
+src/DocumentForge.Engine/DatabaseRegistry.cs                  Registry of attached engines
+src/DocumentForge.Cli/ServiceManager.cs                       Spawn child serve + router processes
+src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs           /databases CRUD + scoped /db/{name}/*
+src/DocumentForge.Cli/Commands/ServiceEndpoints.cs            /services + /routers
+src/DocumentForge.Cli/Commands/RouterCommand.cs               dfdb router CLI verb
+src/DocumentForge.Cli/Commands/RouterEndpoints.cs             Router REST surface
+src/DocumentForge.Cli/Router/ClusterConfig.cs                 cluster.json schema
+src/DocumentForge.Cli/Router/RingClient.cs                    HTTP client per shard ring
+src/DocumentForge.Cli/Router/Router.cs                        Routing brain (hash/replicated)
+
+admin-ui/app/topology/page.tsx                                /topology with 4 tabs
+admin-ui/app/topology/db-node.tsx                             Custom DBNode react-flow renderer
+admin-ui/app/databases/page.tsx                               /databases list view
+admin-ui/app/connections/page.tsx                             /connections + spawn service/router
+admin-ui/lib/api.ts                                           Extended with multi-DB + router verbs
+admin-ui/app/Sidebar.tsx                                      Active-DB indicator + nav cleanup
+
+tests/DocumentForge.Tests/DatabaseRegistryTests.cs            28 tests
+tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs       15 tests
+tests/DocumentForge.Tests/ServiceManagerTests.cs              6 tests
+tests/DocumentForge.Tests/RouterTests.cs                      10 tests (unit)
+tests/DocumentForge.Tests/RouterIntegrationTests.cs           3 tests (full lifecycle)
+```
+
+## Architecture cheat-sheet
+
+```
+┌─── Service (one dfdb serve process, one HTTP port) ──────┐
+│  DatabaseRegistry holds N DocumentForgeDb instances      │
+│                                                            │
+│   default (DB)    alpha (DB)    beta (DB)    ...          │
+│      │              │              │                       │
+│      └──── each has own WAL, lock, page cache, indexes ──┘
+│
+│  ServiceManager spawns child dfdb processes:
+│    - dfdb serve children (more attached-DB hosts)
+│    - dfdb router children (cluster gateways)
+└────────────────────────────────────────────────────────────┘
+
+         ┌───── dfdb router (stateless) ─────┐
+         │  loads cluster.json                │   ← one URL fronts the whole cluster
+         │  routes per (collection, strategy) │
+         └──┬──────────────┬──────────────────┘
+            │              │
+       ring-a leader   ring-b leader   ...
+       (a service+DB)  (a service+DB)
+            │              │
+        followers      followers     ← logical replication, same TCP protocol
+```
+
+Rings can be backed by:
+- A specific attached DB on a multi-DB host (`baseUrl + database`)
+- A separate service's default DB (`baseUrl` only)
+- Same router config works for either — peel a ring from local-dev to prod by editing one field.
+
+## Open questions for tomorrow
+
+- **Phase 6c** scope: should the cluster meta-node SAVE state somewhere? Studio localStorage = single-user, multi-tab fine; backend persistence = needs a new endpoint. Probably localStorage for v1.
+- **Phase 6c** UX: drag a cluster onto canvas, draw lines to shard frames? Or right-click → "Assign to cluster X"? Drag is more delightful but more code.
+- **Phase 4** auth shape: `db:foo` for one DB, `db:*` for all, plus the existing `*` admin? Standard JWT-style scopes or a custom claim format?

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -86,17 +86,19 @@ export function Sidebar() {
         </Link>
       )}
 
+      {/* Consolidation pass (#66 follow-up):
+          - /swarm and /databases live on as pages but their entry point is
+            now the unified Topology page (List + Across-services tabs lift
+            their content). Old bookmarks still work.
+          - /cluster (static config wizard) and /rebalance (pure docs) are
+            destination pages, not operational views — they move to the
+            developer portal (#68) and out of the sidebar. */}
       <nav>
         <Link href="/">Dashboard</Link>
         <Link href="/studio" className="nav-headline">✦ Studio</Link>
-        <Link href="/swarm">🐝 Swarm</Link>
-        <Link href="/databases">🗃 Databases</Link>
         <Link href="/topology">⌬ Topology</Link>
         <Link href="/admin">⚙ Admin</Link>
         <Link href="/connections">⇋ Connections</Link>
-        <div className="nav-divider" />
-        <Link href="/cluster">Cluster topology</Link>
-        <Link href="/rebalance">Rebalance guide</Link>
       </nav>
 
       <div style={{

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -1,12 +1,28 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useConnections } from '@/lib/connections-context';
+import { listDatabases } from '@/lib/api';
 
 export function Sidebar() {
   const { connections, active, setActive } = useConnections();
   const [pickerOpen, setPickerOpen] = useState(false);
+
+  // Issue #66 Phase 2: peek at the active connection's database registry
+  // so the sidebar can show "you're working on DB X" alongside the
+  // connection. Best-effort — old single-DB services pre-#66 will 404 on
+  // /databases and we just hide the indicator.
+  const [defaultDb, setDefaultDb] = useState<string | null>(null);
+  const [dbCount, setDbCount] = useState<number | null>(null);
+  useEffect(() => {
+    if (!active) { setDefaultDb(null); setDbCount(null); return; }
+    let cancelled = false;
+    listDatabases({ connection: active })
+      .then(r => { if (!cancelled) { setDefaultDb(r.default); setDbCount(r.count); } })
+      .catch(() => { if (!cancelled) { setDefaultDb(null); setDbCount(null); } });
+    return () => { cancelled = true; };
+  }, [active?.id, active?.baseUrl]);
 
   return (
     <aside className="sidebar">
@@ -55,10 +71,26 @@ export function Sidebar() {
         )}
       </div>
 
+      {/* Issue #66 Phase 2 — active database indicator. Quietly absent
+          when the connected service predates multi-DB or returns 0 DBs. */}
+      {active && defaultDb && (
+        <Link href="/databases" className="db-indicator" title="Manage attached databases on this service">
+          <div className="db-indicator-label">DATABASE</div>
+          <div className="db-indicator-row">
+            <span className="db-indicator-dot" />
+            <span className="db-indicator-name">{defaultDb}</span>
+            {dbCount !== null && dbCount > 1 && (
+              <span className="db-indicator-count">+{dbCount - 1}</span>
+            )}
+          </div>
+        </Link>
+      )}
+
       <nav>
         <Link href="/">Dashboard</Link>
         <Link href="/studio" className="nav-headline">✦ Studio</Link>
         <Link href="/swarm">🐝 Swarm</Link>
+        <Link href="/databases">🗃 Databases</Link>
         <Link href="/admin">⚙ Admin</Link>
         <Link href="/connections">⇋ Connections</Link>
         <div className="nav-divider" />

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -91,6 +91,7 @@ export function Sidebar() {
         <Link href="/studio" className="nav-headline">✦ Studio</Link>
         <Link href="/swarm">🐝 Swarm</Link>
         <Link href="/databases">🗃 Databases</Link>
+        <Link href="/topology">⌬ Topology</Link>
         <Link href="/admin">⚙ Admin</Link>
         <Link href="/connections">⇋ Connections</Link>
         <div className="nav-divider" />

--- a/admin-ui/app/connections/page.tsx
+++ b/admin-ui/app/connections/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useConnections } from '@/lib/connections-context';
-import { getHealth } from '@/lib/api';
+import { getHealth, listServices, spawnService, stopService, spawnRouter, listDatabases, type ManagedServiceInfo } from '@/lib/api';
 import { discoverNetwork, normalizeUrl, type DiscoveredNode, type DiscoveryResult } from '@/lib/discovery';
 import type { Connection } from '@/lib/connections';
 
@@ -13,6 +13,178 @@ export default function ConnectionsPage() {
   const [draft, setDraft] = useState<Partial<Connection>>({ name: '', baseUrl: '', apiKey: '', color: PALETTE[0] });
   const [editingId, setEditingId] = useState<string | null>(null);
   const [testing, setTesting] = useState<Record<string, { ok?: boolean; msg?: string; pinging?: boolean }>>({});
+
+  // Issue #66 Phase 5 — spawn-local-service state.
+  const [spawnName, setSpawnName] = useState('');
+  const [spawnPort, setSpawnPort] = useState('');
+  const [spawnDataDir, setSpawnDataDir] = useState('');
+  // Shard membership for the new Connection. Backend ignores it — it's
+  // purely a Studio-side grouping label that the Across-services view
+  // uses to draw shard frames.
+  const [spawnShard, setSpawnShard] = useState('');
+  const [spawning, setSpawning] = useState(false);
+  const [spawnError, setSpawnError] = useState<string | null>(null);
+  const [managedServices, setManagedServices] = useState<ManagedServiceInfo[]>([]);
+
+  // Poll the active host's managed children so the user can see what was
+  // spawned through this Studio session. Silent on services that predate
+  // Phase 5 — feature is purely additive.
+  useEffect(() => {
+    if (!active) { setManagedServices([]); return; }
+    let cancelled = false;
+    async function refresh() {
+      try {
+        const r = await listServices({ connection: active ?? undefined });
+        if (!cancelled) setManagedServices(r.services);
+      } catch {
+        if (!cancelled) setManagedServices([]);  // pre-#66 service or transient
+      }
+    }
+    refresh();
+    const id = window.setInterval(refresh, 4000);
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, [active?.id, active?.baseUrl]);
+
+  async function handleSpawn(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!active) {
+      setSpawnError('Pick an active connection first — that service hosts the spawned children.');
+      return;
+    }
+    setSpawnError(null);
+    setSpawning(true);
+    try {
+      const port = spawnPort.trim() ? parseInt(spawnPort.trim(), 10) : undefined;
+      const result = await spawnService({
+        connection: active,
+        nodeName: spawnName.trim() || undefined,
+        port,
+        dataDir: spawnDataDir.trim() || undefined,
+      });
+      // Auto-register the new service as a Connection so it's immediately
+      // usable. Inherit the host's API key — children spawned by the host
+      // run unauthenticated by default (dev mode). The optional shard tag
+      // lands the new connection in the right shard frame on the
+      // Across-services topology view.
+      add({
+        name: result.nodeName || `spawned-:${result.port}`,
+        baseUrl: result.baseUrl,
+        apiKey: undefined,
+        color: PALETTE[(connections.length + 1) % PALETTE.length],
+        tags: ['spawned', `parent:${active.baseUrl}`],
+        shard: spawnShard.trim() || undefined,
+      });
+      setSpawnName(''); setSpawnPort(''); setSpawnDataDir(''); setSpawnShard('');
+      // Refresh the managed-services list.
+      try {
+        const r = await listServices({ connection: active });
+        setManagedServices(r.services);
+      } catch { /* ignore */ }
+    } catch (e: any) {
+      setSpawnError(e.message || String(e));
+    } finally {
+      setSpawning(false);
+    }
+  }
+
+  // ---- Phase 6b — spawn-router state + handlers ----
+  const [routerJson, setRouterJson] = useState('');
+  const [routerName, setRouterName] = useState('');
+  const [routerPort, setRouterPort] = useState('');
+  const [routerSpawning, setRouterSpawning] = useState(false);
+  const [routerError, setRouterError] = useState<string | null>(null);
+
+  // Pre-populate the cluster config textarea by probing the active
+  // connection's databases. Each attached DB becomes a candidate
+  // ring leader; the operator can prune + add collections to taste
+  // before clicking Spawn. The result is a starter cluster.json
+  // that's immediately routable.
+  async function buildStarterClusterConfig() {
+    if (!active) return;
+    try {
+      const r = await listDatabases({ connection: active });
+      const shards = r.databases.map((d) => ({
+        name: `ring-${d.name}`,
+        leader: { baseUrl: active.baseUrl, database: d.name },
+      }));
+      const config = {
+        router: { name: 'studio-cluster', port: 5500 },
+        shards,
+        collections: [
+          { name: 'orders', strategy: 'hash', shardKeyPath: 'pnr' },
+          { name: 'lookup', strategy: 'replicated' },
+        ],
+      };
+      setRouterJson(JSON.stringify(config, null, 2));
+    } catch (e: any) {
+      setRouterError(`Could not probe ${active.name}: ${e.message || String(e)}`);
+    }
+  }
+
+  async function handleSpawnRouter(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!active) {
+      setRouterError('Pick an active connection — its host is what spawns the router process.');
+      return;
+    }
+    if (!routerJson.trim()) {
+      setRouterError('Paste or build a cluster.json first.');
+      return;
+    }
+    // Quick syntax check so we fail fast in the UI rather than at the
+    // backend. Backend's ClusterConfig.Validate() catches semantic issues.
+    try { JSON.parse(routerJson); }
+    catch (e: any) { setRouterError(`Invalid JSON: ${e.message}`); return; }
+
+    setRouterError(null);
+    setRouterSpawning(true);
+    try {
+      const port = routerPort.trim() ? parseInt(routerPort.trim(), 10) : undefined;
+      const result = await spawnRouter(routerJson, {
+        connection: active,
+        name: routerName.trim() || undefined,
+        port,
+      });
+      // Auto-register the router URL as a Connection so the operator
+      // can immediately point Studio at it. The router speaks the
+      // same /collections + /query surface as a service, so it Just
+      // Works as a connection target.
+      add({
+        name: result.name ?? `router-:${result.port}`,
+        baseUrl: result.baseUrl,
+        apiKey: undefined,
+        color: PALETTE[(connections.length + 1) % PALETTE.length],
+        tags: ['router', `parent:${active.baseUrl}`],
+      });
+      // Refresh managed services list.
+      try {
+        const list = await listServices({ connection: active });
+        setManagedServices(list.services);
+      } catch { /* ignore */ }
+      setRouterJson('');
+      setRouterName('');
+      setRouterPort('');
+    } catch (e: any) {
+      setRouterError(e.message || String(e));
+    } finally {
+      setRouterSpawning(false);
+    }
+  }
+
+  async function handleStopSpawned(port: number) {
+    if (!active) return;
+    if (!confirm(`Stop the spawned service on port ${port}? The data files stay on disk.`)) return;
+    try {
+      await stopService(port, { connection: active });
+      const r = await listServices({ connection: active });
+      setManagedServices(r.services);
+      // Remove its Connection too (best-effort match by baseUrl).
+      const dead = connections.find(c => c.baseUrl.endsWith(`:${port}`));
+      if (dead) remove(dead.id);
+    } catch (e: any) {
+      alert(`Could not stop :${port}: ${e.message || String(e)}`);
+    }
+  }
 
   // Discover-network panel state
   const [discoverSeedUrl, setDiscoverSeedUrl] = useState('');
@@ -134,6 +306,193 @@ export default function ConnectionsPage() {
         on Render, individual cluster shards, replication followers. Switch between them from the
         sidebar dropdown. Run swarm-wide commands from <a href="/swarm">Swarm</a>.
       </p>
+
+      {/* Issue #66 Phase 5 — spawn a child dfdb serve process on the
+          machine that's hosting the active connection. Studio auto-
+          registers the new service as a Connection. The fastest way
+          to build a local cluster for testing. */}
+      <div className="card" style={{ borderTop: '3px solid var(--red)', marginBottom: 24 }}>
+        <h3 style={{ marginTop: 0 }}>Spawn local service</h3>
+        <p style={{ fontSize: 13, color: 'var(--gray-500)', marginTop: -8 }}>
+          Start a sibling <code>dfdb serve</code> on the host that's running your active connection.
+          Studio auto-registers it here so you can immediately work against it — pair this with
+          per-DB replication on the <a href="/topology">Topology</a> page to build a local cluster.
+        </p>
+        {!active && (
+          <div style={{ padding: '10px 12px', background: 'rgba(217,4,41,0.06)', color: 'var(--red)', fontSize: 12, borderLeft: '3px solid var(--red)' }}>
+            Pick an active connection in the sidebar — its service is what spawns the children.
+          </div>
+        )}
+        {active && (
+          <>
+            <form onSubmit={handleSpawn} style={{ display: 'grid', gridTemplateColumns: '2fr 1fr 1.5fr 2fr auto', gap: 10, alignItems: 'end' }}>
+              <div>
+                <div className="key">Node name <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(optional)</span></div>
+                <input
+                  type="text"
+                  value={spawnName}
+                  onChange={e => setSpawnName(e.target.value)}
+                  placeholder="shard-a"
+                  disabled={spawning}
+                />
+              </div>
+              <div>
+                <div className="key">Port <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(blank = free)</span></div>
+                <input
+                  type="text"
+                  value={spawnPort}
+                  onChange={e => setSpawnPort(e.target.value)}
+                  placeholder="auto"
+                  disabled={spawning}
+                />
+              </div>
+              <div>
+                <div className="key">Shard <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(Studio grouping)</span></div>
+                <input
+                  type="text"
+                  value={spawnShard}
+                  onChange={e => setSpawnShard(e.target.value)}
+                  placeholder="orders"
+                  disabled={spawning}
+                />
+              </div>
+              <div>
+                <div className="key">Data dir <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(blank = under host)</span></div>
+                <input
+                  type="text"
+                  value={spawnDataDir}
+                  onChange={e => setSpawnDataDir(e.target.value)}
+                  placeholder="C:\\path\\to\\dir"
+                  disabled={spawning}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={spawning}
+                style={{ background: 'var(--red)', color: 'white', border: 'none', padding: '8px 18px', fontWeight: 700, cursor: spawning ? 'wait' : 'pointer', minHeight: 38 }}
+              >
+                {spawning ? 'Spawning…' : '⚡ Spawn'}
+              </button>
+            </form>
+            {spawnError && (
+              <div style={{ marginTop: 12, padding: '10px 12px', background: 'rgba(217,4,41,0.08)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12, borderLeft: '3px solid var(--red)' }}>
+                ✗ {spawnError}
+              </div>
+            )}
+            {managedServices.length > 0 && (
+              <div style={{ marginTop: 16, paddingTop: 12, borderTop: '1px solid var(--gray-100)' }}>
+                <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--gray-500)', fontWeight: 700, marginBottom: 8 }}>
+                  Managed by {active.name} — {managedServices.length} child{managedServices.length === 1 ? '' : 'ren'}
+                </div>
+                <div style={{ display: 'grid', gap: 6 }}>
+                  {managedServices.map(s => (
+                    <div key={s.port} style={{ display: 'grid', gridTemplateColumns: '1fr auto', alignItems: 'center', gap: 12, padding: '6px 0' }}>
+                      <div>
+                        <div style={{ fontSize: 13, fontWeight: 600 }}>
+                          {s.nodeName ?? `port-${s.port}`}
+                          <span style={{ marginLeft: 8, fontFamily: 'var(--mono)', fontSize: 11, color: s.running ? 'var(--green)' : 'var(--red)' }}>
+                            {s.running ? '● running' : `✗ exited${s.exitCode != null ? ` (${s.exitCode})` : ''}`}
+                          </span>
+                        </div>
+                        <div style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>
+                          {s.baseUrl} · {s.dataDir}
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => handleStopSpawned(s.port)}
+                        style={{ background: 'transparent', color: 'var(--red)', border: '1px solid var(--red)', padding: '4px 10px', fontSize: 11, cursor: 'pointer' }}
+                      >
+                        Stop
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Phase 6b — spawn a cluster router process. Same hosting model
+          as "Spawn local service" (the active connection's machine runs
+          the child), but the child is a `dfdb router` rather than a
+          `dfdb serve`. Studio auto-adds the router as a Connection so
+          it appears in the sidebar picker immediately. */}
+      <div className="card" style={{ borderTop: '3px solid var(--red)', marginBottom: 24 }}>
+        <h3 style={{ marginTop: 0 }}>Spawn cluster router</h3>
+        <p style={{ fontSize: 13, color: 'var(--gray-500)', marginTop: -8 }}>
+          Front an entire cluster behind one URL. Paste a <code>cluster.json</code> or hit{' '}
+          <em>Build starter config</em> to scaffold one from the databases on your active
+          connection. Studio auto-registers the new router as a Connection so you can switch
+          to it in the sidebar instantly.
+        </p>
+        {!active && (
+          <div style={{ padding: '10px 12px', background: 'rgba(217,4,41,0.06)', color: 'var(--red)', fontSize: 12, borderLeft: '3px solid var(--red)' }}>
+            Pick an active connection in the sidebar — its host is what runs the router process.
+          </div>
+        )}
+        {active && (
+          <>
+            <form onSubmit={handleSpawnRouter} style={{ display: 'grid', gap: 10 }}>
+              <div style={{ display: 'grid', gridTemplateColumns: '2fr 1fr auto auto', gap: 10, alignItems: 'end' }}>
+                <div>
+                  <div className="key">Router name <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(optional)</span></div>
+                  <input
+                    type="text"
+                    value={routerName}
+                    onChange={e => setRouterName(e.target.value)}
+                    placeholder="studio-cluster"
+                    disabled={routerSpawning}
+                  />
+                </div>
+                <div>
+                  <div className="key">Port <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(blank = free)</span></div>
+                  <input
+                    type="text"
+                    value={routerPort}
+                    onChange={e => setRouterPort(e.target.value)}
+                    placeholder="auto"
+                    disabled={routerSpawning}
+                  />
+                </div>
+                <button
+                  type="button"
+                  onClick={buildStarterClusterConfig}
+                  disabled={routerSpawning}
+                  style={{ background: 'transparent', color: 'var(--ink)', border: '1px solid var(--gray-200)', padding: '8px 14px', fontSize: 12, cursor: 'pointer', minHeight: 38 }}
+                  title="Generate a cluster.json from the databases on the active connection"
+                >
+                  ↺ Build starter config
+                </button>
+                <button
+                  type="submit"
+                  disabled={routerSpawning || !routerJson.trim()}
+                  style={{ background: 'var(--red)', color: 'white', border: 'none', padding: '8px 18px', fontWeight: 700, cursor: routerSpawning ? 'wait' : 'pointer', minHeight: 38 }}
+                >
+                  {routerSpawning ? 'Spawning…' : '⚡ Spawn router'}
+                </button>
+              </div>
+              <div>
+                <div className="key">cluster.json</div>
+                <textarea
+                  value={routerJson}
+                  onChange={e => setRouterJson(e.target.value)}
+                  disabled={routerSpawning}
+                  rows={14}
+                  spellCheck={false}
+                  placeholder={`{\n  "shards": [\n    { "name": "ring-a", "leader": { "baseUrl": "http://localhost:5099", "database": "ring_a" } },\n    { "name": "ring-b", "leader": { "baseUrl": "http://localhost:5099", "database": "ring_b" } }\n  ],\n  "collections": [\n    { "name": "orders", "strategy": "hash", "shardKeyPath": "pnr" },\n    { "name": "lookup", "strategy": "replicated" }\n  ]\n}`}
+                  style={{ width: '100%', minHeight: 240, fontFamily: 'var(--mono)', fontSize: 12, padding: 10, border: '1px solid var(--gray-200)', background: '#fafafa', resize: 'vertical' }}
+                />
+              </div>
+            </form>
+            {routerError && (
+              <div style={{ marginTop: 12, padding: '10px 12px', background: 'rgba(217,4,41,0.08)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12, borderLeft: '3px solid var(--red)' }}>
+                ✗ {routerError}
+              </div>
+            )}
+          </>
+        )}
+      </div>
 
       {/* Discover network */}
       <div className="card" style={{ borderTop: '3px solid var(--red)', marginBottom: 24 }}>

--- a/admin-ui/app/databases/page.tsx
+++ b/admin-ui/app/databases/page.tsx
@@ -1,0 +1,283 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useConnections } from '@/lib/connections-context';
+import {
+  listDatabases,
+  createDatabase,
+  deleteDatabase,
+  setDefaultDatabase,
+  type DatabaseEntry,
+} from '@/lib/api';
+
+// Issue #66 Phase 2 — "create a swarm on one box" lives here. Drop a name
+// in the input, hit Enter, and a fresh .dfdb file lands on the service.
+// The Active toggle is the per-service "I'm working on DB X" switch; until
+// auth scopes ship (Phase 4) flat /collections/* calls resolve through it.
+
+export default function DatabasesPage() {
+  const { active } = useConnections();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [databases, setDatabases] = useState<DatabaseEntry[]>([]);
+  const [defaultName, setDefaultName] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
+  const [draftPath, setDraftPath] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [dropping, setDropping] = useState<string | null>(null);
+  const [switching, setSwitching] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [pulse, setPulse] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await listDatabases();
+      setDatabases(list.databases);
+      setDefaultName(list.default);
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { refresh(); /* eslint-disable-next-line */ }, [active?.id]);
+
+  async function onCreate(e?: React.FormEvent) {
+    e?.preventDefault();
+    const name = draftName.trim();
+    if (!name) return;
+    setCreateError(null);
+    setCreating(true);
+    try {
+      await createDatabase(name, { path: draftPath.trim() || undefined });
+      setDraftName('');
+      setDraftPath('');
+      // Pulse the new row so the user sees what just landed.
+      setPulse(name);
+      setTimeout(() => setPulse(p => (p === name ? null : p)), 900);
+      await refresh();
+    } catch (e: any) {
+      setCreateError(e.message || String(e));
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function onDrop(db: DatabaseEntry, deleteFiles: boolean) {
+    const verb = deleteFiles ? 'DROP' : 'detach';
+    const msg = deleteFiles
+      ? `DROP database "${db.name}" and DELETE every on-disk file?\n\nFile: ${db.filePath}\n\nThis is irreversible.`
+      : `Detach database "${db.name}"?\n\nThe .dfdb file stays on disk — you can re-attach later.`;
+    if (!confirm(msg)) return;
+    setDropping(db.name);
+    try {
+      await deleteDatabase(db.name, { deleteFiles });
+      await refresh();
+    } catch (e: any) {
+      alert(`${verb} failed: ${e.message || String(e)}`);
+    } finally {
+      setDropping(null);
+    }
+  }
+
+  async function onActivate(db: DatabaseEntry) {
+    if (db.isDefault) return;
+    setSwitching(db.name);
+    try {
+      await setDefaultDatabase(db.name);
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not set "${db.name}" active: ${e.message || String(e)}`);
+    } finally {
+      setSwitching(null);
+    }
+  }
+
+  if (!active) {
+    return (
+      <>
+        <h1 className="page-title">Databases</h1>
+        <div className="card">
+          <p>No connection selected.</p>
+          <p>Pick one from the sidebar or <Link href="/connections">add a connection</Link> first.</p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="eyebrow">{active.name}</div>
+      <h1 className="page-title">
+        Databases
+        <span style={{ color: 'var(--gray-500)', fontSize: 18, fontWeight: 500, marginLeft: 12 }}>
+          {databases.length} attached
+        </span>
+      </h1>
+
+      {/* Create card */}
+      <div className="card" style={{ marginBottom: 24 }}>
+        <div style={{ fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--red)', fontWeight: 700, marginBottom: 10 }}>
+          + Add database
+        </div>
+        <form onSubmit={onCreate} style={{ display: 'grid', gridTemplateColumns: '1fr 2fr auto', gap: 10, alignItems: 'end' }}>
+          <div>
+            <label style={labelStyle()}>Name</label>
+            <input
+              type="text"
+              value={draftName}
+              onChange={e => setDraftName(e.target.value)}
+              placeholder="acme"
+              style={inputStyle()}
+              autoFocus
+            />
+          </div>
+          <div>
+            <label style={labelStyle()}>File path <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(optional · defaults to data dir)</span></label>
+            <input
+              type="text"
+              value={draftPath}
+              onChange={e => setDraftPath(e.target.value)}
+              placeholder="leave blank → {dataDir}/acme.dfdb"
+              style={inputStyle()}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={creating || !draftName.trim()}
+            style={primaryBtn(creating || !draftName.trim())}
+          >
+            {creating ? 'Creating…' : 'Create'}
+          </button>
+        </form>
+        <div style={{ marginTop: 8, fontSize: 12, color: 'var(--gray-500)' }}>
+          Creates the file if it doesn't exist, attaches if it does. Names: letters/digits/underscore/dash, must start with a letter, max 64 chars.
+        </div>
+        {createError && (
+          <div style={{ marginTop: 12, padding: 8, background: 'rgba(217,4,41,0.06)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12 }}>
+            ✗ {createError}
+          </div>
+        )}
+      </div>
+
+      {/* Toolbar */}
+      <div className="toolbar">
+        <button onClick={refresh} disabled={loading} style={ghostBtn()}>⟲ Refresh</button>
+        <span className="spacer" />
+        <span style={{ color: 'var(--gray-500)', fontSize: 12 }}>
+          Default → flat <code style={{ fontFamily: 'var(--mono)' }}>/collections</code> routes target the active database
+        </span>
+      </div>
+
+      {/* List */}
+      {error && (
+        <div className="card" style={{ borderLeft: '4px solid var(--red)', background: 'rgba(217,4,41,0.04)' }}>
+          <strong style={{ color: 'var(--red)' }}>Could not load databases.</strong>
+          <div style={{ fontFamily: 'var(--mono)', fontSize: 12, marginTop: 6 }}>{error}</div>
+          <div style={{ fontSize: 12, color: 'var(--gray-500)', marginTop: 6 }}>
+            Make sure the service at <code>{active.baseUrl}</code> is running a build that includes Issue #66.
+          </div>
+        </div>
+      )}
+
+      {!error && !loading && databases.length === 0 && (
+        <div className="card">
+          <p>No databases attached yet.</p>
+          <p style={{ color: 'var(--gray-500)', fontSize: 13 }}>
+            Add one above. The service hosts as many as you like — one process, N attached .dfdb files.
+          </p>
+        </div>
+      )}
+
+      {!error && databases.length > 0 && (
+        <div style={{ display: 'grid', gap: 10 }}>
+          {databases.map(db => {
+            const isDefault = db.isDefault;
+            const isDropping = dropping === db.name;
+            const isSwitching = switching === db.name;
+            const isPulsing = pulse === db.name;
+            return (
+              <div
+                key={db.name}
+                className="card"
+                style={{
+                  borderLeft: `4px solid ${isDefault ? 'var(--red)' : 'var(--gray-200)'}`,
+                  display: 'grid',
+                  gridTemplateColumns: '1fr auto',
+                  alignItems: 'center',
+                  gap: 16,
+                  background: isPulsing ? 'rgba(217,4,41,0.04)' : 'white',
+                  transition: 'background 600ms ease-out',
+                  opacity: isDropping ? 0.5 : 1,
+                }}
+              >
+                <div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                    <span style={{ fontSize: 16, fontWeight: 600 }}>{db.name}</span>
+                    {isDefault && <span className="pill red" style={{ fontSize: 10 }}>ACTIVE</span>}
+                  </div>
+                  <div style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)', marginTop: 4, wordBreak: 'break-all' }}>
+                    {db.filePath}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  {!isDefault && (
+                    <button
+                      onClick={() => onActivate(db)}
+                      disabled={isSwitching || isDropping}
+                      style={ghostBtn()}
+                      title="Make this database the target of flat /collections routes"
+                    >
+                      {isSwitching ? 'Switching…' : 'Set active'}
+                    </button>
+                  )}
+                  <button
+                    onClick={() => onDrop(db, false)}
+                    disabled={isDropping}
+                    style={ghostBtn()}
+                    title="Unregister but keep the .dfdb file on disk"
+                  >
+                    Detach
+                  </button>
+                  <button
+                    onClick={() => onDrop(db, true)}
+                    disabled={isDropping}
+                    style={dangerBtn()}
+                    title="Drop and delete every on-disk file (irreversible)"
+                  >
+                    {isDropping ? 'Dropping…' : 'Drop'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div style={{ color: 'var(--gray-500)', fontSize: 12, marginTop: 32, lineHeight: 1.6 }}>
+        💡 Tip — each attached database is a fully independent engine (own WAL, recovery log, lock file, page cache, replication followers). The registry is just a name → instance dictionary; it adds zero hot-path cost.
+      </div>
+    </>
+  );
+}
+
+// ---------- styling helpers ----------
+function labelStyle(): React.CSSProperties {
+  return { display: 'block', fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--gray-500)', marginBottom: 4, fontWeight: 700 };
+}
+function inputStyle(): React.CSSProperties {
+  return { width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid var(--gray-200)', fontFamily: 'var(--sans)', background: 'white' };
+}
+function primaryBtn(disabled: boolean): React.CSSProperties {
+  return { background: disabled ? 'var(--gray-200)' : 'var(--red)', color: 'white', border: 'none', padding: '10px 18px', fontSize: 13, fontWeight: 600, cursor: disabled ? 'not-allowed' : 'pointer', minHeight: 38 };
+}
+function ghostBtn(): React.CSSProperties {
+  return { background: 'transparent', color: 'var(--ink)', border: '1px solid var(--gray-200)', padding: '6px 12px', fontSize: 12, cursor: 'pointer' };
+}
+function dangerBtn(): React.CSSProperties {
+  return { background: 'transparent', color: 'var(--red)', border: '1px solid var(--red)', padding: '6px 12px', fontSize: 12, fontWeight: 600, cursor: 'pointer' };
+}

--- a/admin-ui/app/globals.css
+++ b/admin-ui/app/globals.css
@@ -168,6 +168,47 @@ textarea:focus, input:focus { outline: none; border-color: var(--red); }
   letter-spacing: 0.02em;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+/* Issue #66 Phase 2: active-database indicator below the connection picker. */
+.db-indicator {
+  display: block;
+  margin: 0 12px 16px;
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.04);
+  border-left: 2px solid var(--red);
+  text-decoration: none;
+  color: inherit;
+  transition: background 120ms ease;
+}
+.db-indicator:hover { background: rgba(255,255,255,0.08); }
+.db-indicator-label {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  color: rgba(255,255,255,0.4);
+  margin-bottom: 4px;
+}
+.db-indicator-row { display: flex; align-items: center; gap: 8px; }
+.db-indicator-dot {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--red);
+}
+.db-indicator-name {
+  flex: 1;
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255,255,255,0.92);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.db-indicator-count {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: rgba(255,255,255,0.45);
+  background: rgba(255,255,255,0.06);
+  padding: 1px 6px;
+  border-radius: 8px;
+}
 .conn-picker-menu {
   position: absolute;
   left: 12px; right: 12px; top: 100%;

--- a/admin-ui/app/globals.css
+++ b/admin-ui/app/globals.css
@@ -181,6 +181,33 @@ textarea:focus, input:focus { outline: none; border-color: var(--red); }
   flex-shrink: 0;
   gap: 16px;
 }
+/* Tab strip for switching between Graph / List / Across-services views.
+   Matches the Studio aesthetic — flat, mono labels, red accent on active. */
+.topology-tabs {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--gray-200);
+  margin-bottom: 16px;
+  gap: 0;
+}
+.topology-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--gray-500);
+  cursor: pointer;
+  font-family: var(--sans);
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.topology-tab:hover { color: var(--ink); }
+.topology-tab.active {
+  color: var(--red);
+  border-bottom-color: var(--red);
+}
+.topology-tab-spacer { flex: 1; }
 /* Stage takes the remaining viewport below main's top padding + header.
    Reactflow needs an explicit pixel height — flex won't propagate down
    through its inner divs. */

--- a/admin-ui/app/globals.css
+++ b/admin-ui/app/globals.css
@@ -168,6 +168,109 @@ textarea:focus, input:focus { outline: none; border-color: var(--red); }
   letter-spacing: 0.02em;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
+/* Issue #66 Phase 2.6: topology page layout. */
+.topology-page {
+  display: flex;
+  flex-direction: column;
+}
+.topology-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+  gap: 16px;
+}
+/* Stage takes the remaining viewport below main's top padding + header.
+   Reactflow needs an explicit pixel height — flex won't propagate down
+   through its inner divs. */
+.topology-stage {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 16px;
+  height: calc(100vh - 200px);
+  min-height: 500px;
+}
+.topology-stage.no-side {
+  grid-template-columns: 1fr;
+}
+.topology-canvas {
+  position: relative;
+  background: white;
+  border: 1px solid var(--gray-200);
+  overflow: hidden;
+}
+.topology-canvas .react-flow__attribution { display: none; }
+.topology-canvas .react-flow__controls button { border-radius: 0; }
+.topology-side {
+  background: white;
+  border: 1px solid var(--gray-200);
+  padding: 18px;
+  overflow-y: auto;
+}
+.topology-side-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--gray-200);
+}
+.topology-side-section { margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--gray-100); }
+.topology-side-section-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--red);
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+.topology-legend {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(255,255,255,0.95);
+  border: 1px solid var(--gray-200);
+  padding: 8px 10px;
+  z-index: 5;
+  font-size: 10px;
+}
+.topology-legend-row { display: flex; align-items: center; gap: 4px; margin-bottom: 4px; }
+.topology-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.topology-modal {
+  background: white;
+  border: 1px solid var(--gray-200);
+  padding: 24px;
+  min-width: 440px;
+  box-shadow: 0 16px 40px rgba(0,0,0,0.2);
+}
+/* Make react-flow's own UI feel native to the rest of Studio. */
+.react-flow__controls {
+  box-shadow: none;
+  border: 1px solid var(--gray-200);
+  background: white;
+}
+.react-flow__minimap {
+  border: 1px solid var(--gray-200);
+  background: white !important;
+}
+.react-flow__edge.animated path {
+  stroke-dasharray: 6 4;
+  animation: dashdraw 0.6s linear infinite;
+}
+@keyframes dashdraw {
+  to { stroke-dashoffset: -10; }
+}
+
 /* Issue #66 Phase 2: active-database indicator below the connection picker. */
 .db-indicator {
   display: block;

--- a/admin-ui/app/studio/tabs/QueryTab.tsx
+++ b/admin-ui/app/studio/tabs/QueryTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { query as runQuery } from '@/lib/api';
+import { query as runQuery, listDatabases } from '@/lib/api';
 import type { Connection } from '@/lib/connections';
 import type { TabContext } from '../studio-types';
 
@@ -12,6 +12,36 @@ export function QueryTab({ tab, ctx, connection }: { tab: any; ctx: TabContext; 
   const [result, setResult] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
+
+  // Issue #66 Phase 3a — per-tab DB picker. Empty string = "use the
+  // service's default DB" (the back-compat flat /query route). Anything
+  // else routes through /db/{name}/query so each Studio tab can target
+  // a different attached database without flipping the service default.
+  const [availableDbs, setAvailableDbs] = useState<string[]>([]);
+  const [defaultDb, setDefaultDb] = useState<string | null>(null);
+  const [selectedDb, setSelectedDb] = useState<string>('');
+  const [dbsAvailable, setDbsAvailable] = useState(false);
+
+  useEffect(() => {
+    if (!connection) { setAvailableDbs([]); setDefaultDb(null); setDbsAvailable(false); return; }
+    let cancelled = false;
+    listDatabases({ connection })
+      .then(r => {
+        if (cancelled) return;
+        setAvailableDbs(r.databases.map(d => d.name));
+        setDefaultDb(r.default);
+        setDbsAvailable(true);
+      })
+      .catch(() => {
+        // Service predates multi-DB or is unreachable. Hide the picker;
+        // the tab silently uses the flat /query route as before.
+        if (cancelled) return;
+        setAvailableDbs([]);
+        setDefaultDb(null);
+        setDbsAvailable(false);
+      });
+    return () => { cancelled = true; };
+  }, [connection?.id, connection?.baseUrl]);
 
   // Resizable SQL/results split — value stored in pixels, persisted globally
   // (all QueryTabs share the same default split so muscle memory holds across tabs).
@@ -54,7 +84,7 @@ export function QueryTab({ tab, ctx, connection }: { tab: any; ctx: TabContext; 
     setRunning(true);
     setError(null);
     try {
-      const r = await runQuery(sql, { connection });
+      const r = await runQuery(sql, { connection, database: selectedDb || undefined });
       setResult(r);
       ctx.setStatus({
         plan: r.plan,
@@ -109,9 +139,34 @@ export function QueryTab({ tab, ctx, connection }: { tab: any; ctx: TabContext; 
           <button className="run-btn" onClick={execute} disabled={running}>
             {running ? 'Running…' : '▶  Run  (Ctrl+Enter)'}
           </button>
+          {dbsAvailable && availableDbs.length > 0 && (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, marginLeft: 10 }}>
+              <span style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--gray-500)', fontWeight: 700 }}>
+                DB
+              </span>
+              <select
+                value={selectedDb}
+                onChange={e => setSelectedDb(e.target.value)}
+                title="Target database for this query. Empty = use the service's default DB."
+                style={{ padding: '3px 6px', fontSize: 12, border: '1px solid var(--gray-200)', background: 'white', fontFamily: 'var(--mono)' }}
+              >
+                <option value="">
+                  (default{defaultDb ? `: ${defaultDb}` : ''})
+                </option>
+                {availableDbs.map(name => (
+                  <option key={name} value={name}>{name}</option>
+                ))}
+              </select>
+            </span>
+          )}
           {result?.plan && (
             <span className="plan">
               {result.plan} · {result.executionTimeMs?.toFixed(2)}ms · {result.count ?? 0} row{result.count === 1 ? '' : 's'}
+              {result.database && (
+                <span style={{ marginLeft: 6, fontFamily: 'var(--mono)', color: 'var(--red)', fontWeight: 600 }}>
+                  · {result.database}
+                </span>
+              )}
             </span>
           )}
         </div>

--- a/admin-ui/app/topology/db-node.tsx
+++ b/admin-ui/app/topology/db-node.tsx
@@ -1,0 +1,86 @@
+// Custom react-flow node renderer for an attached DocumentForge database.
+// Carries enough state to render role-coloured chrome, follower count,
+// active-default indicator, and the read-only badge when the engine has
+// flipped a follower into replica-mode.
+
+import { Handle, Position, type NodeProps, type Node } from '@xyflow/react';
+
+export interface DBNodeData extends Record<string, unknown> {
+  name: string;
+  filePath: string;
+  isDefault: boolean;
+  role: 'leader' | 'follower' | 'none' | 'unknown';
+  leaderPort: number | null;
+  followerCount: number;
+  followerLeaderEndpoint: string | null;
+  readOnly: boolean;
+}
+
+export function DBNode({ data, selected }: NodeProps<Node<DBNodeData>>) {
+  const accent = data.role === 'leader' ? 'var(--red)'
+    : data.role === 'follower' ? '#3b82f6'
+    : 'var(--gray-200)';
+
+  return (
+    <div style={{
+      background: 'white',
+      border: `1px solid ${selected ? 'var(--red)' : 'var(--gray-200)'}`,
+      borderLeft: `4px solid ${accent}`,
+      outline: selected ? '2px solid rgba(217,4,41,0.18)' : 'none',
+      outlineOffset: 1,
+      borderRadius: 2,
+      padding: '10px 14px',
+      minWidth: 180,
+      boxShadow: selected ? '0 4px 12px rgba(0,0,0,0.08)' : '0 1px 2px rgba(0,0,0,0.04)',
+      fontFamily: 'var(--sans)',
+      cursor: 'grab',
+    }}>
+      {/* Handles for incoming/outgoing edges. Source-on-bottom + target-on-top
+          works for the natural "leader sits above followers" layout. */}
+      <Handle type="target" position={Position.Top} style={{ background: accent, width: 6, height: 6, border: 'none' }} />
+      <Handle type="source" position={Position.Bottom} style={{ background: accent, width: 6, height: 6, border: 'none' }} />
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ fontWeight: 600, fontSize: 13, flex: 1 }}>{data.name}</span>
+        {data.isDefault && (
+          <span className="pill red" style={{ fontSize: 9, padding: '1px 6px' }}>ACTIVE</span>
+        )}
+      </div>
+
+      <div style={{ marginTop: 4, display: 'flex', alignItems: 'center', gap: 4 }}>
+        {data.role === 'leader' && (
+          <>
+            <span className="pill red" style={{ fontSize: 9, padding: '1px 6px' }}>LEADER</span>
+            {data.leaderPort != null && (
+              <span style={{ fontFamily: 'var(--mono)', fontSize: 9, color: 'var(--gray-500)' }}>:{data.leaderPort}</span>
+            )}
+          </>
+        )}
+        {data.role === 'follower' && (
+          <span className="pill" style={{ background: '#dbeafe', color: '#1d4ed8', fontSize: 9, padding: '1px 6px' }}>FOLLOWER</span>
+        )}
+        {data.role === 'none' && (
+          <span className="pill gray" style={{ fontSize: 9, padding: '1px 6px' }}>STANDALONE</span>
+        )}
+        {data.role === 'unknown' && (
+          <span className="pill gray" style={{ fontSize: 9, padding: '1px 6px', color: 'var(--gray-500)' }}>—</span>
+        )}
+        {data.readOnly && (
+          <span className="pill red" style={{ fontSize: 9, padding: '1px 6px' }}>RO</span>
+        )}
+      </div>
+
+      {/* Tiny stats footer — keep it sparse, the details panel has the rest. */}
+      {data.role === 'leader' && data.followerCount > 0 && (
+        <div style={{ marginTop: 6, fontSize: 10, color: 'var(--gray-500)', fontFamily: 'var(--mono)' }}>
+          {data.followerCount} follower{data.followerCount === 1 ? '' : 's'}
+        </div>
+      )}
+      {data.role === 'follower' && data.followerLeaderEndpoint && (
+        <div style={{ marginTop: 6, fontSize: 10, color: 'var(--gray-500)', fontFamily: 'var(--mono)' }}>
+          ← {data.followerLeaderEndpoint}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/app/topology/page.tsx
+++ b/admin-ui/app/topology/page.tsx
@@ -1,0 +1,694 @@
+'use client';
+
+// Issue #66 Phase 2.6 — Studio Topology page.
+//
+// One react-flow canvas per active connection. Every attached database on
+// that service shows up as a node; replication relationships render as
+// directed edges. "+ Add database" creates a new local DB (POST /databases);
+// "Set leader on port…" / "Follow this DB" wire up replication via the
+// scoped Phase 2.5 endpoints. The whole topology is queryable, configurable,
+// and re-arrangeable from this one page.
+//
+// React Flow gives us the canvas primitives; everything else (data flow,
+// edge derivation, node positioning persistence) is hand-rolled to match
+// the engine's actual data model — not a generic graph.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+  ReactFlowProvider,
+  type Node,
+  type Edge,
+  type NodeChange,
+  applyNodeChanges,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useConnections } from '@/lib/connections-context';
+import {
+  listDatabases,
+  createDatabase,
+  deleteDatabase,
+  setDefaultDatabase,
+  getDbReplicationStatus,
+  startDbAsLeader,
+  startDbAsFollower,
+  type DatabaseEntry,
+  type PerDbReplicationStatus,
+} from '@/lib/api';
+import { DBNode, type DBNodeData } from './db-node';
+
+const POSITIONS_KEY = 'dfdb_topology_positions';
+
+interface SnapshotEntry {
+  db: DatabaseEntry;
+  status: PerDbReplicationStatus | null;
+}
+
+interface SelectedDbInfo {
+  name: string;
+  status: PerDbReplicationStatus | null;
+  isDefault: boolean;
+  filePath: string;
+}
+
+export default function TopologyPage() {
+  return (
+    <ReactFlowProvider>
+      <TopologyInner />
+    </ReactFlowProvider>
+  );
+}
+
+function TopologyInner() {
+  const { active } = useConnections();
+  const [nodes, setNodes] = useNodesState<Node<DBNodeData>>([]);
+  const [edges, setEdges] = useEdgesState<Edge>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [snapshot, setSnapshot] = useState<SnapshotEntry[]>([]);
+  const [selectedDb, setSelectedDb] = useState<string | null>(null);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [actionBusy, setActionBusy] = useState(false);
+
+  // Keep a ref to the latest snapshot for handlers that capture stale state.
+  const snapshotRef = useRef<SnapshotEntry[]>([]);
+  useEffect(() => { snapshotRef.current = snapshot; }, [snapshot]);
+
+  const nodeTypes = useMemo(() => ({ database: DBNode }), []);
+
+  const refresh = useCallback(async () => {
+    if (!active) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await listDatabases({ connection: active });
+      // Per-DB replication status — fan out, tolerate per-DB failures.
+      const statuses = await Promise.all(list.databases.map(async db => {
+        try {
+          return await getDbReplicationStatus(db.name, { connection: active });
+        } catch { return null; }
+      }));
+      const snap: SnapshotEntry[] = list.databases.map((db, i) => ({
+        db, status: statuses[i],
+      }));
+      setSnapshot(snap);
+      setNodes(buildNodes(snap));
+      setEdges(buildEdges(snap));
+    } catch (e: any) {
+      setError(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [active, setNodes, setEdges]);
+
+  useEffect(() => { refresh(); /* eslint-disable-next-line */ }, [active?.id]);
+
+  // Persist drag positions so a refresh doesn't rearrange the user's layout.
+  const onNodesChange = useCallback((changes: NodeChange<Node<DBNodeData>>[]) => {
+    setNodes((nds) => {
+      const next = applyNodeChanges(changes, nds);
+      // Save positions whenever a drag completes (not every intermediate tick).
+      if (changes.some(c => c.type === 'position' && (c as any).dragging === false)) {
+        savePositions(next);
+      }
+      return next;
+    });
+  }, [setNodes]);
+
+  const onNodeClick = useCallback((_e: React.MouseEvent, node: Node) => {
+    setSelectedDb(node.id);
+  }, []);
+
+  const selected: SelectedDbInfo | null = useMemo(() => {
+    if (!selectedDb) return null;
+    const entry = snapshot.find(s => s.db.name === selectedDb);
+    if (!entry) return null;
+    return {
+      name: entry.db.name,
+      filePath: entry.db.filePath,
+      isDefault: entry.db.isDefault,
+      status: entry.status,
+    };
+  }, [selectedDb, snapshot]);
+
+  // ---- Action handlers ----
+
+  async function handleAddDatabase(name: string, path: string) {
+    setActionBusy(true);
+    try {
+      await createDatabase(name, { path: path || undefined, connection: active ?? undefined });
+      setShowAddModal(false);
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not create: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  async function handleStartLeader(port: number) {
+    if (!selectedDb) return;
+    setActionBusy(true);
+    try {
+      await startDbAsLeader(selectedDb, port, { connection: active ?? undefined });
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not start leader: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  async function handleFollowLeader(leaderName: string) {
+    if (!selectedDb) return;
+    const leaderEntry = snapshot.find(s => s.db.name === leaderName);
+    const leaderPort = leaderEntry?.status?.leader?.port;
+    if (!leaderPort) {
+      alert(`Database "${leaderName}" isn't currently a leader. Start it as leader first.`);
+      return;
+    }
+    setActionBusy(true);
+    try {
+      // Same-service replication uses loopback. Cross-service follow would
+      // pass a different host; that UI lands when we add the "External
+      // attach" branch in the Add Database modal.
+      await startDbAsFollower(selectedDb, 'localhost', leaderPort, { connection: active ?? undefined });
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not follow: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  async function handleMakeActive() {
+    if (!selectedDb) return;
+    setActionBusy(true);
+    try {
+      await setDefaultDatabase(selectedDb, { connection: active ?? undefined });
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not set active: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  async function handleDrop(deleteFiles: boolean) {
+    if (!selectedDb) return;
+    const verb = deleteFiles ? 'DROP' : 'detach';
+    const msg = deleteFiles
+      ? `DROP "${selectedDb}" and delete files? This is irreversible.`
+      : `Detach "${selectedDb}"? The .dfdb file stays on disk.`;
+    if (!confirm(msg)) return;
+    setActionBusy(true);
+    try {
+      await deleteDatabase(selectedDb, { deleteFiles, connection: active ?? undefined });
+      setSelectedDb(null);
+      await refresh();
+    } catch (e: any) {
+      alert(`${verb} failed: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  // ---- Render ----
+
+  if (!active) {
+    return (
+      <div style={{ padding: 24 }}>
+        <h1 className="page-title">Topology</h1>
+        <div className="card">
+          <p>No connection selected. Pick one in the sidebar.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="topology-page">
+      {/* Header */}
+      <div className="topology-header">
+        <div>
+          <div className="eyebrow">{active.name}</div>
+          <h1 className="page-title" style={{ margin: 0 }}>
+            Topology
+            <span style={{ color: 'var(--gray-500)', fontSize: 14, fontWeight: 500, marginLeft: 10 }}>
+              {snapshot.length} database{snapshot.length === 1 ? '' : 's'}
+              {snapshot.filter(s => s.status?.role === 'leader').length > 0 && (
+                <span style={{ marginLeft: 8 }}>
+                  · {snapshot.filter(s => s.status?.role === 'leader').length} leader
+                  {snapshot.filter(s => s.status?.role === 'leader').length === 1 ? '' : 's'}
+                </span>
+              )}
+              {snapshot.filter(s => s.status?.role === 'follower').length > 0 && (
+                <span style={{ marginLeft: 8 }}>
+                  · {snapshot.filter(s => s.status?.role === 'follower').length} follower
+                  {snapshot.filter(s => s.status?.role === 'follower').length === 1 ? '' : 's'}
+                </span>
+              )}
+            </span>
+          </h1>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={refresh} disabled={loading} style={ghostBtn()}>⟲ Refresh</button>
+          <button onClick={() => relayout(snapshot, setNodes)} style={ghostBtn()} title="Re-run auto-layout (resets node positions)">⤢ Auto-layout</button>
+          <button onClick={() => setShowAddModal(true)} style={primaryBtn()}>+ Add Database</button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="card" style={{ borderLeft: '4px solid var(--red)', background: 'rgba(217,4,41,0.04)', margin: '0 0 16px' }}>
+          <strong style={{ color: 'var(--red)' }}>Could not load topology.</strong>
+          <div style={{ fontFamily: 'var(--mono)', fontSize: 12, marginTop: 6 }}>{error}</div>
+          <div style={{ fontSize: 12, color: 'var(--gray-500)', marginTop: 6 }}>
+            The connected service may predate Issue #66 — Topology needs a build that includes /databases and /db/{'{name}'}/replication routes.
+          </div>
+        </div>
+      )}
+
+      {/* Canvas + side panel layout */}
+      <div className={`topology-stage ${selected ? '' : 'no-side'}`}>
+        <div className="topology-canvas">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            onNodesChange={onNodesChange}
+            onNodeClick={onNodeClick}
+            onPaneClick={() => setSelectedDb(null)}
+            fitView
+            proOptions={{ hideAttribution: true }}
+            defaultEdgeOptions={{
+              animated: true,
+              style: { stroke: 'var(--red)', strokeWidth: 2 },
+            }}
+          >
+            <Background gap={20} size={1} color="#e6e6e6" />
+            <Controls showInteractive={false} />
+            <MiniMap nodeColor={n => {
+              const role = (n.data as DBNodeData)?.role;
+              if (role === 'leader') return '#d90429';
+              if (role === 'follower') return '#3b82f6';
+              return '#a3a3a3';
+            }} />
+          </ReactFlow>
+
+          <Legend />
+        </div>
+
+        {selected && (
+          <SidePanel
+            info={selected}
+            availableLeaders={snapshot.filter(s =>
+              s.db.name !== selected.name && s.status?.role === 'leader',
+            )}
+            busy={actionBusy}
+            onClose={() => setSelectedDb(null)}
+            onStartLeader={handleStartLeader}
+            onFollow={handleFollowLeader}
+            onMakeActive={handleMakeActive}
+            onDrop={handleDrop}
+          />
+        )}
+      </div>
+
+      {showAddModal && (
+        <AddDatabaseModal
+          busy={actionBusy}
+          onCancel={() => setShowAddModal(false)}
+          onSubmit={handleAddDatabase}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- nodes/edges
+
+function buildNodes(snapshot: SnapshotEntry[]): Node<DBNodeData>[] {
+  const positions = loadPositions();
+  return snapshot.map((entry, i) => {
+    const id = entry.db.name;
+    const saved = positions[id];
+    const auto = autoPosition(entry, i, snapshot);
+    return {
+      id,
+      type: 'database',
+      position: saved ?? auto,
+      data: {
+        name: entry.db.name,
+        filePath: entry.db.filePath,
+        isDefault: entry.db.isDefault,
+        role: entry.status?.role ?? 'unknown',
+        leaderPort: entry.status?.leader?.port ?? null,
+        followerCount: entry.status?.leader?.followerCount ?? 0,
+        followerLeaderEndpoint: entry.status?.follower?.leader?.endpoint ?? null,
+        readOnly: entry.status?.readOnly ?? false,
+      },
+    };
+  });
+}
+
+function buildEdges(snapshot: SnapshotEntry[]): Edge[] {
+  // Index leaders by their listening port so followers can resolve which
+  // attached DB is feeding them.
+  const leaderByPort = new Map<number, string>();
+  for (const e of snapshot) {
+    if (e.status?.role === 'leader' && e.status.leader.port != null) {
+      leaderByPort.set(e.status.leader.port, e.db.name);
+    }
+  }
+
+  const edges: Edge[] = [];
+  for (const e of snapshot) {
+    if (e.status?.role !== 'follower') continue;
+    const leaderEndpoint = e.status.follower.leader?.endpoint;
+    if (!leaderEndpoint) continue;
+    const port = parsePort(leaderEndpoint);
+    if (port == null) continue;
+    const leaderName = leaderByPort.get(port);
+    if (!leaderName) continue; // leader lives outside this service
+    edges.push({
+      id: `rep:${leaderName}->${e.db.name}`,
+      source: leaderName,
+      target: e.db.name,
+      label: `rep :${port}`,
+      labelStyle: { fontFamily: 'var(--mono)', fontSize: 10, fill: '#6c757d' },
+      labelBgStyle: { fill: 'white' },
+      labelBgPadding: [4, 2],
+      type: 'smoothstep',
+    });
+  }
+  return edges;
+}
+
+function parsePort(endpoint: string): number | null {
+  const m = endpoint.match(/:(\d+)$/);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return isFinite(n) ? n : null;
+}
+
+// Layered auto-layout: standalones top row, leaders middle row, followers
+// below their leader. Quick and deterministic — dagre would be overkill
+// for the ~50 DB ceiling we're targeting.
+function autoPosition(
+  entry: SnapshotEntry,
+  i: number,
+  all: SnapshotEntry[],
+): { x: number; y: number } {
+  const role = entry.status?.role ?? 'unknown';
+  const colWidth = 240;
+  const rowHeight = 160;
+  // Row strategy:
+  //  - role=leader → middle row (y=200)
+  //  - role=follower → below its leader (y=400) — column-aligned with leader if possible
+  //  - role=none/standalone → top row (y=40)
+  if (role === 'leader') {
+    const leaderIdx = all.filter(e => e.status?.role === 'leader').indexOf(entry);
+    return { x: 60 + leaderIdx * colWidth, y: 200 };
+  }
+  if (role === 'follower') {
+    // Column-align with leader if we can identify it.
+    const port = parsePort(entry.status?.follower.leader?.endpoint ?? '');
+    if (port != null) {
+      const leaderEntry = all.find(e => e.status?.role === 'leader' && e.status.leader.port === port);
+      if (leaderEntry) {
+        const leaderIdx = all.filter(e => e.status?.role === 'leader').indexOf(leaderEntry);
+        const sameLeaderFollowers = all.filter(e =>
+          e.status?.role === 'follower' &&
+          parsePort(e.status.follower.leader?.endpoint ?? '') === port,
+        );
+        const followerIdx = sameLeaderFollowers.indexOf(entry);
+        return {
+          x: 60 + leaderIdx * colWidth + (followerIdx - (sameLeaderFollowers.length - 1) / 2) * 100,
+          y: 200 + rowHeight,
+        };
+      }
+    }
+    // Orphan follower: bottom row, indexed by overall position.
+    return { x: 60 + i * colWidth, y: 200 + rowHeight };
+  }
+  // Standalone / unknown — top row.
+  const standaloneIdx = all.filter(e => e.status?.role !== 'leader' && e.status?.role !== 'follower').indexOf(entry);
+  return { x: 60 + standaloneIdx * colWidth, y: 40 };
+}
+
+function loadPositions(): Record<string, { x: number; y: number }> {
+  if (typeof window === 'undefined') return {};
+  try { return JSON.parse(window.localStorage.getItem(POSITIONS_KEY) ?? '{}'); }
+  catch { return {}; }
+}
+function savePositions(nodes: Node<DBNodeData>[]) {
+  if (typeof window === 'undefined') return;
+  const out: Record<string, { x: number; y: number }> = {};
+  for (const n of nodes) out[n.id] = n.position;
+  window.localStorage.setItem(POSITIONS_KEY, JSON.stringify(out));
+}
+
+function relayout(snapshot: SnapshotEntry[], setNodes: (n: Node<DBNodeData>[]) => void) {
+  if (typeof window !== 'undefined') window.localStorage.removeItem(POSITIONS_KEY);
+  setNodes(buildNodes(snapshot));
+}
+
+// ---------------------------------------------------------------- side panel
+
+interface SidePanelProps {
+  info: SelectedDbInfo;
+  availableLeaders: SnapshotEntry[];
+  busy: boolean;
+  onClose: () => void;
+  onStartLeader: (port: number) => void;
+  onFollow: (leaderName: string) => void;
+  onMakeActive: () => void;
+  onDrop: (deleteFiles: boolean) => void;
+}
+
+function SidePanel({ info, availableLeaders, busy, onClose, onStartLeader, onFollow, onMakeActive, onDrop }: SidePanelProps) {
+  const [draftPort, setDraftPort] = useState(5500);
+  const [draftLeader, setDraftLeader] = useState<string>('');
+  const role = info.status?.role ?? 'unknown';
+
+  // Suggest a port that isn't already taken by another leader on this service.
+  useEffect(() => {
+    setDraftPort(suggestPort(info.name));
+  }, [info.name]);
+
+  return (
+    <aside className="topology-side">
+      <div className="topology-side-header">
+        <div style={{ fontSize: 16, fontWeight: 600 }}>{info.name}</div>
+        <button onClick={onClose} style={iconBtn()} title="Close panel">✕</button>
+      </div>
+
+      <div className="setting-row"><span className="key">Role</span>
+        <span className="val">
+          {role === 'leader' && <span className="pill red">LEADER</span>}
+          {role === 'follower' && <span className="pill" style={{ background: '#dbeafe', color: '#1d4ed8' }}>FOLLOWER</span>}
+          {role === 'none' && <span className="pill gray">STANDALONE</span>}
+        </span>
+      </div>
+      <div className="setting-row"><span className="key">Active default</span>
+        <span className="val">{info.isDefault ? '✓ yes' : '—'}</span>
+      </div>
+      <div className="setting-row"><span className="key">File</span>
+        <span className="val" style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>{info.filePath}</span>
+      </div>
+      {role === 'leader' && (
+        <>
+          <div className="setting-row"><span className="key">Listening port</span>
+            <span className="val" style={{ fontFamily: 'var(--mono)' }}>:{info.status!.leader.port ?? '—'}</span>
+          </div>
+          <div className="setting-row"><span className="key">Followers</span>
+            <span className="val">{info.status!.leader.followerCount}</span>
+          </div>
+          <div className="setting-row"><span className="key">Current seq</span>
+            <span className="val" style={{ fontFamily: 'var(--mono)' }}>{info.status!.leader.currentSeq}</span>
+          </div>
+        </>
+      )}
+      {role === 'follower' && (
+        <>
+          <div className="setting-row"><span className="key">Following</span>
+            <span className="val" style={{ fontFamily: 'var(--mono)', fontSize: 11 }}>{info.status!.follower.leader?.endpoint ?? '—'}</span>
+          </div>
+          <div className="setting-row"><span className="key">Applied seq</span>
+            <span className="val" style={{ fontFamily: 'var(--mono)' }}>{info.status!.follower.lastAppliedSeq}</span>
+          </div>
+          <div className="setting-row"><span className="key">Ops applied</span>
+            <span className="val">{info.status!.follower.opsApplied}</span>
+          </div>
+        </>
+      )}
+
+      <div className="topology-side-section">
+        <div className="topology-side-section-label">REPLICATION</div>
+        {role === 'none' && (
+          <>
+            <div style={{ marginBottom: 8 }}>
+              <div style={{ fontSize: 11, color: 'var(--gray-500)', marginBottom: 4 }}>Make this DB a leader on TCP port:</div>
+              <div style={{ display: 'flex', gap: 6 }}>
+                <input
+                  type="number"
+                  value={draftPort}
+                  onChange={e => setDraftPort(parseInt(e.target.value) || 0)}
+                  style={{ width: 80, padding: '6px 8px', fontSize: 12, border: '1px solid var(--gray-200)', fontFamily: 'var(--mono)' }}
+                />
+                <button onClick={() => onStartLeader(draftPort)} disabled={busy || draftPort < 1024} style={primaryBtn()}>
+                  Start leader
+                </button>
+              </div>
+            </div>
+            {availableLeaders.length > 0 && (
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--gray-500)', marginBottom: 4 }}>Or follow an existing leader:</div>
+                <div style={{ display: 'flex', gap: 6 }}>
+                  <select value={draftLeader} onChange={e => setDraftLeader(e.target.value)} style={{ flex: 1, padding: '6px 8px', fontSize: 12, border: '1px solid var(--gray-200)' }}>
+                    <option value="">(pick a leader)</option>
+                    {availableLeaders.map(l => (
+                      <option key={l.db.name} value={l.db.name}>{l.db.name} :{l.status!.leader.port}</option>
+                    ))}
+                  </select>
+                  <button onClick={() => onFollow(draftLeader)} disabled={busy || !draftLeader} style={primaryBtn()}>
+                    Follow
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+        {role === 'leader' && (
+          <div style={{ fontSize: 11, color: 'var(--gray-500)' }}>
+            Already a leader on port :{info.status!.leader.port}. Add followers by selecting another DB and choosing "Follow this DB."
+          </div>
+        )}
+        {role === 'follower' && (
+          <div style={{ fontSize: 11, color: 'var(--gray-500)' }}>
+            Following {info.status!.follower.leader?.endpoint}. Read-only — writes happen at the leader.
+          </div>
+        )}
+      </div>
+
+      <div className="topology-side-section">
+        <div className="topology-side-section-label">DATABASE</div>
+        {!info.isDefault && (
+          <button onClick={onMakeActive} disabled={busy} style={{ ...ghostBtn(), width: '100%', marginBottom: 6 }}>
+            Set as active default
+          </button>
+        )}
+        <button onClick={() => onDrop(false)} disabled={busy} style={{ ...ghostBtn(), width: '100%', marginBottom: 6 }}>
+          Detach (keep file)
+        </button>
+        <button onClick={() => onDrop(true)} disabled={busy} style={{ ...dangerBtn(), width: '100%' }}>
+          Drop and delete files
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function suggestPort(seedName: string): number {
+  // Deterministic-ish: 5500 + hash(name) mod 100. Avoids collision in practice
+  // and gives a stable suggestion per DB so the form doesn't jitter.
+  let h = 0;
+  for (let i = 0; i < seedName.length; i++) h = (h * 31 + seedName.charCodeAt(i)) | 0;
+  return 5500 + (Math.abs(h) % 100);
+}
+
+// ---------------------------------------------------------------- add modal
+
+interface AddModalProps {
+  busy: boolean;
+  onCancel: () => void;
+  onSubmit: (name: string, path: string) => void;
+}
+
+function AddDatabaseModal({ busy, onCancel, onSubmit }: AddModalProps) {
+  const [name, setName] = useState('');
+  const [path, setPath] = useState('');
+  return (
+    <div className="topology-modal-backdrop" onClick={onCancel}>
+      <div className="topology-modal" onClick={e => e.stopPropagation()}>
+        <div style={{ fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--red)', fontWeight: 700, marginBottom: 12 }}>
+          + Add database
+        </div>
+        <form onSubmit={e => { e.preventDefault(); if (name.trim()) onSubmit(name.trim(), path.trim()); }}>
+          <div style={{ marginBottom: 12 }}>
+            <label style={labelStyle()}>Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder="acme"
+              autoFocus
+              style={modalInputStyle()}
+            />
+          </div>
+          <div style={{ marginBottom: 16 }}>
+            <label style={labelStyle()}>File path <span style={{ color: 'var(--gray-500)', fontWeight: 400 }}>(optional)</span></label>
+            <input
+              type="text"
+              value={path}
+              onChange={e => setPath(e.target.value)}
+              placeholder="leave blank → {dataDir}/{name}.dfdb"
+              style={modalInputStyle()}
+            />
+            <div style={{ marginTop: 6, fontSize: 11, color: 'var(--gray-500)' }}>
+              The service creates the file if it doesn't exist, attaches if it does.
+            </div>
+          </div>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+            <button type="button" onClick={onCancel} style={ghostBtn()}>Cancel</button>
+            <button type="submit" disabled={busy || !name.trim()} style={primaryBtn()}>
+              {busy ? 'Creating…' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- legend
+
+function Legend() {
+  return (
+    <div className="topology-legend">
+      <div className="topology-legend-row"><span className="pill red" style={{ fontSize: 9 }}>LEADER</span></div>
+      <div className="topology-legend-row"><span className="pill" style={{ background: '#dbeafe', color: '#1d4ed8', fontSize: 9 }}>FOLLOWER</span></div>
+      <div className="topology-legend-row"><span className="pill gray" style={{ fontSize: 9 }}>STANDALONE</span></div>
+      <div className="topology-legend-row" style={{ marginTop: 6 }}>
+        <svg width="40" height="10"><line x1="0" y1="5" x2="40" y2="5" stroke="var(--red)" strokeWidth="2" strokeDasharray="4 2" /></svg>
+        <span style={{ fontSize: 10, color: 'var(--gray-500)', marginLeft: 4 }}>replication</span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- styles
+
+function primaryBtn(): React.CSSProperties {
+  return { background: 'var(--red)', color: 'white', border: 'none', padding: '6px 14px', fontSize: 12, fontWeight: 600, cursor: 'pointer' };
+}
+function ghostBtn(): React.CSSProperties {
+  return { background: 'transparent', color: 'var(--ink)', border: '1px solid var(--gray-200)', padding: '6px 12px', fontSize: 12, cursor: 'pointer' };
+}
+function dangerBtn(): React.CSSProperties {
+  return { background: 'transparent', color: 'var(--red)', border: '1px solid var(--red)', padding: '6px 12px', fontSize: 12, fontWeight: 600, cursor: 'pointer' };
+}
+function iconBtn(): React.CSSProperties {
+  return { background: 'transparent', border: 'none', color: 'var(--gray-500)', fontSize: 18, cursor: 'pointer', padding: 0, width: 24, height: 24 };
+}
+function labelStyle(): React.CSSProperties {
+  return { display: 'block', fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--gray-500)', marginBottom: 4, fontWeight: 700 };
+}
+function modalInputStyle(): React.CSSProperties {
+  return { width: '100%', padding: '8px 10px', fontSize: 14, border: '1px solid var(--gray-200)', fontFamily: 'var(--sans)', background: 'white' };
+}

--- a/admin-ui/app/topology/page.tsx
+++ b/admin-ui/app/topology/page.tsx
@@ -25,16 +25,20 @@ import {
   type Node,
   type Edge,
   type NodeChange,
+  type Connection as ReactFlowConnection,
+  type NodeMouseHandler,
   applyNodeChanges,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import { useConnections } from '@/lib/connections-context';
+import type { Connection } from '@/lib/connections';
 import {
   listDatabases,
   createDatabase,
   deleteDatabase,
   setDefaultDatabase,
   getDbReplicationStatus,
+  listDbCollections,
   startDbAsLeader,
   startDbAsFollower,
   type DatabaseEntry,
@@ -64,8 +68,10 @@ export default function TopologyPage() {
   );
 }
 
+type TopologyView = 'graph' | 'list' | 'across' | 'collections';
+
 function TopologyInner() {
-  const { active } = useConnections();
+  const { active, connections: connectionsForAcrossView } = useConnections();
   const [nodes, setNodes] = useNodesState<Node<DBNodeData>>([]);
   const [edges, setEdges] = useEdgesState<Edge>([]);
   const [loading, setLoading] = useState(true);
@@ -74,6 +80,14 @@ function TopologyInner() {
   const [selectedDb, setSelectedDb] = useState<string | null>(null);
   const [showAddModal, setShowAddModal] = useState(false);
   const [actionBusy, setActionBusy] = useState(false);
+  // Consolidation pass: Topology is now the unified DB hub. View toggle
+  // determines which lens to show. Default to graph — the new headline view.
+  const [view, setView] = useState<TopologyView>('graph');
+
+  // Drag-to-wire state — opens a confirmation when the user drags a handle
+  // from one DB to another. Source becomes the leader, target the follower;
+  // the modal lets them tweak the port before committing.
+  const [wireDraft, setWireDraft] = useState<{ sourceName: string; targetName: string; suggestedPort: number } | null>(null);
 
   // Keep a ref to the latest snapshot for handlers that capture stale state.
   const snapshotRef = useRef<SnapshotEntry[]>([]);
@@ -242,6 +256,47 @@ function TopologyInner() {
     }
   }
 
+  // Drag-from-handle-to-handle on the Graph canvas. Source must end up
+  // leader, target must end up follower. We don't commit anything from
+  // this callback — a confirmation modal pops first so the user can
+  // sanity-check the port + the direction before any HTTP calls go out.
+  const handleGraphConnect = useCallback((params: ReactFlowConnection) => {
+    if (!params.source || !params.target || params.source === params.target) return;
+    const sourceEntry = snapshotRef.current.find(s => s.db.name === params.source);
+    const targetEntry = snapshotRef.current.find(s => s.db.name === params.target);
+    if (!sourceEntry || !targetEntry) return;
+    // If the source isn't already leading, suggest a port. Otherwise
+    // re-use the leader's current port so the modal reads as "follow
+    // the existing leader on :X" rather than "set up a new leader."
+    const suggestedPort = sourceEntry.status?.leader?.port
+      ?? suggestPortForName(sourceEntry.db.name);
+    setWireDraft({
+      sourceName: params.source,
+      targetName: params.target,
+      suggestedPort,
+    });
+  }, []);
+
+  async function handleWireConfirm(port: number) {
+    if (!wireDraft) return;
+    setActionBusy(true);
+    try {
+      const sourceEntry = snapshotRef.current.find(s => s.db.name === wireDraft.sourceName);
+      // Promote source to leader if it isn't already.
+      if (sourceEntry?.status?.role !== 'leader') {
+        await startDbAsLeader(wireDraft.sourceName, port, { connection: active ?? undefined });
+      }
+      // Always (re)wire target as follower of source on the chosen port.
+      await startDbAsFollower(wireDraft.targetName, 'localhost', port, { connection: active ?? undefined });
+      setWireDraft(null);
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not wire replication: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
   async function handleDrop(deleteFiles: boolean) {
     if (!selectedDb) return;
     const verb = deleteFiles ? 'DROP' : 'detach';
@@ -306,6 +361,37 @@ function TopologyInner() {
         </div>
       </div>
 
+      {/* View tabs — Graph is the headline; List is the table view (lifted
+          from the old /databases page); Across services hosts the future
+          sharding / multi-connection topology (Phase 5). */}
+      <div className="topology-tabs">
+        <button
+          onClick={() => setView('graph')}
+          className={`topology-tab ${view === 'graph' ? 'active' : ''}`}
+        >
+          ⌬ Graph
+        </button>
+        <button
+          onClick={() => setView('list')}
+          className={`topology-tab ${view === 'list' ? 'active' : ''}`}
+        >
+          ☰ List
+        </button>
+        <button
+          onClick={() => setView('across')}
+          className={`topology-tab ${view === 'across' ? 'active' : ''}`}
+        >
+          🐝 Across services
+        </button>
+        <button
+          onClick={() => setView('collections')}
+          className={`topology-tab ${view === 'collections' ? 'active' : ''}`}
+        >
+          📚 Collections
+        </button>
+        <span className="topology-tab-spacer" />
+      </div>
+
       {error && (
         <div className="card" style={{ borderLeft: '4px solid var(--red)', background: 'rgba(217,4,41,0.04)', margin: '0 0 16px' }}>
           <strong style={{ color: 'var(--red)' }}>Could not load topology.</strong>
@@ -316,7 +402,37 @@ function TopologyInner() {
         </div>
       )}
 
-      {/* Canvas + side panel layout */}
+      {view === 'list' && (
+        <ListView
+          snapshot={snapshot}
+          busy={actionBusy}
+          onSelect={(name) => { setView('graph'); setSelectedDb(name); }}
+          onSetActive={async (name) => {
+            setActionBusy(true);
+            try { await setDefaultDatabase(name, { connection: active ?? undefined }); await refresh(); }
+            catch (e: any) { alert(`Could not set active: ${e.message || String(e)}`); }
+            finally { setActionBusy(false); }
+          }}
+          onDrop={async (name, deleteFiles) => {
+            const verb = deleteFiles ? 'DROP' : 'detach';
+            const msg = deleteFiles
+              ? `DROP "${name}" and delete files? This is irreversible.`
+              : `Detach "${name}"? The .dfdb file stays on disk.`;
+            if (!confirm(msg)) return;
+            setActionBusy(true);
+            try { await deleteDatabase(name, { deleteFiles, connection: active ?? undefined }); await refresh(); }
+            catch (e: any) { alert(`${verb} failed: ${e.message || String(e)}`); }
+            finally { setActionBusy(false); }
+          }}
+        />
+      )}
+
+      {view === 'across' && <AcrossServicesView connections={[...connectionsForAcrossView]} />}
+
+      {view === 'collections' && <CollectionsView connections={[...connectionsForAcrossView]} />}
+
+      {view === 'graph' && (
+      /* Canvas + side panel layout */
       <div className={`topology-stage ${selected ? '' : 'no-side'}`}>
         <div className="topology-canvas">
           <ReactFlow
@@ -326,6 +442,8 @@ function TopologyInner() {
             onNodesChange={onNodesChange}
             onNodeClick={onNodeClick}
             onPaneClick={() => setSelectedDb(null)}
+            onConnect={handleGraphConnect}
+            connectionLineStyle={{ stroke: 'var(--red)', strokeWidth: 2, strokeDasharray: '6 4' }}
             fitView
             proOptions={{ hideAttribution: true }}
             defaultEdgeOptions={{
@@ -362,6 +480,7 @@ function TopologyInner() {
           />
         )}
       </div>
+      )}
 
       {showAddModal && (
         <AddDatabaseModal
@@ -370,8 +489,859 @@ function TopologyInner() {
           onSubmit={handleAddDatabase}
         />
       )}
+
+      {wireDraft && (
+        <WireReplicationModal
+          busy={actionBusy}
+          source={wireDraft.sourceName}
+          target={wireDraft.targetName}
+          suggestedPort={wireDraft.suggestedPort}
+          onCancel={() => setWireDraft(null)}
+          onConfirm={handleWireConfirm}
+        />
+      )}
     </div>
   );
+}
+
+// Same hash → stable suggested port that doesn't jitter on rerenders.
+function suggestPortForName(name: string): number {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
+  return 5500 + (Math.abs(h) % 100);
+}
+
+// Strip protocol + port from a baseUrl to get the host the follower
+// should dial. Localhost stays localhost; a public service hosted at
+// https://node-a.example.com:5000 turns into "node-a.example.com".
+function hostnameFromBaseUrl(baseUrl: string): string {
+  try { return new URL(baseUrl).hostname; }
+  catch { return baseUrl.replace(/^https?:\/\//, '').split(':')[0].split('/')[0]; }
+}
+
+interface WireModalProps {
+  busy: boolean;
+  source: string;
+  target: string;
+  suggestedPort: number;
+  onCancel: () => void;
+  onConfirm: (port: number) => void;
+}
+
+// Confirmation that pops after a handle-to-handle drag. Shows the
+// "source becomes leader" arrow, the chosen port, and a single Confirm
+// button. Click anywhere outside cancels (no accidental commits).
+function WireReplicationModal({ busy, source, target, suggestedPort, onCancel, onConfirm }: WireModalProps) {
+  const [port, setPort] = useState(suggestedPort);
+  return (
+    <div className="topology-modal-backdrop" onClick={onCancel}>
+      <div className="topology-modal" onClick={e => e.stopPropagation()}>
+        <div style={{ fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--red)', fontWeight: 700, marginBottom: 12 }}>
+          Wire replication
+        </div>
+        <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 12, fontSize: 14 }}>
+          <span style={{ padding: '6px 12px', background: 'rgba(217,4,41,0.08)', border: '1px solid var(--red)', fontWeight: 600 }}>{source}</span>
+          <span style={{ color: 'var(--gray-500)' }}>(leader)</span>
+          <span style={{ color: 'var(--red)', fontSize: 18 }}>→</span>
+          <span style={{ padding: '6px 12px', background: 'rgba(59,130,246,0.08)', border: '1px solid #3b82f6', fontWeight: 600 }}>{target}</span>
+          <span style={{ color: 'var(--gray-500)' }}>(follower)</span>
+        </div>
+        <div style={{ marginBottom: 16 }}>
+          <label style={{ display: 'block', fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--gray-500)', marginBottom: 4, fontWeight: 700 }}>
+            Replication TCP port
+          </label>
+          <input
+            type="number"
+            value={port}
+            onChange={e => setPort(parseInt(e.target.value) || 0)}
+            style={{ width: 140, padding: '8px 10px', fontSize: 14, border: '1px solid var(--gray-200)', fontFamily: 'var(--mono)' }}
+          />
+          <div style={{ marginTop: 6, fontSize: 11, color: 'var(--gray-500)' }}>
+            Source listens on this port for the follower's connection. Must be free + ≥ 1024.
+          </div>
+        </div>
+        <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+          <button type="button" onClick={onCancel} style={{ background: 'transparent', color: 'var(--ink)', border: '1px solid var(--gray-200)', padding: '6px 12px', fontSize: 12, cursor: 'pointer' }}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(port)}
+            disabled={busy || port < 1024}
+            style={{ background: 'var(--red)', color: 'white', border: 'none', padding: '8px 18px', fontSize: 12, fontWeight: 700, cursor: 'pointer' }}
+          >
+            {busy ? 'Wiring…' : 'Wire replication'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- list view
+
+interface ListViewProps {
+  snapshot: SnapshotEntry[];
+  busy: boolean;
+  onSelect: (name: string) => void;
+  onSetActive: (name: string) => void;
+  onDrop: (name: string, deleteFiles: boolean) => void;
+}
+
+// Table-style view of attached databases — lifted from the now-deprecated
+// /databases page so the consolidation lands all DB-management work in one
+// place. Each row links back to the graph view's side panel for replication
+// configuration; inline actions cover the fast common cases (set active,
+// detach, drop) without context-switching.
+function ListView({ snapshot, busy, onSelect, onSetActive, onDrop }: ListViewProps) {
+  if (snapshot.length === 0) {
+    return (
+      <div className="card">
+        <p>No databases attached yet.</p>
+        <p style={{ color: 'var(--gray-500)', fontSize: 13 }}>
+          Add one via "+ Add Database" above. The service hosts as many as you like — one process, N attached .dfdb files.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div style={{ display: 'grid', gap: 10 }}>
+      {snapshot.map(({ db, status }) => {
+        const role = status?.role ?? 'unknown';
+        const accent = role === 'leader' ? 'var(--red)'
+          : role === 'follower' ? '#3b82f6'
+          : 'var(--gray-200)';
+        return (
+          <div
+            key={db.name}
+            className="card"
+            style={{
+              borderLeft: `4px solid ${db.isDefault ? 'var(--red)' : accent}`,
+              display: 'grid',
+              gridTemplateColumns: '1fr auto',
+              alignItems: 'center',
+              gap: 16,
+            }}
+          >
+            <div onClick={() => onSelect(db.name)} style={{ cursor: 'pointer' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
+                <span style={{ fontSize: 16, fontWeight: 600 }}>{db.name}</span>
+                {db.isDefault && <span className="pill red" style={{ fontSize: 10 }}>ACTIVE</span>}
+                {role === 'leader' && (
+                  <>
+                    <span className="pill red" style={{ fontSize: 10 }}>LEADER</span>
+                    {status?.leader.port != null && (
+                      <span style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>
+                        :{status.leader.port} · {status.leader.followerCount} follower{status.leader.followerCount === 1 ? '' : 's'}
+                      </span>
+                    )}
+                  </>
+                )}
+                {role === 'follower' && (
+                  <>
+                    <span className="pill" style={{ background: '#dbeafe', color: '#1d4ed8', fontSize: 10 }}>FOLLOWER</span>
+                    {status?.follower.leader?.endpoint && (
+                      <span style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>
+                        ← {status.follower.leader.endpoint}
+                      </span>
+                    )}
+                  </>
+                )}
+                {role === 'none' && <span className="pill gray" style={{ fontSize: 10 }}>STANDALONE</span>}
+              </div>
+              <div style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)', marginTop: 4, wordBreak: 'break-all' }}>
+                {db.filePath}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 6 }}>
+              {!db.isDefault && (
+                <button onClick={() => onSetActive(db.name)} disabled={busy} style={ghostBtn()} title="Make this the default DB for flat routes">
+                  Set active
+                </button>
+              )}
+              <button onClick={() => onSelect(db.name)} disabled={busy} style={ghostBtn()} title="Open in graph view to configure replication">
+                Configure
+              </button>
+              <button onClick={() => onDrop(db.name, false)} disabled={busy} style={ghostBtn()}>
+                Detach
+              </button>
+              <button onClick={() => onDrop(db.name, true)} disabled={busy} style={dangerBtn()}>
+                Drop
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------- across-services view
+
+interface AcrossSnapshot {
+  conn: Connection;
+  databases: DatabaseEntry[];
+  statuses: (PerDbReplicationStatus | null)[];
+  error: string | null;
+}
+
+// Phase 5 — every registered Connection contributes its attached DBs to
+// one shared canvas. Cross-service replication edges connect a follower
+// DB on one service to its leader DB on another (matched by TCP port).
+// Each service gets its own column on the canvas with a labelled group
+// box so the visual story stays clear at 5+ services.
+function AcrossServicesView({ connections }: { connections: Connection[] }) {
+  const { update: updateConnection } = useConnections();
+  const [snapshots, setSnapshots] = useState<AcrossSnapshot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [nodes, setNodes] = useNodesState<Node>([]);
+  const [edges, setEdges] = useEdgesState<Edge>([]);
+
+  // Drag-to-wire (cross-service edition) — same modal as the Graph tab
+  // but the source/target may live on different services, so the wire
+  // calls fan out across two connections.
+  const [wireDraft, setWireDraft] = useState<{
+    sourceConn: Connection; sourceName: string;
+    targetConn: Connection; targetName: string;
+    suggestedPort: number;
+  } | null>(null);
+  const [wiring, setWiring] = useState(false);
+
+  const nodeTypes = useMemo(() => ({ database: DBNode }), []);
+
+  const refresh = useCallback(async () => {
+    if (connections.length === 0) { setSnapshots([]); setLoading(false); return; }
+    setLoading(true);
+    const results = await Promise.all(connections.map(async (conn): Promise<AcrossSnapshot> => {
+      try {
+        const list = await listDatabases({ connection: conn });
+        const statuses = await Promise.all(list.databases.map(db =>
+          getDbReplicationStatus(db.name, { connection: conn }).catch(() => null),
+        ));
+        return { conn, databases: list.databases, statuses, error: null };
+      } catch (e: any) {
+        return { conn, databases: [], statuses: [], error: e.message || String(e) };
+      }
+    }));
+    setSnapshots(results);
+    setLoading(false);
+  }, [connections]);
+
+  useEffect(() => { refresh(); /* eslint-disable-next-line */ }, [connections.length, connections.map(c => c.id + c.baseUrl).join('|')]);
+
+  // Auto-refresh every 5s so spawned services light up + replication
+  // edges appear without manual refresh.
+  useEffect(() => {
+    const id = window.setInterval(refresh, 5000);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  // Rebuild nodes + edges whenever snapshots change.
+  useEffect(() => {
+    if (snapshots.length === 0) { setNodes([]); setEdges([]); return; }
+    const built = buildAcrossNodesAndEdges(snapshots);
+    setNodes(built.nodes);
+    setEdges(built.edges);
+  }, [snapshots, setNodes, setEdges]);
+
+  // Drag-from-handle on a DB node to another DB node, possibly on a
+  // different service. Node IDs in this view are `db:<connId>/<dbName>`
+  // so we parse both ends, look up the matching Connection objects,
+  // and open the confirm dialog with a sensible suggested port.
+  const handleAcrossConnect = useCallback((params: ReactFlowConnection) => {
+    if (!params.source || !params.target || params.source === params.target) return;
+    if (!params.source.startsWith('db:') || !params.target.startsWith('db:')) return;
+    const [sourceConnId, sourceName] = params.source.slice('db:'.length).split('/');
+    const [targetConnId, targetName] = params.target.slice('db:'.length).split('/');
+    const sourceConn = connections.find(c => c.id === sourceConnId);
+    const targetConn = connections.find(c => c.id === targetConnId);
+    if (!sourceConn || !targetConn) return;
+    const sourceSnap = snapshots.find(s => s.conn.id === sourceConnId);
+    const sourceStatusIdx = sourceSnap?.databases.findIndex(d => d.name === sourceName) ?? -1;
+    const sourceStatus = sourceStatusIdx >= 0 ? sourceSnap?.statuses[sourceStatusIdx] : null;
+    const suggestedPort = sourceStatus?.leader?.port ?? suggestPortForName(sourceName);
+    setWireDraft({ sourceConn, sourceName, targetConn, targetName, suggestedPort });
+  }, [connections, snapshots]);
+
+  // Drag-to-reshard: when a service column is dropped inside a different
+  // shard frame, update the connection's shard tag. Studio-side only —
+  // the backend doesn't track shards. The next refresh redraws the
+  // column inside the new frame.
+  const handleNodeDragStop = useCallback<NodeMouseHandler>((_event, node) => {
+    if (!node.id.startsWith('conn:')) return;
+    const connectionId = (node.data as any).connectionId as string | undefined;
+    const previousShard = (node.data as any).currentShard as string | undefined;
+    if (!connectionId) return;
+
+    // Where did the column end up? Use the absolute centre to be tolerant
+    // of large columns straddling frame borders.
+    const colW = (node.width ?? (node.style as any)?.width ?? 280) as number;
+    const colH = (node.height ?? (node.style as any)?.height ?? 100) as number;
+    const abs = (node as any).positionAbsolute ?? node.position;
+    const cx = abs.x + colW / 2;
+    const cy = abs.y + colH / 2;
+
+    // Find a shard frame whose bounds contain the centre.
+    let targetShard: string | null = null;
+    for (const candidate of nodes) {
+      if (!candidate.id.startsWith('shard:')) continue;
+      if (candidate.id === `shard:${previousShard}`) continue;
+      const w = (candidate.style as any)?.width ?? 0;
+      const h = (candidate.style as any)?.height ?? 0;
+      const x = candidate.position.x;
+      const y = candidate.position.y;
+      if (cx >= x && cx <= x + w && cy >= y && cy <= y + h) {
+        targetShard = candidate.id.slice('shard:'.length);
+        break;
+      }
+    }
+    if (!targetShard || targetShard === previousShard) return;
+
+    // Commit the change. The next snapshot refresh will rebuild nodes
+    // with the column inside the new frame; until then we leave the
+    // user's drop position alone so the move "feels stable."
+    const newShardValue = targetShard === '__unsharded__' ? undefined : targetShard;
+    updateConnection(connectionId, { shard: newShardValue });
+    refresh();
+  }, [nodes, refresh, updateConnection]);
+
+  async function handleAcrossWireConfirm(port: number) {
+    if (!wireDraft) return;
+    setWiring(true);
+    try {
+      const sourceSnap = snapshots.find(s => s.conn.id === wireDraft.sourceConn.id);
+      const sourceIdx = sourceSnap?.databases.findIndex(d => d.name === wireDraft.sourceName) ?? -1;
+      const sourceStatus = sourceIdx >= 0 ? sourceSnap?.statuses[sourceIdx] : null;
+      // Promote source to leader on its own service if it isn't already.
+      if (sourceStatus?.role !== 'leader') {
+        await startDbAsLeader(wireDraft.sourceName, port, { connection: wireDraft.sourceConn });
+      }
+      // Target follows source's host (parsed from the source connection's
+      // baseUrl). Cross-service replication just works because the
+      // engines speak the same wire protocol over TCP.
+      const sourceHost = hostnameFromBaseUrl(wireDraft.sourceConn.baseUrl);
+      await startDbAsFollower(wireDraft.targetName, sourceHost, port, { connection: wireDraft.targetConn });
+      setWireDraft(null);
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not wire ${wireDraft.sourceName} → ${wireDraft.targetName}: ${e.message || String(e)}`);
+    } finally {
+      setWiring(false);
+    }
+  }
+
+  if (loading && snapshots.length === 0) {
+    return <div className="card"><p>Probing every registered connection…</p></div>;
+  }
+  if (connections.length === 0) {
+    return (
+      <div className="card">
+        <p>No connections registered yet.</p>
+        <p style={{ color: 'var(--gray-500)', fontSize: 13 }}>
+          Head to <a href="/connections" style={{ color: 'var(--red)' }}>Connections</a> and
+          either add an existing endpoint or use "+ Spawn local service" to start a fresh one.
+        </p>
+      </div>
+    );
+  }
+
+  // Quick stats roll-up for the header.
+  const totalDbs = snapshots.reduce((s, x) => s + x.databases.length, 0);
+  const leaderCount = snapshots.reduce((s, x) => s + x.statuses.filter(st => st?.role === 'leader').length, 0);
+  const followerCount = snapshots.reduce((s, x) => s + x.statuses.filter(st => st?.role === 'follower').length, 0);
+  const errored = snapshots.filter(x => x.error);
+
+  return (
+    <>
+      <div className="card" style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 16 }}>
+        <div style={{ fontSize: 14 }}>
+          <strong>{snapshots.length}</strong> service{snapshots.length === 1 ? '' : 's'}
+          · <strong>{totalDbs}</strong> database{totalDbs === 1 ? '' : 's'} total
+          {leaderCount > 0 && <> · <strong>{leaderCount}</strong> leader{leaderCount === 1 ? '' : 's'}</>}
+          {followerCount > 0 && <> · <strong>{followerCount}</strong> follower{followerCount === 1 ? '' : 's'}</>}
+        </div>
+        {errored.length > 0 && (
+          <div style={{ fontSize: 12, color: 'var(--red)' }}>
+            {errored.length} unreachable
+          </div>
+        )}
+      </div>
+
+      <div className="topology-stage no-side">
+        <div className="topology-canvas">
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            onConnect={handleAcrossConnect}
+            onNodeDragStop={handleNodeDragStop}
+            connectionLineStyle={{ stroke: 'var(--red)', strokeWidth: 2, strokeDasharray: '6 4' }}
+            fitView
+            proOptions={{ hideAttribution: true }}
+            defaultEdgeOptions={{
+              animated: true,
+              style: { stroke: 'var(--red)', strokeWidth: 2 },
+            }}
+          >
+            <Background gap={20} size={1} color="#e6e6e6" />
+            <Controls showInteractive={false} />
+            <MiniMap />
+          </ReactFlow>
+        </div>
+      </div>
+
+      {wireDraft && (
+        <WireReplicationModal
+          busy={wiring}
+          source={`${wireDraft.sourceConn.name} / ${wireDraft.sourceName}`}
+          target={`${wireDraft.targetConn.name} / ${wireDraft.targetName}`}
+          suggestedPort={wireDraft.suggestedPort}
+          onCancel={() => setWireDraft(null)}
+          onConfirm={handleAcrossWireConfirm}
+        />
+      )}
+
+      {errored.length > 0 && (
+        <div className="card" style={{ marginTop: 12, background: 'rgba(217,4,41,0.04)', borderLeft: '4px solid var(--red)' }}>
+          <strong style={{ color: 'var(--red)' }}>Unreachable services</strong>
+          <div style={{ fontSize: 12, marginTop: 6 }}>
+            {errored.map(e => (
+              <div key={e.conn.id} style={{ fontFamily: 'var(--mono)', marginBottom: 2 }}>
+                {e.conn.name} ({e.conn.baseUrl}) — {e.error}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+interface BuiltCanvas { nodes: Node[]; edges: Edge[]; }
+
+// Render: connections are grouped by their `shard` tag (Phase 5c). Each
+// shard becomes a labelled meta-frame on the canvas containing its
+// service columns; columns inside a shard cluster horizontally with a
+// header row at the top showing "Shard: X". Connections without a shard
+// tag go in an "Unsharded" frame on the right.
+function buildAcrossNodesAndEdges(snapshots: AcrossSnapshot[]): BuiltCanvas {
+  const COL_WIDTH = 280;
+  const COL_GAP = 40;
+  const ROW_HEIGHT = 110;
+  const HEADER_HEIGHT = 60;
+  const SHARD_GAP = 60;
+  const SHARD_PADDING_X = 20;
+  const SHARD_LABEL_HEIGHT = 36;
+
+  // Group snapshots by shard tag. Stable ordering: shards alphabetically,
+  // "(unsharded)" last so the eye reads grouped clusters first.
+  const grouped = new Map<string, AcrossSnapshot[]>();
+  for (const snap of snapshots) {
+    const key = (snap.conn.shard?.trim() || '__unsharded__');
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(snap);
+  }
+  const shardKeys = Array.from(grouped.keys()).sort((a, b) => {
+    if (a === '__unsharded__') return 1;
+    if (b === '__unsharded__') return -1;
+    return a.localeCompare(b);
+  });
+
+  const nodes: Node[] = [];
+  let cursorX = 0;
+
+  for (const shardKey of shardKeys) {
+    const members = grouped.get(shardKey)!;
+    const shardWidth = SHARD_PADDING_X * 2 + members.length * COL_WIDTH + Math.max(0, members.length - 1) * COL_GAP;
+    // Shard frame height = label + tallest column inside it.
+    const maxRows = Math.max(1, ...members.map(m => m.databases.length));
+    const colHeight = HEADER_HEIGHT + maxRows * ROW_HEIGHT + 12;
+    const shardHeight = SHARD_LABEL_HEIGHT + colHeight + 16;
+
+    const isUnsharded = shardKey === '__unsharded__';
+    const shardId = `shard:${shardKey}`;
+    const shardLabel = isUnsharded ? 'Unsharded' : `Shard · ${shardKey}`;
+    const shardAccent = isUnsharded ? 'var(--gray-200)' : 'var(--red)';
+    const shardBackground = isUnsharded ? 'rgba(245,245,245,0.4)' : 'rgba(217,4,41,0.03)';
+
+    // Shard meta-frame (parent of service columns).
+    nodes.push({
+      id: shardId,
+      type: 'group',
+      position: { x: cursorX, y: 0 },
+      data: { label: shardLabel },
+      style: {
+        width: shardWidth,
+        height: shardHeight,
+        background: shardBackground,
+        border: `1.5px ${isUnsharded ? 'dashed' : 'solid'} ${shardAccent}`,
+        borderRadius: 2,
+      },
+    });
+
+    // Shard label header — non-interactive, sits at the top of the frame.
+    nodes.push({
+      id: `${shardId}/label`,
+      type: 'default',
+      parentId: shardId,
+      extent: 'parent',
+      draggable: false,
+      selectable: false,
+      position: { x: 0, y: 0 },
+      data: {
+        label: (
+          <div style={{ padding: '6px 12px', textAlign: 'left' }}>
+            <div style={{ fontFamily: 'var(--mono)', fontSize: 10, letterSpacing: '0.08em', textTransform: 'uppercase', fontWeight: 700, color: isUnsharded ? 'var(--gray-500)' : 'var(--red)' }}>
+              {shardLabel}
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--gray-500)', marginTop: 2 }}>
+              {members.length} service{members.length === 1 ? '' : 's'} · {members.reduce((s, m) => s + m.databases.length, 0)} database{members.reduce((s, m) => s + m.databases.length, 0) === 1 ? '' : 's'}
+            </div>
+          </div>
+        ),
+      },
+      style: {
+        width: shardWidth - 2,
+        height: SHARD_LABEL_HEIGHT - 4,
+        background: 'transparent',
+        border: 'none',
+      },
+    });
+
+    // Service columns inside this shard frame.
+    for (let i = 0; i < members.length; i++) {
+      const snap = members[i];
+      const rows = Math.max(1, snap.databases.length);
+      const innerColHeight = HEADER_HEIGHT + rows * ROW_HEIGHT + 12;
+      const colXInShard = SHARD_PADDING_X + i * (COL_WIDTH + COL_GAP);
+
+      // Service column group (child of the shard frame). Intentionally
+      // NOT pinned via `extent: 'parent'` so the user can drag the
+      // column into another shard frame to reassign its shard tag —
+      // Phase 5d drag-to-reshard. The drop handler below detects
+      // which frame the column ended up in and updates the connection.
+      nodes.push({
+        id: `conn:${snap.conn.id}`,
+        type: 'group',
+        parentId: shardId,
+        position: { x: colXInShard, y: SHARD_LABEL_HEIGHT + 4 },
+        data: { label: snap.conn.name, connectionId: snap.conn.id, currentShard: shardKey },
+        style: {
+          width: COL_WIDTH,
+          height: innerColHeight,
+          background: snap.error ? 'rgba(217,4,41,0.04)' : 'white',
+          border: `1px solid ${snap.error ? 'var(--red)' : 'var(--gray-200)'}`,
+          borderRadius: 2,
+        },
+      });
+
+      // Service header.
+      nodes.push({
+        id: `header:${snap.conn.id}`,
+        type: 'default',
+        parentId: `conn:${snap.conn.id}`,
+        extent: 'parent',
+        draggable: false,
+        selectable: false,
+        position: { x: 0, y: 0 },
+        data: {
+          label: (
+            <div style={{ textAlign: 'left', padding: '6px 10px' }}>
+              <div style={{ fontWeight: 700, fontSize: 13, color: snap.error ? 'var(--red)' : 'var(--ink)' }}>
+                {snap.conn.name}
+              </div>
+              <div style={{ fontFamily: 'var(--mono)', fontSize: 10, color: 'var(--gray-500)' }}>
+                {snap.conn.baseUrl.replace(/^https?:\/\//, '')}
+                {snap.error ? ' · unreachable' : ''}
+              </div>
+            </div>
+          ),
+        },
+        style: {
+          width: COL_WIDTH - 2,
+          height: HEADER_HEIGHT - 8,
+          background: 'transparent',
+          border: 'none',
+        },
+      });
+
+      // DB nodes inside the service column.
+      for (let j = 0; j < snap.databases.length; j++) {
+        const db = snap.databases[j];
+        const status = snap.statuses[j];
+        nodes.push({
+          id: `db:${snap.conn.id}/${db.name}`,
+          type: 'database',
+          parentId: `conn:${snap.conn.id}`,
+          extent: 'parent',
+          position: { x: 16, y: HEADER_HEIGHT + j * ROW_HEIGHT },
+          data: {
+            name: db.name,
+            filePath: db.filePath,
+            isDefault: db.isDefault,
+            role: status?.role ?? 'unknown',
+            leaderPort: status?.leader?.port ?? null,
+            followerCount: status?.leader?.followerCount ?? 0,
+            followerLeaderEndpoint: status?.follower?.leader?.endpoint ?? null,
+            readOnly: status?.readOnly ?? false,
+          } as DBNodeData,
+        });
+      }
+    }
+
+    cursorX += shardWidth + SHARD_GAP;
+  }
+
+  // Edges: for each follower, find a matching leader anywhere by port.
+  // Build a (port → leaderNodeId) map first.
+  const leaderByPort = new Map<number, string>();
+  for (const snap of snapshots) {
+    for (let j = 0; j < snap.databases.length; j++) {
+      const status = snap.statuses[j];
+      if (status?.role === 'leader' && status.leader.port != null) {
+        leaderByPort.set(status.leader.port, `db:${snap.conn.id}/${snap.databases[j].name}`);
+      }
+    }
+  }
+
+  const edges: Edge[] = [];
+  for (const snap of snapshots) {
+    for (let j = 0; j < snap.databases.length; j++) {
+      const status = snap.statuses[j];
+      if (status?.role !== 'follower') continue;
+      const endpoint = status.follower.leader?.endpoint;
+      if (!endpoint) continue;
+      const m = endpoint.match(/:(\d+)$/);
+      if (!m) continue;
+      const port = parseInt(m[1], 10);
+      const leaderId = leaderByPort.get(port);
+      if (!leaderId) continue;
+      const followerId = `db:${snap.conn.id}/${snap.databases[j].name}`;
+      edges.push({
+        id: `xrep:${leaderId}->${followerId}`,
+        source: leaderId,
+        target: followerId,
+        label: `rep :${port}`,
+        labelStyle: { fontFamily: 'var(--mono)', fontSize: 10, fill: '#6c757d' },
+        labelBgStyle: { fill: 'white' },
+        labelBgPadding: [4, 2],
+        type: 'smoothstep',
+      });
+    }
+  }
+  return { nodes, edges };
+}
+
+// ---------------------------------------------------------------- collections view
+
+interface CollectionLocation {
+  conn: Connection;
+  database: string;
+}
+interface CollectionRow {
+  name: string;
+  locations: CollectionLocation[];
+  inferredStrategy: 'hash' | 'replicated' | 'single' | 'unknown';
+}
+
+/**
+ * Phase 6b — Collections tab. Walks every registered Connection, then
+ * every attached DB on those connections, calling /db/{name}/collections
+ * to build a cross-reference of where each collection lives. The
+ * inference rule for strategy is intentionally crude:
+ *
+ *  - Present on EVERY (connection, database) probed → likely `replicated`.
+ *  - Present on >1 location → likely `hash` (multiple shards hold slices).
+ *  - Present on exactly 1 location → `single` (or unsharded standalone).
+ *
+ * Real strategy comes from a cluster.json the operator hands the router;
+ * once the cluster config builder lands we'll prefer that over inference.
+ */
+function CollectionsView({ connections }: { connections: Connection[] }) {
+  const [rows, setRows] = useState<CollectionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [totalLocations, setTotalLocations] = useState(0);
+
+  useEffect(() => {
+    if (connections.length === 0) { setRows([]); setLoading(false); return; }
+    let cancelled = false;
+    setLoading(true); setError(null);
+    (async () => {
+      try {
+        // Fan out to every connection: list its DBs, then for each DB
+        // list its collections. Per-connection failures don't sink the
+        // whole probe — they show up as gaps in the cross-reference.
+        type Probe = { conn: Connection; database: string; collections: string[] };
+        const probes: Probe[] = [];
+        await Promise.all(connections.map(async (conn) => {
+          try {
+            const dbs = await listDatabases({ connection: conn });
+            await Promise.all(dbs.databases.map(async (db) => {
+              try {
+                const r = await listDbCollections(db.name, { connection: conn });
+                probes.push({ conn, database: db.name, collections: r.collections });
+              } catch { /* ignore per-db failure */ }
+            }));
+          } catch { /* ignore per-conn failure */ }
+        }));
+
+        if (cancelled) return;
+
+        // Build the cross-reference. Map { collectionName -> [...locations] }.
+        const byCollection = new Map<string, CollectionLocation[]>();
+        for (const p of probes) {
+          for (const c of p.collections) {
+            if (!byCollection.has(c)) byCollection.set(c, []);
+            byCollection.get(c)!.push({ conn: p.conn, database: p.database });
+          }
+        }
+
+        const totalProbes = probes.length;
+        const result: CollectionRow[] = Array.from(byCollection.entries())
+          .map(([name, locations]) => ({
+            name,
+            locations,
+            inferredStrategy: inferStrategy(locations.length, totalProbes),
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        setRows(result);
+        setTotalLocations(totalProbes);
+      } catch (e: any) {
+        if (!cancelled) setError(e.message || String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line
+  }, [connections.length, connections.map(c => c.id).join('|')]);
+
+  if (loading) return <div className="card"><p>Probing every connection's collections…</p></div>;
+  if (error) return <div className="card" style={{ borderLeft: '4px solid var(--red)' }}><strong>Error:</strong> {error}</div>;
+  if (connections.length === 0) {
+    return (
+      <div className="card">
+        <p>No connections registered.</p>
+        <p style={{ color: 'var(--gray-500)', fontSize: 13 }}>
+          Add one via the <a href="/connections" style={{ color: 'var(--red)' }}>Connections</a> page to discover collections across your cluster.
+        </p>
+      </div>
+    );
+  }
+  if (rows.length === 0) {
+    return (
+      <div className="card">
+        <p>No collections found across {totalLocations} database{totalLocations === 1 ? '' : 's'}.</p>
+        <p style={{ color: 'var(--gray-500)', fontSize: 13 }}>
+          Insert a doc anywhere — the collection lands and shows up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="card" style={{ marginBottom: 12, display: 'flex', alignItems: 'center', gap: 16 }}>
+        <div style={{ fontSize: 14 }}>
+          <strong>{rows.length}</strong> distinct collection{rows.length === 1 ? '' : 's'}
+          {' '}across <strong>{totalLocations}</strong> database{totalLocations === 1 ? '' : 's'}
+          {' '}on <strong>{connections.length}</strong> connection{connections.length === 1 ? '' : 's'}
+        </div>
+        <span style={{ flex: 1 }} />
+        <div style={{ fontSize: 11, color: 'var(--gray-500)' }}>
+          Strategy is inferred from where each collection appears. Load a cluster.json for exact policies.
+        </div>
+      </div>
+
+      <table className="table" style={{ background: 'white', border: '1px solid var(--gray-200)' }}>
+        <thead>
+          <tr style={{ background: 'var(--gray-100)' }}>
+            <th style={thCell()}>Collection</th>
+            <th style={thCell()}>Inferred strategy</th>
+            <th style={thCell()}>Locations</th>
+            <th style={thCell()}>Lives at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(row => (
+            <tr key={row.name} style={{ borderBottom: '1px solid var(--gray-100)' }}>
+              <td style={tdCell()}>
+                <span style={{ fontWeight: 600, fontFamily: 'var(--mono)' }}>{row.name}</span>
+              </td>
+              <td style={tdCell()}>
+                <StrategyPill strategy={row.inferredStrategy} />
+              </td>
+              <td style={tdCell()}>
+                <span style={{ fontFamily: 'var(--mono)', fontSize: 12 }}>
+                  {row.locations.length} / {totalLocations}
+                </span>
+              </td>
+              <td style={tdCell()}>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                  {row.locations.map((loc, i) => (
+                    <span
+                      key={`${loc.conn.id}/${loc.database}/${i}`}
+                      style={{ fontFamily: 'var(--mono)', fontSize: 10, padding: '2px 6px', background: 'var(--gray-100)', border: '1px solid var(--gray-200)' }}
+                      title={loc.conn.baseUrl}
+                    >
+                      {loc.conn.name}<span style={{ color: 'var(--gray-500)' }}>/{loc.database}</span>
+                    </span>
+                  ))}
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <div style={{ marginTop: 16, fontSize: 12, color: 'var(--gray-500)' }}>
+        💡 The router uses these collection names + an explicit cluster.json
+        (with strategies like <code style={{ fontFamily: 'var(--mono)' }}>hash</code> and{' '}
+        <code style={{ fontFamily: 'var(--mono)' }}>replicated</code>) to route
+        requests. The inferred-strategy column is a heuristic; once we build the
+        cluster config editor it'll show authoritative values.
+      </div>
+    </>
+  );
+}
+
+function inferStrategy(locationCount: number, totalProbes: number): CollectionRow['inferredStrategy'] {
+  if (totalProbes === 0) return 'unknown';
+  if (locationCount === totalProbes && totalProbes > 1) return 'replicated';
+  if (locationCount > 1) return 'hash';
+  return 'single';
+}
+
+function StrategyPill({ strategy }: { strategy: CollectionRow['inferredStrategy'] }) {
+  switch (strategy) {
+    case 'hash':
+      return <span className="pill" style={{ background: '#dbeafe', color: '#1d4ed8' }}>HASH ?</span>;
+    case 'replicated':
+      return <span className="pill" style={{ background: '#dcfce7', color: '#15803d' }}>REPLICATED ?</span>;
+    case 'single':
+      return <span className="pill gray">SINGLE</span>;
+    default:
+      return <span className="pill gray">—</span>;
+  }
+}
+
+function thCell(): React.CSSProperties {
+  return {
+    padding: '10px 12px',
+    textAlign: 'left',
+    fontFamily: 'var(--mono)',
+    fontSize: 11,
+    letterSpacing: '0.06em',
+    textTransform: 'uppercase',
+    color: 'var(--gray-500)',
+    fontWeight: 700,
+    borderBottom: '1px solid var(--gray-200)',
+  };
+}
+function tdCell(): React.CSSProperties {
+  return { padding: '10px 12px', fontSize: 13, verticalAlign: 'middle' };
 }
 
 // ---------------------------------------------------------------- nodes/edges

--- a/admin-ui/app/topology/page.tsx
+++ b/admin-ui/app/topology/page.tsx
@@ -108,6 +108,36 @@ function TopologyInner() {
 
   useEffect(() => { refresh(); /* eslint-disable-next-line */ }, [active?.id]);
 
+  // Periodically re-poll status so follower counts, applied-seq, and
+  // newly-attached DBs land without the user hitting refresh. 5s feels
+  // live without hammering the service.
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => {
+      // Silent refresh — only updates state if anything changed
+      // (buildNodes derives positions from current state when available).
+      refreshSilent();
+    }, 5000);
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line
+  }, [active?.id]);
+
+  async function refreshSilent() {
+    if (!active) return;
+    try {
+      const list = await listDatabases({ connection: active });
+      const statuses = await Promise.all(list.databases.map(async db => {
+        try { return await getDbReplicationStatus(db.name, { connection: active }); }
+        catch { return null; }
+      }));
+      const snap: SnapshotEntry[] = list.databases.map((db, i) => ({ db, status: statuses[i] }));
+      setSnapshot(snap);
+      // Diff-update nodes so dragged positions persist between polls.
+      setNodes(prev => mergeNodes(prev, buildNodes(snap)));
+      setEdges(buildEdges(snap));
+    } catch { /* swallow — banner will show on next manual refresh */ }
+  }
+
   // Persist drag positions so a refresh doesn't rearrange the user's layout.
   const onNodesChange = useCallback((changes: NodeChange<Node<DBNodeData>>[]) => {
     setNodes((nds) => {
@@ -174,13 +204,26 @@ function TopologyInner() {
     }
     setActionBusy(true);
     try {
-      // Same-service replication uses loopback. Cross-service follow would
-      // pass a different host; that UI lands when we add the "External
-      // attach" branch in the Add Database modal.
+      // Intra-service follow uses loopback.
       await startDbAsFollower(selectedDb, 'localhost', leaderPort, { connection: active ?? undefined });
       await refresh();
     } catch (e: any) {
       alert(`Could not follow: ${e.message || String(e)}`);
+    } finally {
+      setActionBusy(false);
+    }
+  }
+
+  // Follow a leader running on a different service. Useful when you want
+  // a DB hosted here to be a hot-standby of a leader on a different host.
+  async function handleFollowExternal(host: string, port: number) {
+    if (!selectedDb) return;
+    setActionBusy(true);
+    try {
+      await startDbAsFollower(selectedDb, host, port, { connection: active ?? undefined });
+      await refresh();
+    } catch (e: any) {
+      alert(`Could not follow ${host}:${port}: ${e.message || String(e)}`);
     } finally {
       setActionBusy(false);
     }
@@ -313,6 +356,7 @@ function TopologyInner() {
             onClose={() => setSelectedDb(null)}
             onStartLeader={handleStartLeader}
             onFollow={handleFollowLeader}
+            onFollowExternal={handleFollowExternal}
             onMakeActive={handleMakeActive}
             onDrop={handleDrop}
           />
@@ -331,6 +375,21 @@ function TopologyInner() {
 }
 
 // ---------------------------------------------------------------- nodes/edges
+
+// On auto-poll, preserve any positions the user has already dragged to.
+// New DBs use the auto-position; removed DBs vanish; existing DBs keep
+// their canvas seat.
+function mergeNodes(
+  previous: Node<DBNodeData>[],
+  next: Node<DBNodeData>[],
+): Node<DBNodeData>[] {
+  const prevById = new Map(previous.map(n => [n.id, n]));
+  return next.map(n => {
+    const prev = prevById.get(n.id);
+    if (!prev) return n;
+    return { ...n, position: prev.position };
+  });
+}
 
 function buildNodes(snapshot: SnapshotEntry[]): Node<DBNodeData>[] {
   const positions = loadPositions();
@@ -467,13 +526,17 @@ interface SidePanelProps {
   onClose: () => void;
   onStartLeader: (port: number) => void;
   onFollow: (leaderName: string) => void;
+  onFollowExternal: (host: string, port: number) => void;
   onMakeActive: () => void;
   onDrop: (deleteFiles: boolean) => void;
 }
 
-function SidePanel({ info, availableLeaders, busy, onClose, onStartLeader, onFollow, onMakeActive, onDrop }: SidePanelProps) {
+function SidePanel({ info, availableLeaders, busy, onClose, onStartLeader, onFollow, onFollowExternal, onMakeActive, onDrop }: SidePanelProps) {
   const [draftPort, setDraftPort] = useState(5500);
   const [draftLeader, setDraftLeader] = useState<string>('');
+  const [showExternal, setShowExternal] = useState(false);
+  const [extHost, setExtHost] = useState('');
+  const [extPort, setExtPort] = useState(5500);
   const role = info.status?.role ?? 'unknown';
 
   // Suggest a port that isn't already taken by another leader on this service.
@@ -547,8 +610,8 @@ function SidePanel({ info, availableLeaders, busy, onClose, onStartLeader, onFol
               </div>
             </div>
             {availableLeaders.length > 0 && (
-              <div>
-                <div style={{ fontSize: 11, color: 'var(--gray-500)', marginBottom: 4 }}>Or follow an existing leader:</div>
+              <div style={{ marginBottom: 8 }}>
+                <div style={{ fontSize: 11, color: 'var(--gray-500)', marginBottom: 4 }}>Or follow an existing leader on this service:</div>
                 <div style={{ display: 'flex', gap: 6 }}>
                   <select value={draftLeader} onChange={e => setDraftLeader(e.target.value)} style={{ flex: 1, padding: '6px 8px', fontSize: 12, border: '1px solid var(--gray-200)' }}>
                     <option value="">(pick a leader)</option>
@@ -562,6 +625,37 @@ function SidePanel({ info, availableLeaders, busy, onClose, onStartLeader, onFol
                 </div>
               </div>
             )}
+            {/* External leader — for cross-service replication. Useful when
+                this service hosts a hot-standby of a leader running elsewhere. */}
+            <div>
+              <button
+                onClick={() => setShowExternal(s => !s)}
+                style={{ background: 'none', border: 'none', color: 'var(--gray-500)', fontSize: 11, cursor: 'pointer', padding: 0, textDecoration: 'underline' }}
+              >
+                {showExternal ? '▾ Hide' : '▸ Follow a leader on a different service'}
+              </button>
+              {showExternal && (
+                <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+                  <input
+                    type="text"
+                    value={extHost}
+                    onChange={e => setExtHost(e.target.value)}
+                    placeholder="host (e.g. 10.0.1.4)"
+                    style={{ flex: 2, padding: '6px 8px', fontSize: 12, border: '1px solid var(--gray-200)', fontFamily: 'var(--mono)' }}
+                  />
+                  <input
+                    type="number"
+                    value={extPort}
+                    onChange={e => setExtPort(parseInt(e.target.value) || 0)}
+                    placeholder="port"
+                    style={{ width: 72, padding: '6px 8px', fontSize: 12, border: '1px solid var(--gray-200)', fontFamily: 'var(--mono)' }}
+                  />
+                  <button onClick={() => onFollowExternal(extHost.trim(), extPort)} disabled={busy || !extHost.trim() || extPort < 1024} style={primaryBtn()}>
+                    Follow
+                  </button>
+                </div>
+              )}
+            </div>
           </>
         )}
         {role === 'leader' && (

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -315,6 +315,76 @@ export async function setDefaultDatabase(name: string, opts?: CallOptions) {
   return handle(r);
 }
 
+// ---------- Per-DB replication (Issue #66 Phase 2.5) ----------
+// Phase 2.5 scoped endpoints under /db/{name}/replication/*. Each attached
+// DB has its own role; Studio's topology page uses these to render and
+// configure the intra-service leader/follower graph.
+
+export interface PerDbReplicationStatus {
+  database: string;
+  role: 'leader' | 'follower' | 'none';
+  readOnly: boolean;
+  leader: {
+    currentSeq: number;
+    port: number | null;        // port this DB is leading on; null when not a leader
+    followerCount: number;
+    followers: Array<{
+      endpoint: string;
+      httpEndpoint: string | null;
+      connectedAt: string;
+      handshakeSeq: number;
+      worstCaseLagSeq: number;
+    }>;
+  };
+  follower: {
+    lastAppliedSeq: number;
+    opsApplied: number;
+    gapsDetected: number;
+    autoFailoverPromoted: boolean;
+    leader: { endpoint: string; httpEndpoint: string | null } | null;
+  };
+}
+
+export async function getDbReplicationStatus(
+  name: string,
+  opts?: CallOptions,
+): Promise<PerDbReplicationStatus> {
+  const r = await fetch(
+    urlFor(`/db/${encodeURIComponent(name)}/replication/status`, opts),
+    { headers: authHeaders(opts) },
+  );
+  return handle(r);
+}
+
+export async function startDbAsLeader(name: string, port: number, opts?: CallOptions) {
+  const r = await fetch(
+    urlFor(`/db/${encodeURIComponent(name)}/replication/start-leader`, opts),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(opts) },
+      body: JSON.stringify({ port }),
+    },
+  );
+  return handle(r);
+}
+
+export async function startDbAsFollower(
+  name: string,
+  host: string,
+  port: number,
+  opts?: CallOptions,
+) {
+  const r = await fetch(
+    urlFor(`/db/${encodeURIComponent(name)}/replication/start-follower`, opts),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders(opts) },
+      body: JSON.stringify({ host, port }),
+    },
+  );
+  return handle(r);
+}
+
 // ---------- Replication control ----------
 export async function startLeader(port: number, sharedSecret?: string, opts?: CallOptions) {
   const r = await fetch(urlFor('/replication/start-leader', opts), {

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -256,6 +256,65 @@ export async function rebuildIndex(collection: string, indexName: string, opts?:
   return handle(r);
 }
 
+// ---------- Databases (Issue #66 Phase 2) ----------
+// One service can now host N attached databases. These verbs drive Studio's
+// "+ Add Database" UX and the per-connection database picker. Until Phase 4
+// lands per-request auth scoping, set-default is how the UI tells the
+// service "all subsequent flat-route calls should target DB X."
+
+export interface DatabaseEntry {
+  name: string;
+  filePath: string;
+  isDefault: boolean;
+}
+
+export interface DatabasesListResponse {
+  default: string | null;
+  count: number;
+  databases: DatabaseEntry[];
+}
+
+export async function listDatabases(opts?: CallOptions): Promise<DatabasesListResponse> {
+  const r = await fetch(urlFor('/databases', opts), { headers: authHeaders(opts) });
+  return handle(r);
+}
+
+export async function createDatabase(
+  name: string,
+  options?: { path?: string; createIfMissing?: boolean } & CallOptions,
+): Promise<DatabaseEntry> {
+  const r = await fetch(urlFor('/databases', options), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(options) },
+    body: JSON.stringify({
+      name,
+      path: options?.path,
+      createIfMissing: options?.createIfMissing ?? true,
+    }),
+  });
+  return handle(r);
+}
+
+export async function deleteDatabase(
+  name: string,
+  options?: { deleteFiles?: boolean } & CallOptions,
+) {
+  const qs = options?.deleteFiles ? '?deleteFiles=true' : '';
+  const r = await fetch(urlFor(`/databases/${encodeURIComponent(name)}${qs}`, options), {
+    method: 'DELETE',
+    headers: authHeaders(options),
+  });
+  return handle(r);
+}
+
+export async function setDefaultDatabase(name: string, opts?: CallOptions) {
+  const r = await fetch(urlFor(`/databases/${encodeURIComponent(name)}/set-default`, opts), {
+    method: 'POST',
+    headers: authHeaders(opts),
+  });
+  return handle(r);
+}
+
 // ---------- Replication control ----------
 export async function startLeader(port: number, sharedSecret?: string, opts?: CallOptions) {
   const r = await fetch(urlFor('/replication/start-leader', opts), {

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -122,8 +122,15 @@ export async function getReplicationStatus(opts?: CallOptions): Promise<Replicat
 }
 
 // ---------- Query ----------
-export async function query(sql: string, opts?: CallOptions) {
-  const r = await fetch(urlFor('/query', opts), {
+// Issue #66 Phase 3a: pass `database` to target a specific attached DB
+// rather than the service's current default. Omitting it falls back to
+// the flat /query route — the back-compat path for any service that
+// predates multi-DB.
+export async function query(sql: string, opts?: CallOptions & { database?: string }) {
+  const path = opts?.database
+    ? `/db/${encodeURIComponent(opts.database)}/query`
+    : '/query';
+  const r = await fetch(urlFor(path, opts), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...authHeaders(opts) },
     body: JSON.stringify({ sql }),
@@ -356,6 +363,19 @@ export async function getDbReplicationStatus(
   return handle(r);
 }
 
+// Issue #66 Phase 6b — collection list per attached DB. Used by the
+// Collections tab to auto-discover what's where across the cluster.
+export async function listDbCollections(
+  name: string,
+  opts?: CallOptions,
+): Promise<{ database: string; collections: string[] }> {
+  const r = await fetch(
+    urlFor(`/db/${encodeURIComponent(name)}/collections`, opts),
+    { headers: authHeaders(opts) },
+  );
+  return handle(r);
+}
+
 export async function startDbAsLeader(name: string, port: number, opts?: CallOptions) {
   const r = await fetch(
     urlFor(`/db/${encodeURIComponent(name)}/replication/start-leader`, opts),
@@ -382,6 +402,99 @@ export async function startDbAsFollower(
       body: JSON.stringify({ host, port }),
     },
   );
+  return handle(r);
+}
+
+// ---------- Service orchestration (Issue #66 Phase 5) ----------
+// Spawn / stop sibling `dfdb serve` processes from an existing service.
+// The "+ Spawn local service" button in the Connections page calls these;
+// the new HTTP base URL comes back and Studio auto-registers it as a
+// Connection so the cluster grows in one click.
+
+export interface ManagedServiceInfo {
+  port: number;
+  baseUrl: string;
+  dataDir: string;
+  nodeName: string | null;
+  startedAt: string;
+  running: boolean;
+  exitCode: number | null;
+  logPath: string;
+}
+
+export interface SpawnServiceResponse {
+  port: number;
+  baseUrl: string;
+  dataDir: string;
+  nodeName: string | null;
+  startedAt: string;
+  ready: boolean;
+  logPath: string;
+}
+
+export async function listServices(opts?: CallOptions): Promise<{ count: number; services: ManagedServiceInfo[] }> {
+  const r = await fetch(urlFor('/services', opts), { headers: authHeaders(opts) });
+  return handle(r);
+}
+
+export async function spawnService(
+  options?: { dataDir?: string; port?: number; nodeName?: string } & CallOptions,
+): Promise<SpawnServiceResponse> {
+  const r = await fetch(urlFor('/services', options), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(options) },
+    body: JSON.stringify({
+      dataDir: options?.dataDir,
+      port: options?.port,
+      nodeName: options?.nodeName,
+    }),
+  });
+  return handle(r);
+}
+
+export async function stopService(port: number, opts?: CallOptions) {
+  const r = await fetch(urlFor(`/services/${port}`, opts), {
+    method: 'DELETE',
+    headers: authHeaders(opts),
+  });
+  return handle(r);
+}
+
+export async function getServiceLog(port: number, opts?: CallOptions): Promise<string> {
+  const r = await fetch(urlFor(`/services/${port}/logs`, opts), { headers: authHeaders(opts) });
+  if (!r.ok) throw new Error(`Failed to fetch log: ${r.status} ${r.statusText}`);
+  return r.text();
+}
+
+// ---------- Spawn cluster router (Issue #66 Phase 6b) ----------
+// One-click cluster router from Studio. The host service writes the
+// cluster.json to disk and starts a `dfdb router` child against it.
+// Studio auto-registers the new router as a Connection.
+
+export interface SpawnRouterResponse {
+  kind: 'router';
+  port: number;
+  baseUrl: string;
+  configPath: string;
+  name: string | null;
+  startedAt: string;
+  ready: boolean;
+  logPath: string;
+}
+
+export async function spawnRouter(
+  clusterConfigJson: string,
+  options?: { port?: number; name?: string } & CallOptions,
+): Promise<SpawnRouterResponse> {
+  const r = await fetch(urlFor('/routers', options), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(options) },
+    body: JSON.stringify({
+      clusterConfigJson,
+      port: options?.port,
+      name: options?.name,
+    }),
+  });
   return handle(r);
 }
 

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "documentforge-admin",
       "version": "0.1.0",
       "dependencies": {
+        "@xyflow/react": "^12.10.2",
         "next": "^15.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -638,6 +639,55 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -652,7 +702,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -666,6 +716,38 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/caniuse-lite": {
@@ -688,6 +770,12 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -698,8 +786,113 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -958,6 +1151,43 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@xyflow/react": "^12.10.2",
     "next": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -147,6 +147,10 @@ public static class DatabaseEndpoints
                 leader = new
                 {
                     currentSeq,
+                    // Phase 2.5 — the port this DB is leading on. Studio
+                    // matches it against followers' leader-endpoint to
+                    // draw intra-service replication edges.
+                    port = db.LogicalLeaderPort,
                     followerCount = db.GetLogicalFollowerCount(),
                     followers = followers.Select(f => new
                     {

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -117,8 +117,125 @@ public static class DatabaseEndpoints
             catch (DocumentForgeException ex) { return Results.NotFound(new { error = ex.Message }); }
             catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
+
+        // ----------------------------------------------------------------
+        // Issue #66 Phase 2.5 — per-DB replication. Each attached DB has
+        // its own _logicalServer / _logicalFollower; until this lands the
+        // flat /replication/* routes only operate on whichever DB was the
+        // initial default at service startup.
+        //
+        // With these routes, "DB A leads, DB B follows A" works inside
+        // one service:
+        //   POST /db/A/replication/start-leader   {"port": 5500}
+        //   POST /db/B/replication/start-follower {"host":"localhost","port":5500}
+        // ----------------------------------------------------------------
+
+        // Per-DB replication status — derived from live engine state, not
+        // startup config. Returns 404 when the named DB isn't attached.
+        app.MapGet("/db/{name}/replication/status", (string name) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            var currentSeq = db.LeaderCurrentSeq;
+            var followers = db.GetLogicalFollowers();
+            return Results.Ok(new
+            {
+                database = name,
+                role = db.LogicalReplicationRole,
+                readOnly = db.IsReadOnly,
+                leader = new
+                {
+                    currentSeq,
+                    followerCount = db.GetLogicalFollowerCount(),
+                    followers = followers.Select(f => new
+                    {
+                        endpoint = f.Endpoint,
+                        httpEndpoint = f.HttpEndpoint,
+                        connectedAt = f.ConnectedAtUtc,
+                        handshakeSeq = f.HandshakeSeq,
+                        worstCaseLagSeq = currentSeq > f.HandshakeSeq
+                            ? currentSeq - f.HandshakeSeq : 0UL,
+                    }).ToArray(),
+                },
+                follower = new
+                {
+                    lastAppliedSeq = db.FollowerLastSeq,
+                    opsApplied = db.LogicallyReplicatedOps(),
+                    gapsDetected = db.GapsDetected,
+                    autoFailoverPromoted = db.WasAutoFailoverPromoted,
+                    leader = db.LogicalFollowerLeaderEndpoint is null
+                        ? null
+                        : (object)new { endpoint = db.LogicalFollowerLeaderEndpoint, httpEndpoint = (string?)null },
+                }
+            });
+        });
+
+        // Mount this DB as a replication leader on a dedicated TCP port.
+        // The port has to differ from the service's HTTP port and from
+        // any other DB's replication port in the same service.
+        app.MapPost("/db/{name}/replication/start-leader", (string name, StartLeaderBody body) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            try
+            {
+                db.StartLogicalReplicationServer(body.Port, body.SharedSecret);
+                return Results.Ok(new { database = name, role = "leader", port = body.Port });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // Mount this DB as a follower of another DB (same service or remote).
+        // First action on a fresh follower triggers a snapshot transfer from
+        // the leader — any existing data in this DB is replaced.
+        app.MapPost("/db/{name}/replication/start-follower", (string name, StartFollowerBody body) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            try
+            {
+                db.StartLogicalReplicationFollower(body.Host, body.Port, body.SharedSecret,
+                    ownHttpEndpoint: null);
+                return Results.Ok(new
+                {
+                    database = name,
+                    role = "follower",
+                    leader = $"{body.Host}:{body.Port}",
+                });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // Manual promotion — same semantics as the flat /replication/promote
+        // but scoped to a named DB. Use during planned handover, or after a
+        // leader-side crash, to flip a follower into leader on its own port.
+        app.MapPost("/db/{name}/replication/promote", (string name, PromoteBody body) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            try
+            {
+                db.PromoteToLeader(body.Port);
+                return Results.Ok(new { database = name, role = "leader", port = body.Port });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
     }
 }
+
+// ----------------------------------------------------------------
+// Issue #66 Phase 2.5: per-DB replication request bodies. Distinct
+// from the flat StartLeaderRequest/etc. records in ServeCommand so
+// the scoped surface can evolve independently (e.g. add a `force`
+// flag for re-attaching a follower to a different leader).
+// ----------------------------------------------------------------
+public record StartLeaderBody(int Port, string? SharedSecret = null);
+public record StartFollowerBody(string Host, int Port, string? SharedSecret = null);
+public record PromoteBody(int Port);
 
 /// <summary>
 /// Issue #66: payload for POST /databases. Path optional — if absent we

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -1,0 +1,128 @@
+using DocumentForge.Core;
+using DocumentForge.Engine;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// Issue #66 Phase 2: multi-database admin REST surface. Lives in its own
+/// class (rather than buried in <see cref="ServeCommand"/>) so it can be
+/// mounted on test fixtures that boot a minimal Kestrel host and assert
+/// against the wire shape directly. The data plane keeps its current flat
+/// routes; these endpoints just manage which databases are attached and
+/// which one is the default that flat routes resolve to.
+///
+/// <para>
+/// Wire shape mirrors the engine API verbatim — Attach for existing files,
+/// Create for new ones, Detach for unregister-but-keep, Drop for delete-files.
+/// The convenience verb <see cref="DatabaseRegistry.AttachOrCreate"/> powers
+/// <c>POST /databases</c> by default so a Studio "+" button works without the
+/// caller knowing whether the file pre-existed.
+/// </para>
+/// </summary>
+public static class DatabaseEndpoints
+{
+    /// <summary>
+    /// Mount the verbs on the supplied route builder. <paramref name="defaultDataDir"/>
+    /// is where a path-less <c>POST /databases</c> drops the new <c>.dfdb</c>
+    /// (defaults to <c>{dataDir}/{name}.dfdb</c>).
+    /// </summary>
+    public static void Map(IEndpointRouteBuilder app, DatabaseRegistry registry, string defaultDataDir)
+    {
+        // List every attached database. Stable shape across phases.
+        app.MapGet("/databases", () =>
+        {
+            var entries = registry.List();
+            return Results.Ok(new
+            {
+                @default = registry.DefaultDatabaseName,
+                count = entries.Count,
+                databases = entries.Select(e => new
+                {
+                    name = e.Name,
+                    filePath = e.FilePath,
+                    isDefault = e.IsDefault,
+                })
+            });
+        });
+
+        // Create-or-attach (Studio "+ Add Database").
+        //   { "name": "acme" }                            -> {dataDir}/acme.dfdb, create-or-attach
+        //   { "name": "acme", "path": "/abs/p.dfdb" }     -> use the supplied path, create-or-attach
+        //   { "name": "acme", "createIfMissing": false }  -> Attach (existing file only)
+        app.MapPost("/databases", (CreateDatabaseRequest req) =>
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(req.Name))
+                    return Results.BadRequest(new { error = "Missing 'name' field." });
+
+                var path = string.IsNullOrWhiteSpace(req.Path)
+                    ? Path.Combine(defaultDataDir, $"{req.Name}.dfdb")
+                    : req.Path!;
+
+                var createIfMissing = req.CreateIfMissing ?? true;
+                if (createIfMissing)
+                    registry.AttachOrCreate(req.Name, path);
+                else
+                    registry.Attach(req.Name, path);
+
+                // Resolve the entry we just registered so we return the
+                // canonical casing + canonical path back to the caller.
+                var info = registry.List().First(e =>
+                    string.Equals(e.Name, req.Name, StringComparison.OrdinalIgnoreCase));
+                return Results.Created($"/databases/{info.Name}", new
+                {
+                    name = info.Name,
+                    filePath = info.FilePath,
+                    isDefault = info.IsDefault,
+                });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (DocumentForgeException ex) { return Results.Conflict(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // Detach (default) or Drop (delete-files=true). 404 when not
+        // registered so Studio's idempotent retries get a clear signal.
+        app.MapDelete("/databases/{name}", (string name, bool? deleteFiles) =>
+        {
+            try
+            {
+                var drop = deleteFiles == true;
+                var removed = drop ? registry.Drop(name) : registry.Detach(name);
+                if (!removed)
+                    return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+                return Results.Ok(new
+                {
+                    name,
+                    action = drop ? "dropped" : "detached",
+                    defaultAfter = registry.DefaultDatabaseName,
+                });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // Phase 2 stopgap for "I'm working on DB X now" — Phase 4 will
+        // replace this with auth-scoped Bearer tokens.
+        app.MapPost("/databases/{name}/set-default", (string name) =>
+        {
+            try
+            {
+                registry.SetDefault(name);
+                return Results.Ok(new { name, isDefault = true });
+            }
+            catch (DocumentForgeException ex) { return Results.NotFound(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+    }
+}
+
+/// <summary>
+/// Issue #66: payload for POST /databases. Path optional — if absent we
+/// derive <c>{dataDir}/{name}.dfdb</c>. CreateIfMissing defaults to true so
+/// the Studio "+ Add" UX works without a file existing yet.
+/// </summary>
+public record CreateDatabaseRequest(string Name, string? Path = null, bool? CreateIfMissing = null);

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using DocumentForge.Core;
 using DocumentForge.Engine;
 using Microsoft.AspNetCore.Routing;
@@ -228,8 +229,79 @@ public static class DatabaseEndpoints
             }
             catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
+
+        // ----------------------------------------------------------------
+        // Issue #66 Phase 3a — scoped data plane. Studio (and any client)
+        // can now run SQL against any attached DB without flipping the
+        // service's default. The flat /query route still targets the
+        // default DB; this route targets the named one. Same response
+        // shape so the client-side handler stays simple.
+        // ----------------------------------------------------------------
+        app.MapPost("/db/{name}/query", (string name, QueryBody body) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            if (string.IsNullOrWhiteSpace(body.Sql))
+                return Results.BadRequest(new { error = "Missing 'sql' field." });
+
+            var result = db.Execute(body.Sql);
+            if (!result.Success)
+                return Results.BadRequest(new { error = result.Message });
+
+            var docs = result.Documents
+                .Select(d => JsonDocument.Parse(d.ToJson()).RootElement)
+                .ToList();
+            return Results.Ok(new
+            {
+                database = name,
+                success = true,
+                count = result.Documents.Count,
+                affected = result.AffectedCount,
+                plan = result.QueryPlan,
+                executionTimeMs = result.ExecutionTime.TotalMilliseconds,
+                message = result.Message,
+                documents = docs,
+            });
+        });
+
+        // Scoped collections list — Studio's Explorer pane uses this when
+        // a tab is pinned to a non-default DB. The flat /collections
+        // continues to return the default DB's collections for back-compat.
+        app.MapGet("/db/{name}/collections", (string name) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            return Results.Ok(new { database = name, collections = db.GetCollectionNames() });
+        });
+
+        // Scoped insert. Required for the Phase 6 router to forward
+        // /collections/{c} POSTs against a multi-DB-backed ring leader.
+        // Body shape mirrors the flat POST /collections/{name}: raw JSON
+        // document. Returns the new doc id on success.
+        app.MapPost("/db/{name}/collections/{collection}", async (string name, string collection, HttpRequest request) =>
+        {
+            var db = registry.TryGet(name);
+            if (db is null)
+                return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            try
+            {
+                using var reader = new StreamReader(request.Body);
+                var body = await reader.ReadToEndAsync();
+                if (string.IsNullOrWhiteSpace(body))
+                    return Results.BadRequest(new { error = "Empty body — JSON document required." });
+                var id = db.Insert(collection, body);
+                return Results.Ok(new { database = name, success = true, id = id.ToString(), collection });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
     }
 }
+
+// Phase 3a — scoped query body. Same field as the flat QueryRequest in
+// ServeCommand, kept distinct so the per-DB API can evolve independently.
+public record QueryBody(string Sql);
 
 // ----------------------------------------------------------------
 // Issue #66 Phase 2.5: per-DB replication request bodies. Distinct

--- a/src/DocumentForge.Cli/Commands/RouterCommand.cs
+++ b/src/DocumentForge.Cli/Commands/RouterCommand.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using DocumentForge.Cli.Router;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// Issue #66 Phase 6 — <c>dfdb router</c> CLI verb. Boots the
+/// stateless routing proxy described in <see cref="Router"/>.
+///
+/// <para>
+/// Usage:
+/// <code>
+///   dfdb router --config cluster.json [--port 5000]
+/// </code>
+/// </para>
+/// </summary>
+public static class RouterCommand
+{
+    public static int Run(string[] args)
+    {
+        if (args.Contains("--help") || args.Contains("-h"))
+        {
+            PrintHelp();
+            return 0;
+        }
+
+        var configPath = GetFlag(args, "--config") ?? GetFlag(args, "-c");
+        if (string.IsNullOrEmpty(configPath))
+        {
+            Console.Error.WriteLine("ERROR: --config <cluster.json> is required.");
+            PrintHelp();
+            return 1;
+        }
+        if (!File.Exists(configPath))
+        {
+            Console.Error.WriteLine($"ERROR: cluster config not found at '{configPath}'.");
+            return 1;
+        }
+
+        var config = ClusterConfig.FromJson(File.ReadAllText(configPath));
+
+        // CLI --port takes precedence over config.router.port; both must
+        // resolve to *something* or we can't bind Kestrel.
+        var portFlag = GetFlag(args, "--port") ?? GetFlag(args, "-p");
+        int port = portFlag is not null && int.TryParse(portFlag, out var p)
+            ? p
+            : (config.Router.Port ?? 5000);
+
+        var bindAll = args.Contains("--bind-all");
+        var host = bindAll ? "0.0.0.0" : "localhost";
+        var bindUrl = $"http://{host}:{port}";
+
+        var router = new ClusterRouter(config);
+
+        // Build the Kestrel host. Same defaults as `dfdb serve` —
+        // quiet ASP.NET request chatter, CORS-open for browser callers.
+        var builder = WebApplication.CreateBuilder(args);
+        builder.Logging
+            .AddFilter("Microsoft.AspNetCore", Microsoft.Extensions.Logging.LogLevel.Warning);
+        builder.WebHost.UseUrls(bindUrl);
+        builder.Services.AddCors(opts => opts.AddDefaultPolicy(p =>
+            p.AllowAnyOrigin().AllowAnyHeader().AllowAnyMethod()));
+        var app = builder.Build();
+        app.UseCors();
+
+        PrintBanner(config, configPath, bindUrl);
+        RouterEndpoints.Map(app, router, configPath);
+
+        app.Lifetime.ApplicationStopping.Register(() => router.Dispose());
+        app.Run();
+        return 0;
+    }
+
+    private static void PrintBanner(ClusterConfig config, string configPath, string bindUrl)
+    {
+        Console.WriteLine();
+        Console.WriteLine("  \x1b[36mdfdb router\x1b[0m");
+        Console.WriteLine($"  config:     {Path.GetFullPath(configPath)}");
+        Console.WriteLine($"  listening:  {bindUrl}");
+        Console.WriteLine($"  shards:     {config.Shards.Count}  ({string.Join(", ", config.Shards.Select(s => s.Name))})");
+        Console.WriteLine($"  collections:{config.Collections.Count}  (" +
+            string.Join(", ", config.Collections.Select(c => $"{c.Name}:{c.Strategy}")) + ")");
+        Console.WriteLine();
+        Console.WriteLine("  endpoints:  POST /collections/{name}   — insert (routed per strategy)");
+        Console.WriteLine("              POST /query                — SELECT (fan-out for hash, single for replicated)");
+        Console.WriteLine("              GET  /cluster/config       — read the active config");
+        Console.WriteLine("              GET  /cluster/health       — per-ring health probe");
+        Console.WriteLine();
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine("Usage: dfdb router --config <path/to/cluster.json> [--port N] [--bind-all]");
+        Console.WriteLine();
+        Console.WriteLine("Boots a stateless proxy that fronts an entire DocumentForge cluster as");
+        Console.WriteLine("one HTTP endpoint. The cluster.json declares shard rings + collections;");
+        Console.WriteLine("the router applies hash / replicated routing on every request.");
+    }
+
+    private static string? GetFlag(string[] args, string flag)
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+            if (string.Equals(args[i], flag, StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        return null;
+    }
+}

--- a/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
@@ -1,0 +1,109 @@
+using System.Text.Json;
+using DocumentForge.Cli.Router;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// REST surface for the <c>dfdb router</c> proxy. Endpoints mirror the
+/// subset of <c>dfdb serve</c>'s surface that clients use directly so
+/// applications can swap their connection string from
+/// <c>http://service:5000</c> to <c>http://router:5000</c> with no
+/// code changes for insert + query workloads.
+/// </summary>
+public static class RouterEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, ClusterRouter router, string configPath)
+    {
+        // POST /collections/{name} — route an insert per strategy.
+        app.MapPost("/collections/{name}", async (string name, HttpRequest request) =>
+        {
+            try
+            {
+                using var reader = new StreamReader(request.Body);
+                var body = await reader.ReadToEndAsync();
+                if (string.IsNullOrWhiteSpace(body))
+                    return Results.BadRequest(new { error = "Empty body — JSON document required." });
+                using var doc = JsonDocument.Parse(body);
+                var upstream = await router.InsertAsync(name, doc.RootElement);
+                var status = (int)upstream.StatusCode;
+                var responseBody = await upstream.Content.ReadAsStringAsync();
+                return Results.Content(responseBody, "application/json", statusCode: status);
+            }
+            catch (InvalidOperationException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // POST /query — fan-out for hash collections, single ring otherwise.
+        app.MapPost("/query", async (HttpRequest request) =>
+        {
+            try
+            {
+                using var reader = new StreamReader(request.Body);
+                var body = await reader.ReadToEndAsync();
+                using var doc = JsonDocument.Parse(body);
+                if (!doc.RootElement.TryGetProperty("sql", out var sqlEl) ||
+                    sqlEl.ValueKind != JsonValueKind.String)
+                    return Results.BadRequest(new { error = "Missing 'sql' field." });
+                var sql = sqlEl.GetString()!;
+                var result = await router.QueryAsync(sql);
+                return Results.Text(result.GetRawText(), "application/json");
+            }
+            catch (InvalidOperationException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // GET /cluster/config — surface the loaded config so Studio can
+        // render the topology + collection strategies without re-parsing
+        // the JSON on disk.
+        app.MapGet("/cluster/config", () =>
+        {
+            return Results.Text(router.Config.ToJson(), "application/json");
+        });
+
+        // GET /cluster/health — probe every ring in parallel; return a
+        // status object the admin UI can render in real time.
+        app.MapGet("/cluster/health", async () =>
+        {
+            var checks = await Task.WhenAll(router.Rings.Select(async kv => new
+            {
+                shard = kv.Key,
+                baseUrl = kv.Value.BaseUrl,
+                database = kv.Value.Endpoint.Database,
+                healthy = await kv.Value.IsHealthyAsync(),
+            }));
+            var anyUnhealthy = checks.Any(c => !c.healthy);
+            return Results.Json(new
+            {
+                status = anyUnhealthy ? "degraded" : "ok",
+                shards = checks,
+            });
+        });
+
+        // GET /health — root-level health for load balancers + Studio's
+        // connection picker. Matches the dfdb serve shape on purpose.
+        app.MapGet("/health", () => Results.Ok(new
+        {
+            status = "ok",
+            node = "router",
+            role = "router",
+            version = "0.1.0",
+            configPath = Path.GetFullPath(configPath),
+            shards = router.Config.Shards.Count,
+            collections = router.Config.Collections.Count,
+        }));
+
+        // GET /collections — list every distinct collection declared in
+        // the cluster config. Studio's Explorer pane uses this when
+        // pointed at a router endpoint.
+        app.MapGet("/collections", () =>
+        {
+            return Results.Ok(new
+            {
+                collections = router.Config.Collections.Select(c => c.Name).ToArray(),
+            });
+        });
+    }
+}

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -107,9 +107,22 @@ public static class ServeCommand
         // single-DB clients see no change.
         DatabaseEndpoints.Map(app, registry, config.DataDir);
 
+        // Issue #66 Phase 5: service orchestration. Lets Studio (or a CLI)
+        // spawn sibling dfdb serve processes from one running service —
+        // the foundation for the "create a local cluster in one click"
+        // UX. Children are tracked, reaped on parent shutdown.
+        var serviceManager = new ServiceManager();
+        ServiceEndpoints.Map(app, serviceManager, config.DataDir);
+
         // Dispose the registry on shutdown — it cascades to every attached
-        // database, including the Phase 1 single "default" one.
-        app.Lifetime.ApplicationStopping.Register(() => registry.Dispose());
+        // database, including the Phase 1 single "default" one. The service
+        // manager is disposed first so child processes are reaped before
+        // we close their parent's data files.
+        app.Lifetime.ApplicationStopping.Register(() =>
+        {
+            try { serviceManager.Dispose(); } catch { }
+            try { registry.Dispose(); } catch { }
+        });
         app.Run();
         return 0;
     }
@@ -135,6 +148,7 @@ public static class ServeCommand
         Console.WriteLine("             POST /seed | GET /health | GET /version");
         Console.WriteLine("  databases: GET  /databases | POST /databases | DELETE /databases/{name}");
         Console.WriteLine("             POST /databases/{name}/set-default");
+        Console.WriteLine("  services:  GET  /services | POST /services | DELETE /services/{port}");
         Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
         Console.WriteLine("             POST /admin/compact/{collection}");
         Console.WriteLine("             POST /admin/rebuild-indexes/{collection}");

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -101,6 +101,11 @@ public static class ServeCommand
         MapEndpoints(app, db);
         MapAdminEndpoints(app, db, config);
         MapReplicationEndpoints(app, db, config);
+        // Issue #66 Phase 2: multi-database admin verbs (list/attach/create/
+        // detach/drop/set-default). The registry holds the engines; flat
+        // data-plane routes still resolve to registry.GetDefault() so
+        // single-DB clients see no change.
+        DatabaseEndpoints.Map(app, registry, config.DataDir);
 
         // Dispose the registry on shutdown — it cascades to every attached
         // database, including the Phase 1 single "default" one.
@@ -128,6 +133,8 @@ public static class ServeCommand
         Console.WriteLine("             DELETE /collections/{name} | GET /indexes/{collection} | POST /index");
         Console.WriteLine("             POST /tx/batch                  (atomic multi-doc transaction)");
         Console.WriteLine("             POST /seed | GET /health | GET /version");
+        Console.WriteLine("  databases: GET  /databases | POST /databases | DELETE /databases/{name}");
+        Console.WriteLine("             POST /databases/{name}/set-default");
         Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
         Console.WriteLine("             POST /admin/compact/{collection}");
         Console.WriteLine("             POST /admin/rebuild-indexes/{collection}");

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -54,7 +54,15 @@ public static class ServeCommand
 
         Directory.CreateDirectory(config.DataDir);
         var dbPath = Path.Combine(config.DataDir, "data.dfdb");
-        var db = DocumentForgeDb.OpenOrCreate(dbPath);
+
+        // Issue #66 Phase 1: every database now lives inside a registry, so
+        // future phases (Studio "+" button, /databases CRUD, lazy open) can
+        // grow without touching the route map. For Phase 1 the registry
+        // holds exactly one entry — "default" — pointed at data.dfdb. All
+        // existing flat routes resolve through registry.GetDefault(), so
+        // single-DB clients written before this change see zero difference.
+        var registry = new DatabaseRegistry();
+        var db = registry.AttachOrCreate("default", dbPath);
 
         // Optional replication wiring - leader / follower / none
         var replicationSummary = StartReplication(db, config);
@@ -94,7 +102,9 @@ public static class ServeCommand
         MapAdminEndpoints(app, db, config);
         MapReplicationEndpoints(app, db, config);
 
-        app.Lifetime.ApplicationStopping.Register(() => db.Dispose());
+        // Dispose the registry on shutdown — it cascades to every attached
+        // database, including the Phase 1 single "default" one.
+        app.Lifetime.ApplicationStopping.Register(() => registry.Dispose());
         app.Run();
         return 0;
     }

--- a/src/DocumentForge.Cli/Commands/ServiceEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/ServiceEndpoints.cs
@@ -1,0 +1,154 @@
+using DocumentForge.Cli;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// Issue #66 Phase 5 — REST surface for spawning local <c>dfdb serve</c>
+/// children from Studio. The "+ Spawn local service" button in the
+/// Connections page calls POST /services; the new HTTP base URL comes
+/// back and Studio auto-registers it as a Connection. End-to-end the
+/// user gets a fresh sibling service in ~1 second.
+///
+/// <para>
+/// Endpoints:
+/// <code>
+///   GET    /services                 — list managed children
+///   POST   /services { dataDir?, port?, nodeName? } — spawn
+///   DELETE /services/{port}          — stop + reap
+///   GET    /services/{port}/logs     — tail the child's combined stdout/stderr
+/// </code>
+/// </para>
+///
+/// <para>
+/// Auth: same Bearer middleware as the rest of the service. Dev mode (no
+/// API key configured) gates nothing — that's deliberate for "click to
+/// spawn" UX. Production deployments should never enable this surface
+/// without an admin-scoped token; Phase 4's auth scope work tightens it.
+/// </para>
+/// </summary>
+public static class ServiceEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, ServiceManager manager, string defaultDataDirRoot)
+    {
+        app.MapGet("/services", () =>
+        {
+            var entries = manager.List();
+            return Results.Ok(new { count = entries.Count, services = entries });
+        });
+
+        app.MapPost("/services", (SpawnServiceRequest req) =>
+        {
+            try
+            {
+                // Default data dir: a sibling of the parent's, named by port
+                // (or "child-{nodeName}" if supplied). Operators can override
+                // by passing an explicit path.
+                string dataDir;
+                if (!string.IsNullOrWhiteSpace(req.DataDir))
+                {
+                    dataDir = req.DataDir!;
+                }
+                else
+                {
+                    var label = !string.IsNullOrWhiteSpace(req.NodeName)
+                        ? req.NodeName!
+                        : (req.Port is int p && p > 0 ? $"port-{p}" : $"node-{DateTime.UtcNow:HHmmss}");
+                    dataDir = Path.Combine(defaultDataDirRoot, "services", label);
+                }
+
+                var service = manager.Spawn(new SpawnOptions
+                {
+                    DataDir = dataDir,
+                    Port = req.Port ?? 0,
+                    NodeName = req.NodeName,
+                });
+
+                return Results.Created($"/services/{service.Port}", new
+                {
+                    port = service.Port,
+                    baseUrl = service.BaseUrl,
+                    dataDir = service.DataDir,
+                    nodeName = service.NodeName,
+                    startedAt = service.StartedAt,
+                    ready = service.Ready,
+                    logPath = service.LogPath,
+                });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        app.MapDelete("/services/{port:int}", (int port) =>
+        {
+            var stopped = manager.Stop(port);
+            if (!stopped)
+                return Results.NotFound(new { error = $"No managed service on port {port}." });
+            return Results.Ok(new { port, stopped = true });
+        });
+
+        app.MapGet("/services/{port:int}/logs", (int port, int? maxBytes) =>
+        {
+            var log = manager.ReadLog(port, maxBytes ?? 16384);
+            return Results.Text(log, "text/plain");
+        });
+
+        // Phase 6b — POST /routers spawns a `dfdb router` child against a
+        // cluster.json the caller provides inline. The router runs on a
+        // free port (or the supplied one) and gets tracked by the same
+        // ServiceManager that handles serve children. Studio's "Spawn
+        // router" button hits this; the new HTTP base URL comes back
+        // and Studio auto-registers it as a Connection.
+        app.MapPost("/routers", (SpawnRouterRequest req) =>
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(req.ClusterConfigJson))
+                    return Results.BadRequest(new { error = "Missing 'clusterConfigJson' body field." });
+
+                // Drop the config to a file under {dataDir}/routers/{name}/
+                // so each router has a stable home for its log + config.
+                var label = !string.IsNullOrWhiteSpace(req.Name) ? req.Name! : $"router-{DateTime.UtcNow:HHmmss}";
+                var routerDir = Path.Combine(defaultDataDirRoot, "routers", label);
+                Directory.CreateDirectory(routerDir);
+                var configPath = Path.Combine(routerDir, "cluster.json");
+                File.WriteAllText(configPath, req.ClusterConfigJson);
+
+                var service = manager.SpawnRouter(new SpawnRouterOptions
+                {
+                    ConfigPath = configPath,
+                    Port = req.Port ?? 0,
+                    Name = req.Name,
+                    LogDir = routerDir,
+                });
+
+                return Results.Created($"/services/{service.Port}", new
+                {
+                    kind = "router",
+                    port = service.Port,
+                    baseUrl = service.BaseUrl,
+                    configPath,
+                    name = service.NodeName,
+                    startedAt = service.StartedAt,
+                    ready = service.Ready,
+                    logPath = service.LogPath,
+                });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (InvalidOperationException ex) { return Results.Conflict(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+    }
+}
+
+// Phase 6b — POST /routers request body. The cluster config is
+// inlined as a JSON string so Studio's editor can post the textarea
+// contents verbatim without writing it to disk first.
+public record SpawnRouterRequest(string ClusterConfigJson, int? Port = null, string? Name = null);
+
+// Phase 5 spawn payload. All optional — POST /services with {} is valid
+// and gives you a child on a free port with a derived data dir.
+public record SpawnServiceRequest(string? DataDir = null, int? Port = null, string? NodeName = null);

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -20,6 +20,7 @@ public class Program
             return sub switch
             {
                 "serve"     => ServeCommand.Run(rest),
+                "router"    => RouterCommand.Run(rest),
                 "repl"      => ReplCommand.Run(rest),
                 "inspect"   => InspectCommand.Run(rest),
                 "query"     => QueryCommand.Run(rest),

--- a/src/DocumentForge.Cli/Router/ClusterConfig.cs
+++ b/src/DocumentForge.Cli/Router/ClusterConfig.cs
@@ -1,0 +1,228 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DocumentForge.Cli.Router;
+
+/// <summary>
+/// Issue #66 Phase 6 — cluster topology + routing policy for the
+/// <c>dfdb router</c> stateless proxy. One JSON file describes
+/// every shard ring (each with a leader + optional followers) and
+/// every collection's distribution strategy (hash / replicated / single).
+///
+/// <para>
+/// A ring "endpoint" is a <c>(baseUrl, database?)</c> pair. The
+/// optional <c>database</c> targets a specific attached DB on a
+/// multi-DB host (Issue #66 Phase 1+); omitting it routes to the
+/// service's default DB, which preserves back-compat with the
+/// pre-#66 single-DB topology format the existing /cluster page
+/// generates.
+/// </para>
+///
+/// <para>
+/// Wire format mirrors the JSON the admin-UI's existing static
+/// /cluster page produces, extended for multi-DB. JSON loader is
+/// permissive — endpoint as bare URL string is normalised to
+/// <c>{ baseUrl: "...", database: null }</c> so old configs Just Work.
+/// </para>
+/// </summary>
+public sealed class ClusterConfig
+{
+    /// <summary>Router-level settings (port, name). Optional —
+    /// CLI flags override these when both are present.</summary>
+    public RouterConfig Router { get; set; } = new();
+
+    /// <summary>Shard rings — each one is a leader plus zero or more
+    /// followers. Hash-sharded collections distribute documents across
+    /// these rings via modular hashing of the shard key.</summary>
+    public List<ShardConfig> Shards { get; set; } = new();
+
+    /// <summary>Per-collection distribution policy.</summary>
+    public List<CollectionConfig> Collections { get; set; } = new();
+
+    /// <summary>Resolve "orders" to its strategy. Returns null when
+    /// the collection isn't declared — the router treats undeclared
+    /// collections as <c>strategy: single</c> against the first ring,
+    /// so casual dev workflows don't trip on a missing entry.</summary>
+    public CollectionConfig? FindCollection(string name) =>
+        Collections.FirstOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+
+    public static ClusterConfig FromJson(string json)
+    {
+        var opts = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+        // Custom converter accepts endpoint as either a bare URL string
+        // or the structured object form.
+        opts.Converters.Add(new EndpointConverter());
+        // ShardStrategy is serialised as a lowercase string ("hash" /
+        // "replicated" / "single") rather than its numeric value —
+        // matches the JSON the /cluster page emits and is what
+        // operators expect to write by hand.
+        opts.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+
+        var cfg = JsonSerializer.Deserialize<ClusterConfig>(json, opts)
+            ?? throw new InvalidOperationException("cluster.json deserialised to null.");
+
+        cfg.Validate();
+        return cfg;
+    }
+
+    public string ToJson()
+    {
+        var opts = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            // Emit camelCase keys to match the convention used by every
+            // other endpoint in DocumentForge and the format the
+            // /cluster page already generates.
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        opts.Converters.Add(new EndpointConverter());
+        opts.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        return JsonSerializer.Serialize(this, opts);
+    }
+
+    /// <summary>Throw on structural mistakes that would only show up
+    /// as 500s mid-request. Cheap upfront beats a 3am page.</summary>
+    public void Validate()
+    {
+        if (Shards.Count == 0)
+            throw new InvalidOperationException("cluster.json: at least one shard is required.");
+        var seenShardNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in Shards)
+        {
+            if (string.IsNullOrWhiteSpace(s.Name))
+                throw new InvalidOperationException("cluster.json: every shard needs a 'name'.");
+            if (!seenShardNames.Add(s.Name))
+                throw new InvalidOperationException($"cluster.json: duplicate shard name '{s.Name}'.");
+            if (s.Leader is null || string.IsNullOrWhiteSpace(s.Leader.BaseUrl))
+                throw new InvalidOperationException($"cluster.json: shard '{s.Name}' needs a 'leader.baseUrl'.");
+        }
+        foreach (var c in Collections)
+        {
+            if (string.IsNullOrWhiteSpace(c.Name))
+                throw new InvalidOperationException("cluster.json: every collection needs a 'name'.");
+            if (c.Strategy == ShardStrategy.Hash && string.IsNullOrWhiteSpace(c.ShardKeyPath))
+                throw new InvalidOperationException(
+                    $"cluster.json: hash-sharded collection '{c.Name}' needs a 'shardKeyPath'.");
+        }
+    }
+}
+
+public sealed class RouterConfig
+{
+    public int? Port { get; set; }
+    public string? Name { get; set; }
+}
+
+public sealed class ShardConfig
+{
+    public string Name { get; set; } = "";
+    public ShardEndpoint? Leader { get; set; }
+    public List<ShardEndpoint> Followers { get; set; } = new();
+}
+
+public sealed class ShardEndpoint
+{
+    public string BaseUrl { get; set; } = "";
+
+    /// <summary>Optional attached-DB name (multi-DB hosting, Issue #66).
+    /// When null, the router targets the service's default DB.</summary>
+    public string? Database { get; set; }
+
+    /// <summary>Bearer token if the target service is auth-gated.</summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>Compose the URL path prefix for this endpoint. Multi-DB
+    /// targets prefix with <c>/db/{database}</c>; flat targets stay at
+    /// the root.</summary>
+    public string PathPrefix => string.IsNullOrEmpty(Database) ? string.Empty : $"/db/{Database}";
+}
+
+public sealed class CollectionConfig
+{
+    public string Name { get; set; } = "";
+    public ShardStrategy Strategy { get; set; } = ShardStrategy.Single;
+    public string? ShardKeyPath { get; set; }
+}
+
+/// <summary>
+/// How a collection is distributed across the cluster.
+/// </summary>
+public enum ShardStrategy
+{
+    /// <summary>Single-shard. Default. Routes everything to the first
+    /// shard in the config. Equivalent to running a collection on
+    /// only one ring.</summary>
+    Single = 0,
+
+    /// <summary>Hash-sharded by <see cref="CollectionConfig.ShardKeyPath"/>.
+    /// Documents distribute across all shards by hash modulo shard count.</summary>
+    Hash = 1,
+
+    /// <summary>Full copy on every shard. Inserts fan out to every leader;
+    /// reads can hit any one (the router picks the cheapest).</summary>
+    Replicated = 2,
+}
+
+// ----------------------------------------------------------------
+// JSON converter: lets the user write a bare URL string instead of
+// the object form. Two equivalent representations:
+//
+//   "leader": "http://localhost:5000"
+//   "leader": { "baseUrl": "http://localhost:5000", "database": "ring_a" }
+//
+// The first is what the legacy /cluster page produces; the second
+// is the new multi-DB-aware form.
+// ----------------------------------------------------------------
+internal sealed class EndpointConverter : JsonConverter<ShardEndpoint>
+{
+    public override ShardEndpoint? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null) return null;
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var url = reader.GetString();
+            if (string.IsNullOrWhiteSpace(url)) return null;
+            return new ShardEndpoint { BaseUrl = url };
+        }
+        if (reader.TokenType != JsonTokenType.StartObject)
+            throw new JsonException($"Expected string or object for ShardEndpoint, got {reader.TokenType}.");
+
+        var ep = new ShardEndpoint();
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.EndObject) return ep;
+            if (reader.TokenType != JsonTokenType.PropertyName) continue;
+            var prop = reader.GetString();
+            reader.Read();
+            switch (prop?.ToLowerInvariant())
+            {
+                case "baseurl":  ep.BaseUrl  = reader.GetString() ?? ""; break;
+                case "database": ep.Database = reader.GetString(); break;
+                case "apikey":   ep.ApiKey   = reader.GetString(); break;
+                default: reader.Skip(); break;
+            }
+        }
+        throw new JsonException("Unexpected end of object while reading ShardEndpoint.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, ShardEndpoint value, JsonSerializerOptions options)
+    {
+        // Prefer the compact string form when there's nothing to add.
+        if (string.IsNullOrEmpty(value.Database) && string.IsNullOrEmpty(value.ApiKey))
+        {
+            writer.WriteStringValue(value.BaseUrl);
+            return;
+        }
+        writer.WriteStartObject();
+        writer.WriteString("baseUrl", value.BaseUrl);
+        if (!string.IsNullOrEmpty(value.Database)) writer.WriteString("database", value.Database);
+        if (!string.IsNullOrEmpty(value.ApiKey))   writer.WriteString("apiKey",   value.ApiKey);
+        writer.WriteEndObject();
+    }
+}

--- a/src/DocumentForge.Cli/Router/RingClient.cs
+++ b/src/DocumentForge.Cli/Router/RingClient.cs
@@ -1,0 +1,101 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace DocumentForge.Cli.Router;
+
+/// <summary>
+/// Thin HTTP client around one shard ring endpoint — leader or follower.
+/// Owns a pinned <see cref="HttpClient"/>, the path-prefix logic for
+/// multi-DB targets, and the auth header if the backing service is
+/// API-keyed. Everything the router needs to talk to one slice of the
+/// cluster.
+///
+/// <para>Stateless beyond the HttpClient itself: no caching, no retries,
+/// no health tracking. The router orchestrates retries / fallbacks; this
+/// class just makes the call.</para>
+/// </summary>
+public sealed class RingClient : IDisposable
+{
+    private readonly HttpClient _http;
+    private readonly ShardEndpoint _endpoint;
+
+    public string ShardName { get; }
+    public ShardEndpoint Endpoint => _endpoint;
+    public string BaseUrl => _endpoint.BaseUrl.TrimEnd('/');
+
+    public RingClient(string shardName, ShardEndpoint endpoint, TimeSpan? timeout = null)
+    {
+        ShardName = shardName;
+        _endpoint = endpoint;
+        _http = new HttpClient
+        {
+            Timeout = timeout ?? TimeSpan.FromSeconds(15),
+        };
+        if (!string.IsNullOrEmpty(endpoint.ApiKey))
+            _http.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", endpoint.ApiKey);
+    }
+
+    private string Url(string path) => BaseUrl + _endpoint.PathPrefix + path;
+
+    /// <summary>POST /collections/{name}. Forwarded verbatim — the
+    /// router doesn't peek inside the doc payload here, it already
+    /// did the shard-key extraction to pick this ring.</summary>
+    public async Task<HttpResponseMessage> InsertAsync(string collection, JsonElement doc, CancellationToken ct = default)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, Url($"/collections/{Uri.EscapeDataString(collection)}"))
+        {
+            Content = JsonContent.Create(doc),
+        };
+        return await _http.SendAsync(req, ct);
+    }
+
+    /// <summary>POST /query. Returns the parsed JSON response so the
+    /// router can merge results across rings for hash-sharded queries.</summary>
+    public async Task<JsonElement> QueryAsync(string sql, CancellationToken ct = default)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, Url("/query"))
+        {
+            Content = JsonContent.Create(new { sql }),
+        };
+        var resp = await _http.SendAsync(req, ct);
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Ring '{ShardName}' query failed: {(int)resp.StatusCode} {body}");
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.Clone();
+    }
+
+    /// <summary>GET /collections — used for auto-discovery of which
+    /// collections exist on this ring.</summary>
+    public async Task<List<string>> ListCollectionsAsync(CancellationToken ct = default)
+    {
+        var resp = await _http.GetAsync(Url("/collections"), ct);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(body);
+        var arr = doc.RootElement.GetProperty("collections");
+        var names = new List<string>(arr.GetArrayLength());
+        foreach (var n in arr.EnumerateArray()) names.Add(n.GetString() ?? "");
+        return names;
+    }
+
+    /// <summary>Cheap health probe — returns true if the backing
+    /// service's /health responds 200. Probes the bare base URL,
+    /// not the multi-DB scoped path, because /health is service-
+    /// wide, not per-DB.</summary>
+    public async Task<bool> IsHealthyAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(TimeSpan.FromSeconds(2));
+            var resp = await _http.GetAsync($"{BaseUrl}/health", cts.Token);
+            return resp.IsSuccessStatusCode;
+        }
+        catch { return false; }
+    }
+
+    public void Dispose() => _http.Dispose();
+}

--- a/src/DocumentForge.Cli/Router/Router.cs
+++ b/src/DocumentForge.Cli/Router/Router.cs
@@ -1,0 +1,262 @@
+using System.Text.Json;
+
+namespace DocumentForge.Cli.Router;
+
+/// <summary>
+/// Issue #66 Phase 6 — the routing brain. Stateless: given a
+/// <see cref="ClusterConfig"/> and a request, decides which ring(s)
+/// to forward to and merges the result.
+///
+/// <para>
+/// Strategies (mirrored from <see cref="ShardStrategy"/>):
+///  - <c>Single</c>: every op goes to shards[0]. Default for undeclared
+///     collections so casual workflows ("just attach this DB to the
+///     router for now") don't trip on a missing config entry.
+///  - <c>Hash</c>: insert goes to <c>hash(doc[shardKeyPath]) % N</c>;
+///     query fans out to every shard and merges by concatenation.
+///  - <c>Replicated</c>: insert fans out to every shard's leader;
+///     query reads from one shard (least-loaded heuristic = first
+///     healthy in config order).
+/// </para>
+///
+/// <para>
+/// Hashing: 32-bit FNV-1a over the UTF-8 bytes of the shard-key value.
+/// Chosen for stable distribution + zero dependencies. Stable across
+/// platforms because the bytes are produced by the same encoder.
+/// </para>
+/// </summary>
+public sealed class ClusterRouter : IDisposable
+{
+    private readonly ClusterConfig _config;
+    private readonly Dictionary<string, RingClient> _ringByName;
+
+    public ClusterConfig Config => _config;
+
+    public ClusterRouter(ClusterConfig config)
+    {
+        config.Validate();
+        _config = config;
+        // One client per shard leader. Followers aren't dialed by the
+        // router today — replication handles the read side. A future
+        // "read from followers" optimisation will dial them too.
+        _ringByName = config.Shards.ToDictionary(
+            s => s.Name,
+            s => new RingClient(s.Name, s.Leader!),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Public clients keyed by shard name. Useful for callers
+    /// that want to drive a specific ring directly (health probes,
+    /// admin ops).</summary>
+    public IReadOnlyDictionary<string, RingClient> Rings => _ringByName;
+
+    // -------------------------------------------------------------- insert
+
+    /// <summary>
+    /// Route an insert per the collection's strategy. Returns the
+    /// upstream response from the (single) ring that handled it, or
+    /// for replicated collections the response from the first ring
+    /// (every ring gets the same insert; the IDs may differ).
+    /// </summary>
+    public async Task<HttpResponseMessage> InsertAsync(string collection, JsonElement doc, CancellationToken ct = default)
+    {
+        var policy = _config.FindCollection(collection)
+            ?? new CollectionConfig { Name = collection, Strategy = ShardStrategy.Single };
+
+        switch (policy.Strategy)
+        {
+            case ShardStrategy.Hash:
+            {
+                var ring = SelectRingByHash(doc, policy.ShardKeyPath!);
+                return await ring.InsertAsync(collection, doc, ct);
+            }
+            case ShardStrategy.Replicated:
+            {
+                // Fan-out. Surface a 5xx if ANY ring rejects — partial
+                // replication leaves the cluster in an inconsistent state
+                // that's worse than failing closed.
+                HttpResponseMessage? firstOk = null;
+                Exception? firstErr = null;
+                foreach (var (_, ring) in _ringByName)
+                {
+                    try
+                    {
+                        var resp = await ring.InsertAsync(collection, doc, ct);
+                        if (!resp.IsSuccessStatusCode)
+                        {
+                            firstErr ??= new InvalidOperationException(
+                                $"Ring '{ring.ShardName}' rejected replicated insert: {(int)resp.StatusCode}");
+                        }
+                        firstOk ??= resp;
+                    }
+                    catch (Exception ex) { firstErr ??= ex; }
+                }
+                if (firstErr is not null) throw firstErr;
+                return firstOk!;
+            }
+            case ShardStrategy.Single:
+            default:
+            {
+                var ring = _ringByName[_config.Shards[0].Name];
+                return await ring.InsertAsync(collection, doc, ct);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------- query
+
+    /// <summary>
+    /// Run a SELECT across the right ring(s) and merge the result.
+    /// For hash collections, fans out to every ring and concatenates
+    /// document arrays. For replicated, hits exactly one ring (the
+    /// first by config order — health-aware selection is a follow-up).
+    /// </summary>
+    public async Task<JsonElement> QueryAsync(string sql, CancellationToken ct = default)
+    {
+        // Best-effort collection extraction — we don't run a real SQL
+        // parser here; we just look for a "FROM <name>" token to pick
+        // a strategy. INSERT/DELETE/UPDATE that hit the router today
+        // get the same fan-out treatment (correct for replicated,
+        // hash-key-aware INSERT happens in InsertAsync).
+        var coll = TryExtractCollectionFromSql(sql);
+        var policy = coll is null ? null : _config.FindCollection(coll);
+        var strategy = policy?.Strategy ?? ShardStrategy.Single;
+
+        switch (strategy)
+        {
+            case ShardStrategy.Hash:
+            {
+                // Fan-out + merge documents from every ring.
+                var responses = await Task.WhenAll(_ringByName.Values
+                    .Select(r => r.QueryAsync(sql, ct)));
+                return MergeQueryResponses(responses);
+            }
+            case ShardStrategy.Replicated:
+            case ShardStrategy.Single:
+            default:
+            {
+                var firstRing = _ringByName[_config.Shards[0].Name];
+                return await firstRing.QueryAsync(sql, ct);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------- helpers
+
+    private RingClient SelectRingByHash(JsonElement doc, string shardKeyPath)
+    {
+        var keyValue = ExtractKey(doc, shardKeyPath);
+        if (keyValue is null)
+            throw new InvalidOperationException(
+                $"Hash routing requires '{shardKeyPath}' in the document; not present.");
+        var hash = Fnv1a32(keyValue);
+        var index = (int)(hash % (uint)_config.Shards.Count);
+        var ringName = _config.Shards[index].Name;
+        return _ringByName[ringName];
+    }
+
+    /// <summary>Pull the shard-key value out of the document. Supports
+    /// simple top-level paths ("pnr") and dotted paths ("customer.id").
+    /// Anything missing returns null.</summary>
+    public static string? ExtractKey(JsonElement doc, string path)
+    {
+        var segments = path.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        var cursor = doc;
+        foreach (var seg in segments)
+        {
+            if (cursor.ValueKind != JsonValueKind.Object) return null;
+            if (!cursor.TryGetProperty(seg, out var next)) return null;
+            cursor = next;
+        }
+        return cursor.ValueKind switch
+        {
+            JsonValueKind.String => cursor.GetString(),
+            JsonValueKind.Number => cursor.GetRawText(),
+            JsonValueKind.True => "true",
+            JsonValueKind.False => "false",
+            _ => null,
+        };
+    }
+
+    /// <summary>FNV-1a 32-bit hash. Cheap, stable, well-distributed
+    /// for short keys. The router uses it for shard-index selection;
+    /// the engine's index hashing is independent.</summary>
+    public static uint Fnv1a32(string s)
+    {
+        const uint offset = 2166136261u;
+        const uint prime = 16777619u;
+        var bytes = System.Text.Encoding.UTF8.GetBytes(s);
+        uint h = offset;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            h ^= bytes[i];
+            h *= prime;
+        }
+        return h;
+    }
+
+    public static string? TryExtractCollectionFromSql(string sql)
+    {
+        // Regex-free, parser-free, best-effort: look for "FROM <name>"
+        // case-insensitively. Real parsing happens engine-side at the
+        // ring; here we just need a hint for strategy lookup.
+        var idx = sql.IndexOf("FROM", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0) return null;
+        idx += 4; // past "FROM"
+        // Skip whitespace.
+        while (idx < sql.Length && char.IsWhiteSpace(sql[idx])) idx++;
+        var start = idx;
+        while (idx < sql.Length && (char.IsLetterOrDigit(sql[idx]) || sql[idx] == '_'))
+            idx++;
+        return idx > start ? sql.Substring(start, idx - start) : null;
+    }
+
+    /// <summary>Merge {documents: [...], count, ...} from every ring
+    /// into one envelope. Counts sum, documents concatenate, plan/
+    /// executionTimeMs come from the slowest ring so the client sees
+    /// realistic latency for the whole fan-out.</summary>
+    private static JsonElement MergeQueryResponses(JsonElement[] responses)
+    {
+        var allDocs = new List<JsonElement>();
+        int totalCount = 0;
+        int totalAffected = 0;
+        double maxMs = 0;
+        string? plan = null;
+
+        foreach (var r in responses)
+        {
+            if (r.TryGetProperty("documents", out var docs) && docs.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var d in docs.EnumerateArray()) allDocs.Add(d);
+            }
+            if (r.TryGetProperty("count", out var c) && c.ValueKind == JsonValueKind.Number)
+                totalCount += c.GetInt32();
+            if (r.TryGetProperty("affected", out var a) && a.ValueKind == JsonValueKind.Number)
+                totalAffected += a.GetInt32();
+            if (r.TryGetProperty("executionTimeMs", out var ms) && ms.ValueKind == JsonValueKind.Number)
+                maxMs = Math.Max(maxMs, ms.GetDouble());
+            if (plan is null && r.TryGetProperty("plan", out var p) && p.ValueKind == JsonValueKind.String)
+                plan = p.GetString();
+        }
+
+        var merged = new
+        {
+            success = true,
+            count = totalCount,
+            affected = totalAffected,
+            plan = plan ?? "FAN_OUT_MERGE",
+            executionTimeMs = maxMs,
+            documents = allDocs,
+            shards = responses.Length,
+        };
+        var json = JsonSerializer.Serialize(merged);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.Clone();
+    }
+
+    public void Dispose()
+    {
+        foreach (var c in _ringByName.Values) c.Dispose();
+        _ringByName.Clear();
+    }
+}

--- a/src/DocumentForge.Cli/ServiceManager.cs
+++ b/src/DocumentForge.Cli/ServiceManager.cs
@@ -1,0 +1,434 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+
+namespace DocumentForge.Cli;
+
+/// <summary>
+/// Issue #66 Phase 5: spawn child <c>dfdb serve</c> processes on demand
+/// so a single Studio session can stand up an entire local cluster
+/// without juggling terminals. Each managed service is a real OS process,
+/// owns its own data directory + ports, and dies when this manager is
+/// disposed (parent shutdown).
+///
+/// <para>
+/// Scope: <em>local dev orchestration</em>. Production setups want a real
+/// supervisor (systemd, Docker, Kubernetes). The features that would make
+/// this safe in production — capability-gated auth, binary allow-listing,
+/// per-child resource limits — are explicit non-goals for v1.
+/// </para>
+///
+/// <para>
+/// Cross-platform: works on Windows / Linux / macOS because the .NET
+/// host binary (resolved via <see cref="Environment.ProcessPath"/>) is
+/// the same binary that's spawning. Children inherit the same .NET 9
+/// runtime, no extra config required.
+/// </para>
+/// </summary>
+public sealed class ServiceManager : IDisposable
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<int, ManagedService> _services = new();
+    private bool _disposed;
+
+    /// <summary>
+    /// Spawn a <c>dfdb router</c> child against the given cluster
+    /// config. Used by the Studio "Spawn router" UI. Routers are
+    /// tracked the same way as serve children — same port allocation,
+    /// same log capture, same reap-on-shutdown — but their args differ
+    /// and they don't take a data directory.
+    /// </summary>
+    public ManagedService SpawnRouter(SpawnRouterOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ConfigPath))
+            throw new ArgumentException("configPath is required.", nameof(options));
+        if (!File.Exists(options.ConfigPath))
+            throw new ArgumentException(
+                $"configPath '{options.ConfigPath}' does not exist.", nameof(options));
+
+        var binary = options.BinaryPath ?? Environment.ProcessPath
+            ?? throw new InvalidOperationException(
+                "Cannot determine the dfdb binary path — set SpawnRouterOptions.BinaryPath.");
+
+        var binaryFileName = Path.GetFileNameWithoutExtension(binary);
+        var isDotnetHost = string.Equals(binaryFileName, "dotnet", StringComparison.OrdinalIgnoreCase);
+        var preArgs = new List<string>();
+        if (isDotnetHost)
+        {
+            var dll = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+            if (string.IsNullOrEmpty(dll))
+                throw new InvalidOperationException(
+                    "Parent runs under dotnet host but entry assembly path is unresolved.");
+            preArgs.Add(dll);
+        }
+
+        var port = options.Port > 0 ? options.Port : FindFreePort();
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (_services.ContainsKey(port))
+                throw new InvalidOperationException($"Port {port} is already managed.");
+        }
+
+        var logDir = options.LogDir
+            ?? Path.GetDirectoryName(Path.GetFullPath(options.ConfigPath))!;
+        Directory.CreateDirectory(logDir);
+        var logPath = Path.Combine(logDir, $"router-{port}.log");
+
+        var args = new List<string>(preArgs)
+        {
+            "router",
+            "--config", options.ConfigPath,
+            "--port", port.ToString(),
+        };
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binary,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var process = new Process { StartInfo = psi };
+        var logWriter = new StreamWriter(File.Open(logPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+        {
+            AutoFlush = true,
+        };
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) logWriter.WriteLine(e.Data); };
+        process.ErrorDataReceived  += (_, e) => { if (e.Data is not null) logWriter.WriteLine("[stderr] " + e.Data); };
+
+        if (!process.Start())
+            throw new InvalidOperationException($"Failed to start router child on port {port}.");
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var service = new ManagedService
+        {
+            Port = port,
+            DataDir = Path.GetFullPath(options.ConfigPath),  // for routers, "data dir" = config path (for display)
+            NodeName = options.Name ?? $"router-{port}",
+            Process = process,
+            LogPath = logPath,
+            StartedAt = DateTime.UtcNow,
+            BaseUrl = $"http://localhost:{port}",
+            LogWriter = logWriter,
+            Kind = "router",
+        };
+
+        lock (_lock) _services[port] = service;
+        service.Ready = WaitForReady(service, TimeSpan.FromSeconds(10));
+        return service;
+    }
+
+    /// <summary>
+    /// Spawn a new <c>dfdb serve</c> on <paramref name="port"/> (or pick a
+    /// free port if 0) with its own <paramref name="dataDir"/>. Returns
+    /// the new service's HTTP base URL once Kestrel reports ready.
+    /// Throws if the binary can't be found or the child fails to start.
+    /// </summary>
+    public ManagedService Spawn(SpawnOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.DataDir))
+            throw new ArgumentException("dataDir is required.", nameof(options));
+
+        var binary = options.BinaryPath ?? Environment.ProcessPath
+            ?? throw new InvalidOperationException(
+                "Cannot determine the dfdb binary path — set SpawnOptions.BinaryPath or run under a host that exposes Environment.ProcessPath.");
+
+        // Two invocation modes coexist in practice:
+        //   1. Apphost: dfdb.exe spawned directly. Environment.ProcessPath
+        //      is dfdb.exe and we just re-launch it with the serve verb.
+        //   2. Framework-dependent: `dotnet dfdb.dll serve …`. Environment.ProcessPath
+        //      is dotnet.exe (or just `dotnet` on Unix); we must pass the
+        //      entry-assembly dll as the FIRST argument so dotnet runs it.
+        // Apphost mode is the production shape; framework-dependent is what
+        // `dotnet run` and explicit `dotnet path/to.dll` produce, and what
+        // CI / local-dev workflows hit when launching without publish.
+        var binaryFileName = Path.GetFileNameWithoutExtension(binary);
+        var isDotnetHost = string.Equals(binaryFileName, "dotnet", StringComparison.OrdinalIgnoreCase);
+        var preArgs = new List<string>();
+        if (isDotnetHost)
+        {
+            var dll = Assembly.GetEntryAssembly()?.Location;
+            if (string.IsNullOrEmpty(dll))
+                throw new InvalidOperationException(
+                    "Parent is running under the dotnet host but the entry assembly path could not be resolved. " +
+                    "Set SpawnOptions.BinaryPath to the dfdb dll or apphost explicitly.");
+            preArgs.Add(dll);
+        }
+
+        // Validate or assign a port. 0 means "pick something free."
+        var port = options.Port > 0 ? options.Port : FindFreePort();
+
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (_services.ContainsKey(port))
+                throw new InvalidOperationException($"Port {port} is already managed by this service.");
+        }
+
+        Directory.CreateDirectory(options.DataDir);
+        var logPath = Path.Combine(options.DataDir, "serve.log");
+
+        var args = new List<string>(preArgs)
+        {
+            "serve",
+            "--data-dir", options.DataDir,
+            "--port", port.ToString(),
+        };
+        if (!string.IsNullOrEmpty(options.NodeName))
+            args.AddRange(new[] { "--node", options.NodeName });
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = binary,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+
+        var process = new Process { StartInfo = psi };
+        // Tee output to a per-child log file so operators can inspect
+        // crashes after the fact. The pipe is unbounded if we don't
+        // drain it, which would deadlock the child.
+        var logWriter = new StreamWriter(File.Open(logPath, FileMode.Create, FileAccess.Write, FileShare.Read))
+        {
+            AutoFlush = true,
+        };
+        process.OutputDataReceived += (_, e) => { if (e.Data is not null) logWriter.WriteLine(e.Data); };
+        process.ErrorDataReceived  += (_, e) => { if (e.Data is not null) logWriter.WriteLine("[stderr] " + e.Data); };
+
+        if (!process.Start())
+            throw new InvalidOperationException($"Failed to start child process for port {port}.");
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        var service = new ManagedService
+        {
+            Port = port,
+            DataDir = Path.GetFullPath(options.DataDir),
+            NodeName = options.NodeName,
+            Process = process,
+            LogPath = logPath,
+            StartedAt = DateTime.UtcNow,
+            BaseUrl = $"http://localhost:{port}",
+            LogWriter = logWriter,
+            Kind = "serve",
+        };
+
+        lock (_lock) _services[port] = service;
+
+        // Best-effort readiness probe. /health responds in <100ms typically;
+        // give up to 10s for slow startups (cold .NET, disk-bound recovery).
+        // The caller gets a usable URL even if the probe times out — the
+        // child may yet come up; we just can't promise it's ready.
+        service.Ready = WaitForReady(service, TimeSpan.FromSeconds(10));
+        return service;
+    }
+
+    /// <summary>
+    /// Stop a managed service. Sends a kill signal and reaps the process
+    /// (we don't have a cross-platform graceful SIGINT today). Returns
+    /// false if no service is managed on that port.
+    /// </summary>
+    public bool Stop(int port)
+    {
+        ManagedService? service;
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (!_services.TryGetValue(port, out service))
+                return false;
+            _services.Remove(port);
+        }
+        StopService(service);
+        return true;
+    }
+
+    /// <summary>Snapshot of every managed service — safe to enumerate.</summary>
+    public IReadOnlyList<ManagedServiceInfo> List()
+    {
+        lock (_lock)
+        {
+            return _services.Values
+                .Select(s => new ManagedServiceInfo(
+                    s.Port,
+                    s.DataDir,
+                    s.NodeName,
+                    s.BaseUrl,
+                    s.StartedAt,
+                    !s.Process.HasExited,
+                    s.Process.HasExited ? (int?)s.Process.ExitCode : null,
+                    s.LogPath,
+                    s.Kind))
+                .ToList();
+        }
+    }
+
+    /// <summary>Read the tail of a managed service's log file.</summary>
+    public string ReadLog(int port, int maxBytes = 16384)
+    {
+        ManagedService? service;
+        lock (_lock)
+        {
+            if (!_services.TryGetValue(port, out service)) return string.Empty;
+        }
+        try
+        {
+            using var fs = File.Open(service.LogPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            if (fs.Length > maxBytes) fs.Seek(-maxBytes, SeekOrigin.End);
+            using var sr = new StreamReader(fs);
+            return sr.ReadToEnd();
+        }
+        catch (IOException) { return string.Empty; }
+    }
+
+    public void Dispose()
+    {
+        List<ManagedService> toStop;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            toStop = _services.Values.ToList();
+            _services.Clear();
+        }
+        foreach (var s in toStop) StopService(s);
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static void StopService(ManagedService s)
+    {
+        try
+        {
+            if (!s.Process.HasExited)
+            {
+                s.Process.Kill(entireProcessTree: true);
+                s.Process.WaitForExit(2_000);
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[ServiceManager] error stopping :{s.Port} (PID {s.Process.Id}): {ex.Message}");
+        }
+        try { s.LogWriter.Dispose(); } catch { }
+        try { s.Process.Dispose(); } catch { }
+    }
+
+    private static int FindFreePort()
+    {
+        // Bind to port 0 — OS hands us a free ephemeral port, we read it
+        // off, immediately release the socket. There's an inherent race
+        // where another process snags the port between our release and
+        // the child's bind; in practice this is fine for dev orchestration.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    private static bool WaitForReady(ManagedService s, TimeSpan timeout)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (s.Process.HasExited) return false;
+            try
+            {
+                var resp = http.GetAsync($"{s.BaseUrl}/health").GetAwaiter().GetResult();
+                if (resp.IsSuccessStatusCode) return true;
+            }
+            catch { /* not yet listening */ }
+            Thread.Sleep(150);
+        }
+        return false;
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(ServiceManager));
+    }
+}
+
+public sealed class SpawnOptions
+{
+    /// <summary>Working directory for the new service's data file + sidecars.
+    /// Each spawn must use its own directory — they each take a lock file.</summary>
+    public required string DataDir { get; init; }
+
+    /// <summary>HTTP port. 0 = let the manager pick a free ephemeral port.</summary>
+    public int Port { get; init; }
+
+    /// <summary>Optional human label exposed via /health.node — Studio shows it
+    /// in the connection picker. Defaults to "node-{port}" inside the child.</summary>
+    public string? NodeName { get; init; }
+
+    /// <summary>Override the binary used to spawn the child. Production sets
+    /// this to <see cref="Environment.ProcessPath"/> implicitly; tests pass
+    /// the path to the built dfdb host because under `dotnet test`
+    /// <see cref="Environment.ProcessPath"/> points at the test runner.</summary>
+    public string? BinaryPath { get; init; }
+}
+
+/// <summary>Internal record of a running child. Studio sees the projection
+/// via <see cref="ManagedServiceInfo"/>.</summary>
+public sealed class ManagedService
+{
+    public int Port { get; init; }
+    public string DataDir { get; init; } = "";
+    public string? NodeName { get; init; }
+    public required Process Process { get; init; }
+    public string LogPath { get; init; } = "";
+    public DateTime StartedAt { get; init; }
+    public string BaseUrl { get; init; } = "";
+    public bool Ready { get; set; }
+    public required StreamWriter LogWriter { get; init; }
+
+    /// <summary>"serve" | "router". Studio shows different chrome
+    /// (icons, connection-add behaviour) per kind.</summary>
+    public string Kind { get; init; } = "serve";
+}
+
+/// <summary>
+/// Options for spawning a <c>dfdb router</c> child. The router is
+/// stateless beyond its config file, so unlike <see cref="SpawnOptions"/>
+/// there's no DataDir — the config path is the only required identity.
+/// </summary>
+public sealed class SpawnRouterOptions
+{
+    /// <summary>Path to the cluster.json the router will load.</summary>
+    public required string ConfigPath { get; init; }
+    /// <summary>HTTP port. 0 = let the manager pick a free ephemeral port.</summary>
+    public int Port { get; init; }
+    /// <summary>Optional human label exposed in the managed-services
+    /// list. Defaults to "router-{port}".</summary>
+    public string? Name { get; init; }
+    /// <summary>Directory to drop the router's stdout/stderr log into.
+    /// Defaults to the config file's directory.</summary>
+    public string? LogDir { get; init; }
+    /// <summary>Override the dfdb binary for tests.</summary>
+    public string? BinaryPath { get; init; }
+}
+
+/// <summary>Public, serializable view of a managed service.</summary>
+public sealed record ManagedServiceInfo(
+    int Port,
+    string DataDir,
+    string? NodeName,
+    string BaseUrl,
+    DateTime StartedAt,
+    bool Running,
+    int? ExitCode,
+    string LogPath,
+    string Kind = "serve");

--- a/src/DocumentForge.Engine/DatabaseRegistry.cs
+++ b/src/DocumentForge.Engine/DatabaseRegistry.cs
@@ -1,0 +1,365 @@
+using DocumentForge.Core;
+
+namespace DocumentForge.Engine;
+
+/// <summary>
+/// Hosts multiple <see cref="DocumentForgeDb"/> instances inside a single
+/// service process — the foundation for Issue #66 (LocalDB-style multi-database
+/// hosting). Each registered database remains a fully independent engine
+/// (own WAL, recovery log, lock file, page cache, index catalog, shard
+/// ring, replication followers); the registry adds nothing more than a
+/// thread-safe name→instance dictionary and lifecycle management.
+///
+/// <para>
+/// Phase 1 (this class): attach/create/detach/drop/get/list verbs and a
+/// designated "default" database for back-compat with single-DB clients
+/// hitting flat <c>/collections/...</c> routes. Lazy open, per-DB quotas,
+/// auth scopes, and SQL <c>USE</c> are later phases of the same issue.
+/// </para>
+///
+/// <para>
+/// Naming rules: case-insensitive on lookup, alphanumeric / underscore /
+/// dash, must start with a letter, 1-64 chars. Operator-supplied casing
+/// is preserved for display.
+/// </para>
+///
+/// <para>
+/// Thread safety: a single internal lock guards the dictionary. Registry
+/// ops (attach, detach) are infrequent compared to data-plane traffic;
+/// once <see cref="Get"/> returns a <see cref="DocumentForgeDb"/>, all
+/// further work runs on the engine's own synchronisation. No lock
+/// contention in the hot path.
+/// </para>
+/// </summary>
+public sealed class DatabaseRegistry : IDisposable
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<string, RegisteredDatabase> _databases
+        = new(StringComparer.OrdinalIgnoreCase);
+    private string? _defaultName;
+    private bool _disposed;
+
+    // Path equality follows the host filesystem: Windows is case-insensitive,
+    // Linux/macOS are case-sensitive. Mis-matching this on Windows would let
+    // the same .dfdb be attached twice (and both engine instances would race
+    // on the lock file).
+    private static readonly StringComparer PathComparer =
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Name of the database that flat REST routes (<c>/collections/...</c>,
+    /// <c>/query</c>, etc.) resolve against. <c>null</c> if no database is
+    /// attached yet. Set automatically to the first attached database;
+    /// override via <see cref="SetDefault"/>.
+    /// </summary>
+    public string? DefaultDatabaseName
+    {
+        get { lock (_lock) return _defaultName; }
+    }
+
+    /// <summary>
+    /// Snapshot of every attached database (immutable copy — safe to
+    /// enumerate without holding the lock).
+    /// </summary>
+    public IReadOnlyList<DatabaseInfo> List()
+    {
+        lock (_lock)
+        {
+            return _databases.Values
+                .Select(e => new DatabaseInfo(
+                    Name: e.Name,
+                    FilePath: e.FilePath,
+                    IsDefault: string.Equals(e.Name, _defaultName, StringComparison.OrdinalIgnoreCase)))
+                .ToList();
+        }
+    }
+
+    /// <summary>
+    /// Attach an existing <c>.dfdb</c> file under <paramref name="name"/>.
+    /// Throws if the name is taken, the canonical file path is already
+    /// attached under a different name, or the engine refuses to open the
+    /// file (corruption, lock contention, missing file).
+    /// </summary>
+    public DocumentForgeDb Attach(string name, string filePath, DatabaseOptions? options = null)
+    {
+        ValidateName(name);
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path is required.", nameof(filePath));
+
+        var canonicalPath = Path.GetFullPath(filePath);
+
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (_databases.ContainsKey(name))
+                throw new DocumentForgeException(
+                    $"Database '{name}' is already attached.");
+
+            foreach (var existing in _databases.Values)
+            {
+                if (PathComparer.Equals(existing.FilePath, canonicalPath))
+                    throw new DocumentForgeException(
+                        $"File '{canonicalPath}' is already attached as database '{existing.Name}'.");
+            }
+
+            // Open OUTSIDE the lock? — no. Open holds the .lock file for the
+            // lifetime of the engine; concurrent Attach calls for *different*
+            // paths could be parallelised, but the simplicity of one global
+            // lock vs. the cost (Attach is called once per DB at service
+            // startup or via admin endpoint) doesn't justify the complexity.
+            var db = DocumentForgeDb.Open(canonicalPath, options);
+            _databases[name] = new RegisteredDatabase(name, canonicalPath, db);
+            _defaultName ??= name;
+            return db;
+        }
+    }
+
+    /// <summary>
+    /// Create a new <c>.dfdb</c> file at <paramref name="filePath"/> and
+    /// attach it under <paramref name="name"/>. Equivalent to SQL Server's
+    /// <c>CREATE DATABASE</c>.
+    /// </summary>
+    public DocumentForgeDb Create(string name, string filePath, DatabaseOptions? options = null)
+    {
+        ValidateName(name);
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path is required.", nameof(filePath));
+
+        var canonicalPath = Path.GetFullPath(filePath);
+        if (File.Exists(canonicalPath))
+            throw new DocumentForgeException(
+                $"Cannot create database '{name}': file '{canonicalPath}' already exists. " +
+                $"Use Attach instead, or choose a different path.");
+
+        // Ensure the directory exists so the engine's Create call doesn't
+        // fail with a cryptic "path not found" deep in DataFile.Create.
+        var dir = Path.GetDirectoryName(canonicalPath);
+        if (!string.IsNullOrEmpty(dir)) Directory.CreateDirectory(dir);
+
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (_databases.ContainsKey(name))
+                throw new DocumentForgeException(
+                    $"Database '{name}' is already attached.");
+
+            var db = DocumentForgeDb.OpenOrCreate(canonicalPath, options);
+            _databases[name] = new RegisteredDatabase(name, canonicalPath, db);
+            _defaultName ??= name;
+            return db;
+        }
+    }
+
+    /// <summary>
+    /// Attach if the file exists; create + attach otherwise. The natural
+    /// verb for service startup ("open the DB at this path; create if
+    /// first time") and admin endpoints where the caller doesn't know
+    /// whether the operator pre-seeded the file.
+    /// </summary>
+    public DocumentForgeDb AttachOrCreate(string name, string filePath, DatabaseOptions? options = null)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+            throw new ArgumentException("File path is required.", nameof(filePath));
+        var canonicalPath = Path.GetFullPath(filePath);
+        return File.Exists(canonicalPath)
+            ? Attach(name, canonicalPath, options)
+            : Create(name, canonicalPath, options);
+    }
+
+    /// <summary>
+    /// Unregister and dispose the named database. The <c>.dfdb</c> file
+    /// stays on disk — re-attach later, or move it to another host.
+    /// Returns <c>false</c> if no database with that name was registered.
+    /// </summary>
+    public bool Detach(string name)
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (!_databases.TryGetValue(name, out var entry))
+                return false;
+
+            _databases.Remove(entry.Name);
+            if (string.Equals(entry.Name, _defaultName, StringComparison.OrdinalIgnoreCase))
+                _defaultName = _databases.Keys.FirstOrDefault();
+
+            // Dispose AFTER removing from the dictionary so a concurrent
+            // Get with the same name returns "not found" rather than a
+            // half-disposed engine.
+            entry.Db.Dispose();
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Detach the database and delete its on-disk files (<c>.dfdb</c>, <c>.wal</c>,
+    /// <c>.recovery</c>, <c>.lock</c>, <c>.followerseq</c>). Irreversible.
+    /// Returns <c>false</c> if no database with that name was registered.
+    /// </summary>
+    public bool Drop(string name)
+    {
+        string? filePath;
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (!_databases.TryGetValue(name, out var entry))
+                return false;
+
+            filePath = entry.FilePath;
+            _databases.Remove(entry.Name);
+            if (string.Equals(entry.Name, _defaultName, StringComparison.OrdinalIgnoreCase))
+                _defaultName = _databases.Keys.FirstOrDefault();
+            entry.Db.Dispose();
+        }
+
+        // File deletion outside the lock — slow I/O has no business blocking
+        // other registry ops, and at this point the engine is already
+        // disposed so the files aren't in use.
+        DeleteSidecarFiles(filePath);
+        return true;
+    }
+
+    /// <summary>
+    /// Resolve <paramref name="name"/> to its engine instance. Throws
+    /// <see cref="DocumentForgeException"/> if not found — the routing
+    /// layer should translate to 404.
+    /// </summary>
+    public DocumentForgeDb Get(string name)
+    {
+        var db = TryGet(name);
+        if (db is null)
+            throw new DocumentForgeException($"Database '{name}' is not attached.");
+        return db;
+    }
+
+    /// <summary>
+    /// Non-throwing variant of <see cref="Get"/>; returns <c>null</c> when
+    /// the name isn't registered.
+    /// </summary>
+    public DocumentForgeDb? TryGet(string name)
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            return _databases.TryGetValue(name, out var entry) ? entry.Db : null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the default database. Throws if no database is attached.
+    /// Used by flat REST routes (<c>/collections/...</c>) for back-compat
+    /// with single-DB clients written before Issue #66.
+    /// </summary>
+    public DocumentForgeDb GetDefault()
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (_defaultName is null)
+                throw new DocumentForgeException(
+                    "No databases are attached. " +
+                    "Attach one via the registry before issuing data-plane requests.");
+            return _databases[_defaultName].Db;
+        }
+    }
+
+    /// <summary>
+    /// Designate <paramref name="name"/> as the database that flat routes
+    /// resolve against. Throws if the name isn't currently attached.
+    /// </summary>
+    public void SetDefault(string name)
+    {
+        lock (_lock)
+        {
+            ThrowIfDisposed();
+            if (!_databases.ContainsKey(name))
+                throw new DocumentForgeException(
+                    $"Cannot set '{name}' as default: not attached.");
+            // Preserve the operator's exact casing from the dictionary's
+            // canonical entry (lookup was case-insensitive).
+            _defaultName = _databases.Keys.First(k =>
+                string.Equals(k, name, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    /// <summary>
+    /// Dispose every attached database. After this call the registry
+    /// rejects all further operations.
+    /// </summary>
+    public void Dispose()
+    {
+        List<RegisteredDatabase> toDispose;
+        lock (_lock)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            toDispose = _databases.Values.ToList();
+            _databases.Clear();
+            _defaultName = null;
+        }
+
+        // Dispose outside the lock — a slow disk flush in one DB must not
+        // block disposal of the others.
+        foreach (var entry in toDispose)
+        {
+            try { entry.Db.Dispose(); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[DocumentForge] WARNING: error disposing database '{entry.Name}': {ex.Message}");
+            }
+        }
+    }
+
+    private void ThrowIfDisposed()
+    {
+        if (_disposed)
+            throw new ObjectDisposedException(nameof(DatabaseRegistry));
+    }
+
+    /// <summary>
+    /// Names must start with a letter and contain only letters, digits,
+    /// underscores, and dashes. Max 64 chars. Constrained on purpose —
+    /// names appear in URLs and SQL, so spaces / quotes / dots would be
+    /// nightmares. Operators wanting "My Database" should pick "my_database".
+    /// </summary>
+    private static void ValidateName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Database name is required.", nameof(name));
+        if (name.Length > 64)
+            throw new ArgumentException(
+                $"Database name '{name}' exceeds 64 characters.", nameof(name));
+        if (!char.IsLetter(name[0]))
+            throw new ArgumentException(
+                $"Database name '{name}' must start with a letter.", nameof(name));
+        foreach (var c in name)
+        {
+            if (!(char.IsLetterOrDigit(c) || c == '_' || c == '-'))
+                throw new ArgumentException(
+                    $"Database name '{name}' contains invalid character '{c}'. " +
+                    $"Allowed: letters, digits, underscore, dash.", nameof(name));
+        }
+    }
+
+    private static void DeleteSidecarFiles(string dataFilePath)
+    {
+        foreach (var ext in new[] { "", ".wal", ".recovery", ".lock", ".followerseq" })
+        {
+            try { File.Delete(dataFilePath + ext); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[DocumentForge] WARNING: failed to delete '{dataFilePath}{ext}': {ex.Message}");
+            }
+        }
+    }
+
+    private sealed record RegisteredDatabase(string Name, string FilePath, DocumentForgeDb Db);
+}
+
+/// <summary>
+/// Public view of an attached database — exposed via <see cref="DatabaseRegistry.List"/>
+/// and the <c>GET /databases</c> endpoint (Phase 2).
+/// </summary>
+public sealed record DatabaseInfo(string Name, string FilePath, bool IsDefault);

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -1591,6 +1591,12 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     /// "leader with no followers yet" and "not a leader at all".</summary>
     public bool IsLogicalLeader => _logicalServer is not null;
 
+    /// <summary>TCP port this DB is listening on as a replication leader,
+    /// or null when not a leader. Studio's topology view uses this to
+    /// match a follower's leader-endpoint ("host:port") back to the DB
+    /// that's leading them when both live in the same service.</summary>
+    public int? LogicalLeaderPort => _logicalServer?.Port;
+
     /// <summary>True if this DB is currently acting as a replication follower
     /// (connected to a leader and applying incoming ops).</summary>
     public bool IsLogicalFollower => _logicalFollower is not null;

--- a/src/DocumentForge.Engine/DocumentForgeDb.cs
+++ b/src/DocumentForge.Engine/DocumentForgeDb.cs
@@ -1585,6 +1585,23 @@ public sealed class DocumentForgeDb : IDisposable, DocumentForge.Transactions.IT
     /// or null if this node isn't a follower.</summary>
     public string? LogicalFollowerLeaderEndpoint => _logicalFollower?.LeaderEndpoint;
 
+    /// <summary>True if this DB is currently acting as a replication leader
+    /// (TCP listener accepting follower connections). Distinct from
+    /// <see cref="GetLogicalFollowerCount"/> which returns 0 both for
+    /// "leader with no followers yet" and "not a leader at all".</summary>
+    public bool IsLogicalLeader => _logicalServer is not null;
+
+    /// <summary>True if this DB is currently acting as a replication follower
+    /// (connected to a leader and applying incoming ops).</summary>
+    public bool IsLogicalFollower => _logicalFollower is not null;
+
+    /// <summary>"leader" | "follower" | "none" — derived from live engine state,
+    /// not from startup config. Issue #66 Phase 2.5 needs this for the
+    /// per-DB <c>/db/{name}/replication/status</c> endpoint, where each
+    /// attached DB has its own dynamically-assignable role.</summary>
+    public string LogicalReplicationRole =>
+        IsLogicalLeader ? "leader" : IsLogicalFollower ? "follower" : "none";
+
     /// <summary>
     /// Start this DB as a logical replication follower (read-only replica).
     /// Applies incoming ops through the engine's own Insert/Delete/CreateIndex so indexes

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -239,6 +239,100 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
     }
 
     [Fact]
+    public async Task ScopedReplication_AlphaLeadsBeta_InsertPropagates()
+    {
+        // The "swarm on one box" demo: two attached DBs in one service,
+        // wire one as leader and the other as its follower over local TCP,
+        // insert into the leader, observe in the follower. Pre-Phase 2.5
+        // this required two `dfdb serve` processes; the scoped routes
+        // make it intra-service.
+        var (registry, baseUrl, _) = BootServer();
+
+        // Phase 1: stand up alpha + beta.
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "alpha" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "beta" });
+
+        // Phase 2: alpha leader on a free TCP port.
+        var replPort = FindFreePort();
+        var leaderResp = await _http.PostAsJsonAsync(
+            $"{baseUrl}/db/alpha/replication/start-leader", new { port = replPort });
+        leaderResp.EnsureSuccessStatusCode();
+
+        // Phase 3: beta dials alpha. Same process — loopback only.
+        var followerResp = await _http.PostAsJsonAsync(
+            $"{baseUrl}/db/beta/replication/start-follower",
+            new { host = "localhost", port = replPort });
+        followerResp.EnsureSuccessStatusCode();
+
+        // Phase 4: wait for handshake to complete. The TCP connect + snapshot
+        // transfer is async; poll status until alpha sees its follower OR
+        // we hit a generous deadline. The deadline guards against a
+        // genuinely broken wiring rather than slow CI — handshake is
+        // usually <100ms on loopback.
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var status = await _http.GetFromJsonAsync<ReplicationStatusResponse>(
+                $"{baseUrl}/db/alpha/replication/status");
+            if (status?.Leader?.FollowerCount > 0) break;
+            await Task.Delay(100);
+        }
+
+        // Phase 5: drive a write through alpha's engine directly (bypassing
+        // the flat /collections route's set-default plumbing) and verify
+        // beta sees it. We use the engine instances from the registry to
+        // keep the test focused on replication, not on route routing.
+        var alpha = registry.Get("alpha");
+        var beta = registry.Get("beta");
+        alpha.Insert("orders", """{"pnr":"REP-A1"}""");
+
+        // Replication is async — wait for the op to land on beta.
+        var seen = false;
+        deadline = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            var rows = beta.Execute("SELECT * FROM orders").Documents;
+            if (rows.Count == 1 && rows[0]["pnr"].AsString == "REP-A1")
+            {
+                seen = true;
+                break;
+            }
+            await Task.Delay(100);
+        }
+        Assert.True(seen, "Beta never received the replicated insert.");
+
+        // Phase 6: status surface — alpha reports beta as a follower,
+        // beta reports alpha as its leader endpoint.
+        var alphaStatus = await _http.GetFromJsonAsync<ReplicationStatusResponse>(
+            $"{baseUrl}/db/alpha/replication/status");
+        var betaStatus = await _http.GetFromJsonAsync<ReplicationStatusResponse>(
+            $"{baseUrl}/db/beta/replication/status");
+        Assert.Equal("leader", alphaStatus!.Role);
+        Assert.True(alphaStatus.Leader!.FollowerCount >= 1);
+        Assert.Equal("follower", betaStatus!.Role);
+        Assert.NotNull(betaStatus.Follower?.Leader);
+        Assert.Equal($"localhost:{replPort}", betaStatus.Follower!.Leader!.Endpoint);
+    }
+
+    [Fact]
+    public async Task ScopedReplication_UnknownDatabase_Returns404()
+    {
+        var (_, baseUrl, _) = BootServer();
+        // No DB called "ghost" — every scoped verb must 404, not 500.
+        var statusResp = await _http.GetAsync($"{baseUrl}/db/ghost/replication/status");
+        Assert.Equal(HttpStatusCode.NotFound, statusResp.StatusCode);
+
+        var leaderResp = await _http.PostAsJsonAsync(
+            $"{baseUrl}/db/ghost/replication/start-leader", new { port = 5500 });
+        Assert.Equal(HttpStatusCode.NotFound, leaderResp.StatusCode);
+
+        var followerResp = await _http.PostAsJsonAsync(
+            $"{baseUrl}/db/ghost/replication/start-follower",
+            new { host = "localhost", port = 5500 });
+        Assert.Equal(HttpStatusCode.NotFound, followerResp.StatusCode);
+    }
+
+    [Fact]
     public async Task SwarmScenario_AttachThreeDropOne_StateConsistent()
     {
         // The user-facing point of Phase 2: "create a swarm on one box."
@@ -283,5 +377,26 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
         public string Name { get; set; } = "";
         public string Action { get; set; } = "";
         public string? DefaultAfter { get; set; }
+    }
+    private sealed class ReplicationStatusResponse
+    {
+        public string Database { get; set; } = "";
+        public string Role { get; set; } = "";
+        public ReplicationLeaderInfo? Leader { get; set; }
+        public ReplicationFollowerInfo? Follower { get; set; }
+    }
+    private sealed class ReplicationLeaderInfo
+    {
+        public ulong CurrentSeq { get; set; }
+        public int FollowerCount { get; set; }
+    }
+    private sealed class ReplicationFollowerInfo
+    {
+        public ulong LastAppliedSeq { get; set; }
+        public ReplicationLeaderEndpoint? Leader { get; set; }
+    }
+    private sealed class ReplicationLeaderEndpoint
+    {
+        public string Endpoint { get; set; } = "";
     }
 }

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -1,0 +1,287 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Net.Sockets;
+using DocumentForge.Cli.Commands;
+using DocumentForge.Engine;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// HTTP integration tests for Issue #66 Phase 2's <c>/databases</c> REST
+/// surface. Boots a minimal Kestrel host wired up with the registry +
+/// <see cref="DatabaseEndpoints.Map"/> and asserts the wire shape +
+/// status codes that Studio (and any other client) rely on.
+/// </summary>
+public sealed class DatabaseEndpointsHttpTests : IDisposable
+{
+    private readonly List<IDisposable> _disposables = new();
+    private readonly List<string> _dirs = new();
+    private static readonly HttpClient _http = new();
+
+    private (DatabaseRegistry registry, string baseUrl, string dataDir) BootServer()
+    {
+        var port = FindFreePort();
+        var dataDir = Path.Combine(Path.GetTempPath(), $"dbep_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dataDir);
+        _dirs.Add(dataDir);
+
+        var registry = new DatabaseRegistry();
+        _disposables.Add(registry);
+
+        var builder = WebApplication.CreateBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls($"http://127.0.0.1:{port}");
+        var app = builder.Build();
+        DatabaseEndpoints.Map(app, registry, dataDir);
+
+        app.StartAsync().GetAwaiter().GetResult();
+        _disposables.Add(new HostStopper(app));
+
+        return (registry, $"http://127.0.0.1:{port}", dataDir);
+    }
+
+    private static int FindFreePort()
+    {
+        using var listener = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    public void Dispose()
+    {
+        for (int i = _disposables.Count - 1; i >= 0; i--)
+        {
+            try { _disposables[i].Dispose(); } catch { }
+        }
+        foreach (var d in _dirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { }
+        }
+    }
+
+    // Helper used to bring Kestrel down cleanly in Dispose.
+    private sealed class HostStopper : IDisposable
+    {
+        private readonly WebApplication _app;
+        public HostStopper(WebApplication app) => _app = app;
+        public void Dispose()
+        {
+            try
+            {
+                using var cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(2));
+                _app.StopAsync(cts.Token).GetAwaiter().GetResult();
+            }
+            catch { }
+            try { _app.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
+        }
+    }
+
+    [Fact]
+    public async Task GetDatabases_EmptyRegistry_ReturnsZero()
+    {
+        var (_, baseUrl, _) = BootServer();
+        var response = await _http.GetAsync($"{baseUrl}/databases");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadFromJsonAsync<DatabasesListResponse>();
+        Assert.NotNull(body);
+        Assert.Equal(0, body!.Count);
+        Assert.Empty(body.Databases);
+        Assert.Null(body.Default);
+    }
+
+    [Fact]
+    public async Task PostDatabases_CreatesNewFile_InDefaultDataDir()
+    {
+        // Path-less POST → registry derives {dataDir}/acme.dfdb. This is
+        // the Studio "+ Add Database" path — operators don't have to know
+        // the on-disk layout.
+        var (_, baseUrl, dataDir) = BootServer();
+
+        var resp = await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "acme" });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var created = await resp.Content.ReadFromJsonAsync<DatabaseEntryResponse>();
+        Assert.NotNull(created);
+        Assert.Equal("acme", created!.Name);
+        Assert.True(created.IsDefault);
+        Assert.Equal(Path.Combine(dataDir, "acme.dfdb"), created.FilePath);
+        Assert.True(File.Exists(created.FilePath));
+    }
+
+    [Fact]
+    public async Task PostDatabases_ExplicitPath_Honoured()
+    {
+        var (_, baseUrl, dataDir) = BootServer();
+        var explicitPath = Path.Combine(dataDir, "weird-name.dfdb");
+
+        var resp = await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "weird", path = explicitPath });
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+        var created = await resp.Content.ReadFromJsonAsync<DatabaseEntryResponse>();
+        Assert.Equal(explicitPath, created!.FilePath);
+        Assert.True(File.Exists(explicitPath));
+    }
+
+    [Fact]
+    public async Task PostDatabases_DuplicateName_Returns409()
+    {
+        // Conflict is the natural status for "this resource already exists".
+        // Studio uses it to render an "already exists" inline error instead
+        // of a generic 500.
+        var (_, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "acme" });
+
+        var dup = await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "acme" });
+        Assert.Equal(HttpStatusCode.Conflict, dup.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostDatabases_InvalidName_Returns400()
+    {
+        var (_, baseUrl, _) = BootServer();
+        var resp = await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "1starts_with_digit" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostDatabases_MissingName_Returns400()
+    {
+        var (_, baseUrl, _) = BootServer();
+        var resp = await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetDatabases_MultipleAttached_AllReturned()
+    {
+        var (_, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "alpha" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "beta" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "gamma" });
+
+        var list = await _http.GetFromJsonAsync<DatabasesListResponse>($"{baseUrl}/databases");
+        Assert.Equal(3, list!.Count);
+        var names = list.Databases.Select(d => d.Name).OrderBy(n => n).ToList();
+        Assert.Equal(new[] { "alpha", "beta", "gamma" }, names);
+        // First attached is implicit default.
+        Assert.Equal("alpha", list.Default);
+    }
+
+    [Fact]
+    public async Task DeleteDatabase_DefaultsToDetach_FileKept()
+    {
+        var (registry, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "acme" });
+        var info = registry.List().First();
+        Assert.True(File.Exists(info.FilePath));
+
+        var resp = await _http.DeleteAsync($"{baseUrl}/databases/acme");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DeleteDatabaseResponse>();
+        Assert.Equal("detached", body!.Action);
+        Assert.True(File.Exists(info.FilePath), "Detach must NOT delete the data file.");
+    }
+
+    [Fact]
+    public async Task DeleteDatabase_DeleteFilesTrue_DropsEverything()
+    {
+        var (registry, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "doomed" });
+        var info = registry.List().First();
+        // Force WAL materialisation so the test proves sidecars are cleaned.
+        registry.Get("doomed").Insert("orders", """{"pnr":"X"}""");
+
+        var resp = await _http.DeleteAsync($"{baseUrl}/databases/doomed?deleteFiles=true");
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DeleteDatabaseResponse>();
+        Assert.Equal("dropped", body!.Action);
+        Assert.False(File.Exists(info.FilePath));
+        foreach (var ext in new[] { ".wal", ".recovery", ".lock", ".followerseq" })
+            Assert.False(File.Exists(info.FilePath + ext));
+    }
+
+    [Fact]
+    public async Task DeleteDatabase_Unknown_Returns404()
+    {
+        var (_, baseUrl, _) = BootServer();
+        var resp = await _http.DeleteAsync($"{baseUrl}/databases/ghost");
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetDefault_SwitchesActiveDatabase()
+    {
+        var (_, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "alpha" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "beta" });
+
+        var resp = await _http.PostAsync($"{baseUrl}/databases/beta/set-default", content: null);
+        resp.EnsureSuccessStatusCode();
+
+        var list = await _http.GetFromJsonAsync<DatabasesListResponse>($"{baseUrl}/databases");
+        Assert.Equal("beta", list!.Default);
+        Assert.Equal(1, list.Databases.Count(d => d.IsDefault));
+    }
+
+    [Fact]
+    public async Task SetDefault_UnknownName_Returns404()
+    {
+        var (_, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "alpha" });
+        var resp = await _http.PostAsync($"{baseUrl}/databases/ghost/set-default", content: null);
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SwarmScenario_AttachThreeDropOne_StateConsistent()
+    {
+        // The user-facing point of Phase 2: "create a swarm on one box."
+        // Drive the registry through the exact sequence Studio would.
+        var (_, baseUrl, _) = BootServer();
+
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "tenant_a" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "tenant_b" });
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "tenant_c" });
+
+        var afterAttach = await _http.GetFromJsonAsync<DatabasesListResponse>($"{baseUrl}/databases");
+        Assert.Equal(3, afterAttach!.Count);
+
+        // Switch active to tenant_b.
+        await _http.PostAsync($"{baseUrl}/databases/tenant_b/set-default", content: null);
+
+        // Drop tenant_a.
+        var drop = await _http.DeleteAsync($"{baseUrl}/databases/tenant_a?deleteFiles=true");
+        drop.EnsureSuccessStatusCode();
+
+        var final = await _http.GetFromJsonAsync<DatabasesListResponse>($"{baseUrl}/databases");
+        Assert.Equal(2, final!.Count);
+        Assert.Equal("tenant_b", final.Default);
+        Assert.DoesNotContain(final.Databases, d => d.Name == "tenant_a");
+    }
+
+    // Response DTOs — narrow shapes for deserialization in tests.
+    private sealed class DatabasesListResponse
+    {
+        public string? Default { get; set; }
+        public int Count { get; set; }
+        public List<DatabaseEntryResponse> Databases { get; set; } = new();
+    }
+    private sealed class DatabaseEntryResponse
+    {
+        public string Name { get; set; } = "";
+        public string FilePath { get; set; } = "";
+        public bool IsDefault { get; set; }
+    }
+    private sealed class DeleteDatabaseResponse
+    {
+        public string Name { get; set; } = "";
+        public string Action { get; set; } = "";
+        public string? DefaultAfter { get; set; }
+    }
+}

--- a/tests/DocumentForge.Tests/DatabaseRegistryTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseRegistryTests.cs
@@ -1,0 +1,395 @@
+using DocumentForge.Core;
+using DocumentForge.Engine;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Phase 1 of Issue #66 (multi-database hosting). Exercises the
+/// <see cref="DatabaseRegistry"/> in isolation — no HTTP layer, no
+/// service plumbing — so regressions point at the right component.
+/// </summary>
+public sealed class DatabaseRegistryTests
+{
+    private static string FreshDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"reg_{label}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void CleanupDir(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Create_NewDatabase_AppearsInListAndIsDefault()
+    {
+        var dir = FreshDir("create");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            var db = registry.Create("acme", Path.Combine(dir, "acme.dfdb"));
+
+            Assert.NotNull(db);
+            Assert.Equal("acme", registry.DefaultDatabaseName);
+
+            var list = registry.List();
+            Assert.Single(list);
+            Assert.Equal("acme", list[0].Name);
+            Assert.True(list[0].IsDefault);
+            Assert.True(File.Exists(list[0].FilePath));
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Attach_ExistingFile_OpensWithoutRecreating()
+    {
+        var dir = FreshDir("attach");
+        var path = Path.Combine(dir, "existing.dfdb");
+        try
+        {
+            // Phase 1: stand up a DB outside the registry so we have a real
+            // file to attach. Insert a doc so the test can prove attach
+            // opens the SAME file (data survives).
+            using (var db = DocumentForgeDb.OpenOrCreate(path))
+            {
+                db.Insert("orders", """{"pnr":"X"}""");
+            }
+
+            using var registry = new DatabaseRegistry();
+            var reattached = registry.Attach("acme", path);
+
+            var rows = reattached.Execute("SELECT * FROM orders").Documents;
+            Assert.Single(rows);
+            Assert.Equal("X", rows[0]["pnr"].AsString);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Attach_DuplicateName_Throws()
+    {
+        var dir = FreshDir("dupname");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            registry.Create("acme", Path.Combine(dir, "a.dfdb"));
+
+            var ex = Assert.Throws<DocumentForgeException>(() =>
+                registry.Create("acme", Path.Combine(dir, "b.dfdb")));
+            Assert.Contains("already attached", ex.Message);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Attach_SameFileUnderDifferentName_Throws()
+    {
+        // Two engine instances racing on the same lock file would corrupt
+        // recovery state. The registry catches the duplicate path up front.
+        var dir = FreshDir("dupfile");
+        var path = Path.Combine(dir, "shared.dfdb");
+        try
+        {
+            using (var bootstrap = DocumentForgeDb.OpenOrCreate(path)) { }
+
+            using var registry = new DatabaseRegistry();
+            registry.Attach("alpha", path);
+
+            var ex = Assert.Throws<DocumentForgeException>(() =>
+                registry.Attach("beta", path));
+            Assert.Contains("already attached as database 'alpha'", ex.Message);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Get_ResolvesIndependentInstances()
+    {
+        // Two attached DBs share no state. A write to one isn't visible
+        // in the other.
+        var dir = FreshDir("isolation");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            var a = registry.Create("a", Path.Combine(dir, "a.dfdb"));
+            var b = registry.Create("b", Path.Combine(dir, "b.dfdb"));
+
+            a.Insert("orders", """{"pnr":"A1"}""");
+
+            Assert.Single(registry.Get("a").Execute("SELECT * FROM orders").Documents);
+            Assert.Empty(registry.Get("b").Execute("SELECT * FROM orders").Documents);
+            // First-attached implicitly becomes default.
+            Assert.Equal("a", registry.DefaultDatabaseName);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Get_CaseInsensitiveLookup()
+    {
+        var dir = FreshDir("case");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            registry.Create("Acme", Path.Combine(dir, "x.dfdb"));
+
+            // All three should resolve to the same engine.
+            Assert.NotNull(registry.Get("Acme"));
+            Assert.NotNull(registry.Get("ACME"));
+            Assert.NotNull(registry.Get("acme"));
+            Assert.Same(registry.Get("Acme"), registry.Get("acme"));
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Get_UnknownName_Throws()
+    {
+        using var registry = new DatabaseRegistry();
+        var ex = Assert.Throws<DocumentForgeException>(() => registry.Get("does_not_exist"));
+        Assert.Contains("not attached", ex.Message);
+    }
+
+    [Fact]
+    public void TryGet_UnknownName_ReturnsNull()
+    {
+        using var registry = new DatabaseRegistry();
+        Assert.Null(registry.TryGet("does_not_exist"));
+    }
+
+    [Fact]
+    public void GetDefault_NoDatabases_Throws()
+    {
+        using var registry = new DatabaseRegistry();
+        var ex = Assert.Throws<DocumentForgeException>(() => registry.GetDefault());
+        Assert.Contains("No databases are attached", ex.Message);
+    }
+
+    [Fact]
+    public void Detach_RemovesAndKeepsFile()
+    {
+        var dir = FreshDir("detach");
+        var path = Path.Combine(dir, "kept.dfdb");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            registry.Create("acme", path);
+            Assert.True(File.Exists(path));
+
+            Assert.True(registry.Detach("acme"));
+            Assert.Empty(registry.List());
+            Assert.Null(registry.DefaultDatabaseName);
+            Assert.True(File.Exists(path), "Detach must NOT delete the data file.");
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Detach_Unknown_ReturnsFalse()
+    {
+        using var registry = new DatabaseRegistry();
+        Assert.False(registry.Detach("ghost"));
+    }
+
+    [Fact]
+    public void Detach_PromotesNextDefault()
+    {
+        // The default is sticky to a single named DB. When that DB is
+        // detached, *some* other attached DB takes over as default so
+        // flat routes still resolve. Order isn't contractually defined
+        // but the property "default is non-null while any DB is attached"
+        // matters — clients hitting /collections/... shouldn't 500.
+        var dir = FreshDir("defaultpromote");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            registry.Create("a", Path.Combine(dir, "a.dfdb"));
+            registry.Create("b", Path.Combine(dir, "b.dfdb"));
+            Assert.Equal("a", registry.DefaultDatabaseName);
+
+            Assert.True(registry.Detach("a"));
+            Assert.Equal("b", registry.DefaultDatabaseName);
+
+            Assert.True(registry.Detach("b"));
+            Assert.Null(registry.DefaultDatabaseName);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Drop_DeletesSidecarFiles()
+    {
+        var dir = FreshDir("drop");
+        var path = Path.Combine(dir, "doomed.dfdb");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            var db = registry.Create("acme", path);
+            // Force WAL/recovery to materialise so we have something to clean up.
+            db.Insert("orders", """{"pnr":"X"}""");
+
+            Assert.True(File.Exists(path));
+            Assert.True(registry.Drop("acme"));
+
+            // Primary file and every sidecar must be gone.
+            Assert.False(File.Exists(path));
+            foreach (var ext in new[] { ".wal", ".recovery", ".lock", ".followerseq" })
+                Assert.False(File.Exists(path + ext),
+                    $"Drop did not clean up sidecar '{path + ext}'.");
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void SetDefault_PointsFlatRoutesAtNamedDb()
+    {
+        var dir = FreshDir("setdefault");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            registry.Create("a", Path.Combine(dir, "a.dfdb"));
+            registry.Create("b", Path.Combine(dir, "b.dfdb"));
+
+            registry.SetDefault("b");
+            Assert.Equal("b", registry.DefaultDatabaseName);
+            Assert.Same(registry.Get("b"), registry.GetDefault());
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void SetDefault_UnknownName_Throws()
+    {
+        using var registry = new DatabaseRegistry();
+        Assert.Throws<DocumentForgeException>(() => registry.SetDefault("ghost"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("1starts_with_digit")]
+    [InlineData("_starts_with_underscore")]
+    [InlineData("has space")]
+    [InlineData("has.dot")]
+    [InlineData("has/slash")]
+    public void Create_InvalidName_Throws(string badName)
+    {
+        var dir = FreshDir("invalid");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            Assert.Throws<ArgumentException>(() =>
+                registry.Create(badName, Path.Combine(dir, "x.dfdb")));
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Create_NameTooLong_Throws()
+    {
+        var dir = FreshDir("toolong");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            var name = "a" + new string('b', 64);  // 65 chars
+            Assert.Throws<ArgumentException>(() =>
+                registry.Create(name, Path.Combine(dir, "x.dfdb")));
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Create_FileAlreadyExists_Throws()
+    {
+        var dir = FreshDir("exists");
+        var path = Path.Combine(dir, "occupied.dfdb");
+        try
+        {
+            // Use OpenOrCreate from the engine to materialise a real file.
+            using (var bootstrap = DocumentForgeDb.OpenOrCreate(path)) { }
+
+            using var registry = new DatabaseRegistry();
+            var ex = Assert.Throws<DocumentForgeException>(() =>
+                registry.Create("acme", path));
+            Assert.Contains("already exists", ex.Message);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void AttachOrCreate_NewFile_Creates()
+    {
+        // Mirrors the ServeCommand path: file may or may not exist. On a
+        // first-run service start the file doesn't exist; this is the
+        // verb that handles it.
+        var dir = FreshDir("attachorcreate_new");
+        var path = Path.Combine(dir, "fresh.dfdb");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            Assert.False(File.Exists(path));
+            var db = registry.AttachOrCreate("default", path);
+            Assert.True(File.Exists(path));
+            db.Insert("orders", """{"pnr":"X"}""");
+            Assert.Single(db.Execute("SELECT * FROM orders").Documents);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void AttachOrCreate_ExistingFile_Attaches()
+    {
+        var dir = FreshDir("attachorcreate_existing");
+        var path = Path.Combine(dir, "preexisting.dfdb");
+        try
+        {
+            using (var seed = DocumentForgeDb.OpenOrCreate(path))
+            {
+                seed.Insert("orders", """{"pnr":"PRESEEDED"}""");
+            }
+
+            using var registry = new DatabaseRegistry();
+            var db = registry.AttachOrCreate("default", path);
+            var rows = db.Execute("SELECT * FROM orders").Documents;
+            Assert.Single(rows);
+            Assert.Equal("PRESEEDED", rows[0]["pnr"].AsString);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Dispose_DisposesAllAttachedDatabases()
+    {
+        // After Dispose, the registry rejects further calls and the engines
+        // are released (file locks freed, so another Open succeeds).
+        var dir = FreshDir("dispose");
+        var path = Path.Combine(dir, "x.dfdb");
+        try
+        {
+            var registry = new DatabaseRegistry();
+            registry.Create("acme", path);
+            registry.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => registry.Get("acme"));
+
+            // The lock was released — reopening succeeds. Pre-dispose this
+            // would throw "file is locked by another process".
+            using var reopen = DocumentForgeDb.Open(path);
+            Assert.NotNull(reopen);
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        using var registry = new DatabaseRegistry();
+        registry.Dispose();
+        // Second dispose must not throw — common pattern in DI lifetimes.
+        registry.Dispose();
+    }
+}

--- a/tests/DocumentForge.Tests/RouterIntegrationTests.cs
+++ b/tests/DocumentForge.Tests/RouterIntegrationTests.cs
@@ -1,0 +1,212 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using DocumentForge.Cli;
+using DocumentForge.Cli.Router;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Real-services router integration. Boots two child <c>dfdb serve</c>
+/// processes (via <see cref="ServiceManager"/>), points a <see cref="Router"/>
+/// at them, and asserts that hash-sharded inserts distribute correctly and
+/// that fan-out queries see every document.
+///
+/// <para>
+/// Slower than the unit tests (~3-5s for both child boots) but covers
+/// the round-trip path applications actually use: client → router →
+/// pick shard → forward HTTP → engine writes → fan-out read → merge.
+/// </para>
+/// </summary>
+public sealed class RouterIntegrationTests : IDisposable
+{
+    private readonly ServiceManager _services = new();
+    private readonly List<string> _dirs = new();
+    private readonly List<ClusterRouter> _routers = new();
+
+    public void Dispose()
+    {
+        foreach (var r in _routers) try { r.Dispose(); } catch { }
+        _services.Dispose();
+        foreach (var d in _dirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { }
+        }
+    }
+
+    private string FreshDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"router_{label}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+        return dir;
+    }
+
+    // Resolve the dfdb binary from the CLI project bin output. Same
+    // pattern as ServiceManagerTests since `dotnet test` runs in the
+    // test runner, not the dfdb apphost.
+    private static string ResolveBinary()
+    {
+        var asmDir = Path.GetDirectoryName(typeof(RouterIntegrationTests).Assembly.Location)!;
+        var conf = new DirectoryInfo(asmDir).Parent!.Name;
+        var path = Path.GetFullPath(Path.Combine(
+            asmDir, "..", "..", "..", "..", "..",
+            "src", "DocumentForge.Cli", "bin", conf, "net9.0",
+            OperatingSystem.IsWindows() ? "dfdb.exe" : "dfdb"));
+        if (!File.Exists(path))
+            throw new InvalidOperationException(
+                $"dfdb binary not found at {path} — build src/DocumentForge.Cli first.");
+        return path;
+    }
+
+    [Fact]
+    public void Router_HashStrategy_DistributesInsertsAcrossShards()
+    {
+        // Spawn two backing dfdb instances on free ports.
+        var binary = ResolveBinary();
+        var ringA = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-a"), BinaryPath = binary });
+        var ringB = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-b"), BinaryPath = binary });
+        Assert.True(ringA.Ready, "ring-a never became ready");
+        Assert.True(ringB.Ready, "ring-b never became ready");
+
+        // Cluster config: orders is hash-sharded across the two ring leaders.
+        var config = new ClusterConfig
+        {
+            Shards =
+            {
+                new ShardConfig { Name = "ring-a", Leader = new ShardEndpoint { BaseUrl = ringA.BaseUrl } },
+                new ShardConfig { Name = "ring-b", Leader = new ShardEndpoint { BaseUrl = ringB.BaseUrl } },
+            },
+            Collections =
+            {
+                new CollectionConfig { Name = "orders", Strategy = ShardStrategy.Hash, ShardKeyPath = "pnr" },
+            },
+        };
+        var router = new ClusterRouter(config);
+        _routers.Add(router);
+
+        // Insert 100 unique-pnr docs through the router.
+        for (int i = 0; i < 100; i++)
+        {
+            using var doc = JsonDocument.Parse($$"""{"pnr":"PNR-{{i:D4}}","amount":{{i}}}""");
+            var resp = router.InsertAsync("orders", doc.RootElement).GetAwaiter().GetResult();
+            Assert.True(resp.IsSuccessStatusCode, $"insert {i} failed: {resp.StatusCode}");
+        }
+
+        // Probe each ring directly: every doc must land on exactly one
+        // of the two rings (no replication, no duplication). Distribution
+        // should be roughly even — FNV-1a over 100 distinct keys.
+        var ringADocs = CountOrdersOn(ringA.BaseUrl);
+        var ringBDocs = CountOrdersOn(ringB.BaseUrl);
+        Assert.Equal(100, ringADocs + ringBDocs);
+        // Loose distribution bound — chi-square would be overkill; just
+        // catch egregious "all docs on one ring" failures.
+        Assert.InRange(ringADocs, 30, 70);
+        Assert.InRange(ringBDocs, 30, 70);
+
+        // Fan-out query via the router merges both rings' results.
+        var queryResult = router.QueryAsync("SELECT * FROM orders").GetAwaiter().GetResult();
+        Assert.True(queryResult.GetProperty("documents").GetArrayLength() == 100,
+            $"fan-out merge returned {queryResult.GetProperty("documents").GetArrayLength()} docs, expected 100");
+        Assert.Equal(100, queryResult.GetProperty("count").GetInt32());
+        Assert.Equal(2, queryResult.GetProperty("shards").GetInt32());
+    }
+
+    [Fact]
+    public void Router_ReplicatedStrategy_FansInsertToEveryShard()
+    {
+        // For lookup tables and reference data, every ring needs the
+        // same content. The router fans the insert to every leader.
+        var binary = ResolveBinary();
+        var ringA = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-a"), BinaryPath = binary });
+        var ringB = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-b"), BinaryPath = binary });
+        Assert.True(ringA.Ready && ringB.Ready);
+
+        var config = new ClusterConfig
+        {
+            Shards =
+            {
+                new ShardConfig { Name = "ring-a", Leader = new ShardEndpoint { BaseUrl = ringA.BaseUrl } },
+                new ShardConfig { Name = "ring-b", Leader = new ShardEndpoint { BaseUrl = ringB.BaseUrl } },
+            },
+            Collections =
+            {
+                new CollectionConfig { Name = "lookup", Strategy = ShardStrategy.Replicated },
+            },
+        };
+        var router = new ClusterRouter(config);
+        _routers.Add(router);
+
+        for (int i = 0; i < 5; i++)
+        {
+            using var doc = JsonDocument.Parse($$"""{"code":"L{{i}}","label":"Label {{i}}"}""");
+            var resp = router.InsertAsync("lookup", doc.RootElement).GetAwaiter().GetResult();
+            Assert.True(resp.IsSuccessStatusCode);
+        }
+
+        // Each ring should hold a full copy.
+        var ringACount = CountLookupOn(ringA.BaseUrl);
+        var ringBCount = CountLookupOn(ringB.BaseUrl);
+        Assert.Equal(5, ringACount);
+        Assert.Equal(5, ringBCount);
+
+        // Replicated read goes to one ring (the first) — no fan-out
+        // since the data is identical everywhere.
+        var queryResult = router.QueryAsync("SELECT * FROM lookup").GetAwaiter().GetResult();
+        Assert.Equal(5, queryResult.GetProperty("documents").GetArrayLength());
+    }
+
+    [Fact]
+    public void Router_UndeclaredCollection_DefaultsToSingleShard()
+    {
+        // Casual workflow: you wire up a router but haven't declared
+        // every collection's strategy yet. Undeclared collections
+        // should pin to shards[0] rather than crash — keeps the
+        // "spin up a router and start poking" UX smooth.
+        var binary = ResolveBinary();
+        var ringA = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-a"), BinaryPath = binary });
+        var ringB = _services.Spawn(new SpawnOptions { DataDir = FreshDir("ring-b"), BinaryPath = binary });
+        Assert.True(ringA.Ready && ringB.Ready);
+
+        var config = new ClusterConfig
+        {
+            Shards =
+            {
+                new ShardConfig { Name = "ring-a", Leader = new ShardEndpoint { BaseUrl = ringA.BaseUrl } },
+                new ShardConfig { Name = "ring-b", Leader = new ShardEndpoint { BaseUrl = ringB.BaseUrl } },
+            },
+            // No collection declarations.
+        };
+        var router = new ClusterRouter(config);
+        _routers.Add(router);
+
+        using var doc = JsonDocument.Parse("""{"name":"Acme","tier":"gold"}""");
+        var resp = router.InsertAsync("customers", doc.RootElement).GetAwaiter().GetResult();
+        Assert.True(resp.IsSuccessStatusCode);
+
+        Assert.Equal(1, CountCustomersOn(ringA.BaseUrl));
+        Assert.Equal(0, CountCustomersOn(ringB.BaseUrl));
+    }
+
+    // -------------------------------------------------------------- helpers
+
+    private static int CountOrdersOn(string baseUrl) => CountCollectionOn(baseUrl, "orders");
+    private static int CountLookupOn(string baseUrl) => CountCollectionOn(baseUrl, "lookup");
+    private static int CountCustomersOn(string baseUrl) => CountCollectionOn(baseUrl, "customers");
+    private static int CountCollectionOn(string baseUrl, string collection)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        // SELECT * FROM <col> is the simplest portable query. Counting
+        // .documents.length avoids depending on a "SELECT COUNT(*)" path
+        // that might not be implemented yet.
+        var req = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/query")
+        {
+            Content = JsonContent.Create(new { sql = $"SELECT * FROM {collection}" }),
+        };
+        var resp = http.SendAsync(req).GetAwaiter().GetResult();
+        var body = resp.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        if (!resp.IsSuccessStatusCode) return 0; // collection might not exist yet on this ring
+        using var doc = JsonDocument.Parse(body);
+        return doc.RootElement.GetProperty("documents").GetArrayLength();
+    }
+}

--- a/tests/DocumentForge.Tests/RouterTests.cs
+++ b/tests/DocumentForge.Tests/RouterTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using DocumentForge.Cli.Router;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Unit tests for the routing brain. Cover the hash-key extraction +
+/// shard selection arithmetic directly so failures localise. The
+/// HTTP fan-out + end-to-end "two backing services behind a router"
+/// flow lives in <see cref="RouterIntegrationTests"/> — slower, real
+/// Kestrel hosts, real cross-process replication style.
+/// </summary>
+public sealed class RouterUnitTests
+{
+    [Fact]
+    public void ClusterConfig_AcceptsBareUrlStringForLegacyCompat()
+    {
+        // The /cluster page produced this format pre-multi-DB. Has to
+        // continue to load without modification — that's the upgrade
+        // path for existing configs.
+        var json = """
+        {
+          "shards": [
+            { "name": "ring-a", "leader": "http://localhost:5001", "followers": ["http://localhost:5002"] }
+          ],
+          "collections": [
+            { "name": "orders", "strategy": "hash", "shardKeyPath": "pnr" }
+          ]
+        }
+        """;
+        var cfg = ClusterConfig.FromJson(json);
+        Assert.Equal("http://localhost:5001", cfg.Shards[0].Leader!.BaseUrl);
+        Assert.Null(cfg.Shards[0].Leader!.Database);
+        Assert.Equal("http://localhost:5002", cfg.Shards[0].Followers[0].BaseUrl);
+    }
+
+    [Fact]
+    public void ClusterConfig_AcceptsObjectFormWithDatabase()
+    {
+        // The new multi-DB-aware format: endpoint is an object that
+        // names the attached DB on the target service.
+        var json = """
+        {
+          "shards": [
+            { "name": "ring-a",
+              "leader": { "baseUrl": "http://localhost:5099", "database": "ring_a" },
+              "followers": []
+            }
+          ]
+        }
+        """;
+        var cfg = ClusterConfig.FromJson(json);
+        Assert.Equal("ring_a", cfg.Shards[0].Leader!.Database);
+        Assert.Equal("/db/ring_a", cfg.Shards[0].Leader!.PathPrefix);
+    }
+
+    [Fact]
+    public void ClusterConfig_ValidatesShardKeyForHashStrategy()
+    {
+        var json = """
+        {
+          "shards": [{ "name": "ring-a", "leader": "http://localhost:5000" }],
+          "collections": [{ "name": "orders", "strategy": "hash" }]
+        }
+        """;
+        var ex = Assert.Throws<InvalidOperationException>(() => ClusterConfig.FromJson(json));
+        Assert.Contains("shardKeyPath", ex.Message);
+    }
+
+    [Fact]
+    public void ClusterConfig_ValidatesAtLeastOneShard()
+    {
+        var json = """{ "shards": [] }""";
+        var ex = Assert.Throws<InvalidOperationException>(() => ClusterConfig.FromJson(json));
+        Assert.Contains("at least one shard", ex.Message);
+    }
+
+    [Fact]
+    public void ExtractKey_TopLevelString()
+    {
+        var doc = JsonDocument.Parse("""{"pnr":"ABC123","amount":42}""").RootElement;
+        Assert.Equal("ABC123", ClusterRouter.ExtractKey(doc, "pnr"));
+    }
+
+    [Fact]
+    public void ExtractKey_DottedPath()
+    {
+        // Composite shard keys ("customer.id") are common in real
+        // OMS schemas — orders shard by customer to keep a single
+        // customer's data on one ring.
+        var doc = JsonDocument.Parse("""{"customer":{"id":"C-7","name":"Acme"}}""").RootElement;
+        Assert.Equal("C-7", ClusterRouter.ExtractKey(doc, "customer.id"));
+    }
+
+    [Fact]
+    public void ExtractKey_Missing_ReturnsNull()
+    {
+        var doc = JsonDocument.Parse("""{"pnr":"X"}""").RootElement;
+        Assert.Null(ClusterRouter.ExtractKey(doc, "customer.id"));
+    }
+
+    [Fact]
+    public void Fnv1a32_DistributesEvenly_AcrossThreeShards()
+    {
+        // Sanity: for a stream of pnr-like strings, FNV-1a should
+        // hit each of N shards within a reasonable tolerance. Loose
+        // bound — we just want to catch egregious bucket bias.
+        const int total = 3000;
+        var counts = new int[3];
+        for (int i = 0; i < total; i++)
+        {
+            var h = ClusterRouter.Fnv1a32($"PNR-{i:D5}");
+            counts[h % 3u]++;
+        }
+        var min = counts.Min();
+        var max = counts.Max();
+        Assert.True(max < min * 1.5,
+            $"Hash distribution skewed badly: {counts[0]} / {counts[1]} / {counts[2]}");
+    }
+
+    [Fact]
+    public void TryExtractCollectionFromSql_ReadsTheFromClause()
+    {
+        Assert.Equal("orders", ClusterRouter.TryExtractCollectionFromSql("SELECT * FROM orders LIMIT 50"));
+        Assert.Equal("orders", ClusterRouter.TryExtractCollectionFromSql("select pnr from orders where status='OK'"));
+        Assert.Equal("orders_archive", ClusterRouter.TryExtractCollectionFromSql("SELECT * FROM orders_archive"));
+    }
+
+    [Fact]
+    public void TryExtractCollectionFromSql_NoFromClause_ReturnsNull()
+    {
+        Assert.Null(ClusterRouter.TryExtractCollectionFromSql("DELETE FROM"));  // no name after FROM
+        Assert.Null(ClusterRouter.TryExtractCollectionFromSql("not-sql"));
+    }
+}

--- a/tests/DocumentForge.Tests/ServiceManagerTests.cs
+++ b/tests/DocumentForge.Tests/ServiceManagerTests.cs
@@ -1,0 +1,145 @@
+using DocumentForge.Cli;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Issue #66 Phase 5: the <see cref="ServiceManager"/> spawns real
+/// child <c>dfdb serve</c> processes. These tests exercise the
+/// lifecycle (spawn, ready-probe, list, stop, dispose) against the
+/// actual binary built into the CLI project's bin output — so the
+/// path-resolution + arg-passing + process-tree-kill semantics
+/// are covered, not mocked away.
+///
+/// <para>
+/// Cost: each spawn boots a .NET 9 host (~1-2s cold) and binds Kestrel
+/// on a free port. The full suite stays under ~10s by sharing a manager
+/// across the test class and minimising spawns.
+/// </para>
+/// </summary>
+public sealed class ServiceManagerTests : IDisposable
+{
+    private readonly List<string> _dirs = new();
+    private readonly ServiceManager _manager = new();
+
+    public void Dispose()
+    {
+        _manager.Dispose();
+        foreach (var d in _dirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { }
+        }
+    }
+
+    private string FreshDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"svc_{label}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+        return dir;
+    }
+
+    // Resolve the dfdb binary built into the CLI project's bin output.
+    // Under `dotnet test`, Environment.ProcessPath points at the test
+    // runner, not dfdb — so we discover the apphost via a relative path
+    // from the test assembly's location.
+    private static string ResolveBinary()
+    {
+        var asmDir = Path.GetDirectoryName(typeof(ServiceManagerTests).Assembly.Location)!;
+        // tests/DocumentForge.Tests/bin/<conf>/net9.0 → src/DocumentForge.Cli/bin/<conf>/net9.0/dfdb.exe
+        var conf = new DirectoryInfo(asmDir).Parent!.Name; // Debug or Release
+        var candidate = Path.GetFullPath(Path.Combine(
+            asmDir, "..", "..", "..", "..", "..",
+            "src", "DocumentForge.Cli", "bin", conf, "net9.0",
+            OperatingSystem.IsWindows() ? "dfdb.exe" : "dfdb"));
+        if (!File.Exists(candidate))
+            throw new InvalidOperationException(
+                $"Could not find dfdb binary at {candidate}. " +
+                $"Build src/DocumentForge.Cli before running ServiceManager tests.");
+        return candidate;
+    }
+
+    [Fact]
+    public void Spawn_ProducesRunningServiceOnFreePort()
+    {
+        var dir = FreshDir("spawn");
+        var svc = _manager.Spawn(new SpawnOptions
+        {
+            DataDir = dir,
+            BinaryPath = ResolveBinary(),
+        });
+
+        Assert.True(svc.Port > 0, "spawn must allocate a port");
+        Assert.StartsWith("http://localhost:", svc.BaseUrl);
+        Assert.True(svc.Ready, $"child did not become ready within timeout. Log:\n{_manager.ReadLog(svc.Port)}");
+
+        // /health on the child must answer 200.
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
+        var resp = http.GetAsync($"{svc.BaseUrl}/health").GetAwaiter().GetResult();
+        Assert.True(resp.IsSuccessStatusCode);
+    }
+
+    [Fact]
+    public void List_ReflectsRunningChildren()
+    {
+        var dir = FreshDir("list");
+        var svc = _manager.Spawn(new SpawnOptions { DataDir = dir, BinaryPath = ResolveBinary() });
+
+        var entries = _manager.List();
+        Assert.Contains(entries, e => e.Port == svc.Port && e.Running);
+    }
+
+    [Fact]
+    public void Stop_TerminatesAndReaps()
+    {
+        var dir = FreshDir("stop");
+        var svc = _manager.Spawn(new SpawnOptions { DataDir = dir, BinaryPath = ResolveBinary() });
+
+        Assert.True(_manager.Stop(svc.Port));
+        Assert.DoesNotContain(_manager.List(), e => e.Port == svc.Port);
+
+        // After stop, the child's HTTP port stops listening (give the OS
+        // a beat to release it before asserting).
+        Thread.Sleep(500);
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(1) };
+        var caught = false;
+        try { _ = http.GetAsync($"{svc.BaseUrl}/health").GetAwaiter().GetResult(); }
+        catch { caught = true; }
+        Assert.True(caught, "child still answered /health after Stop");
+    }
+
+    [Fact]
+    public void Stop_UnknownPort_ReturnsFalse()
+    {
+        Assert.False(_manager.Stop(63999));  // arbitrary unmanaged port
+    }
+
+    [Fact]
+    public void Spawn_RejectsDuplicatePort()
+    {
+        var dir = FreshDir("dupport");
+        var svc = _manager.Spawn(new SpawnOptions { DataDir = dir, BinaryPath = ResolveBinary() });
+
+        // Same explicit port → ServiceManager refuses to track a second.
+        var dir2 = FreshDir("dupport2");
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            _manager.Spawn(new SpawnOptions { DataDir = dir2, Port = svc.Port, BinaryPath = ResolveBinary() }));
+        Assert.Contains("already managed", ex.Message);
+    }
+
+    [Fact]
+    public void ReadLog_CapturesChildOutput()
+    {
+        // The child writes its banner ("dfdb serve" + listening URL) to
+        // stdout right after Kestrel starts. The manager tees output to a
+        // per-child log; ReadLog should surface those lines.
+        var dir = FreshDir("logs");
+        var svc = _manager.Spawn(new SpawnOptions { DataDir = dir, BinaryPath = ResolveBinary() });
+
+        // Give the log writer a moment to flush — the redirected pipe
+        // event handlers are best-effort.
+        Thread.Sleep(500);
+        var log = _manager.ReadLog(svc.Port);
+        Assert.Contains("dfdb serve", log, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the visible portion of Issue #66 — one process now hosts N attached databases, and Studio gets a click-to-add swarm-builder UI. Drop a name, hit Enter, watch a fresh .dfdb file land on the service.

Combines **Phase 1** (registry plumbing) and **Phase 2** (REST + Studio) into one shippable feature. Phases 3 (lazy open + quotas) and 4 (auth scopes + cross-DB SELECTs) remain for follow-up PRs.

## What's in

### Phase 1 — `DatabaseRegistry`

Thread-safe holder of named `DocumentForgeDb` instances. Each engine remains fully independent (own WAL, recovery log, lock file, page cache, shard ring, replication followers). Registry adds one dictionary lookup; no hot-path cost.

| Verb | Behaviour |
|---|---|
| `Attach(name, path)` | Register an existing `.dfdb` |
| `Create(name, path)` | Make a new `.dfdb`, register |
| `AttachOrCreate(name, path)` | Open-or-create — the ServeCommand path |
| `Detach(name)` | Unregister + dispose, keep files |
| `Drop(name)` | Detach + delete files (`.dfdb`, `.wal`, `.recovery`, `.lock`, `.followerseq`) |
| `Get(name)` / `TryGet(name)` | Resolve by name (case-insensitive) |
| `GetDefault()` | Designated default for flat routes |
| `SetDefault(name)` | Override default |
| `List()` | Snapshot of attached DBs |
| `Dispose()` | Cascade dispose every engine |

ServeCommand now does:
```csharp
var registry = new DatabaseRegistry();
var db = registry.AttachOrCreate("default", dbPath);
```
Flat routes (`/collections/...`) continue to work and resolve via `registry.GetDefault()` — zero migration tax for single-DB users.

### Phase 2 — REST `/databases` surface

New `DatabaseEndpoints.Map(app, registry, dataDir)` mounts:

```
GET    /databases                          — list
POST   /databases                          — create-or-attach
DELETE /databases/{name}                   — detach
DELETE /databases/{name}?deleteFiles=true  — drop
POST   /databases/{name}/set-default       — switch flat-route target
```

Path is optional on POST — defaults to `{dataDir}/{name}.dfdb` so Studio's "+" button works without the operator thinking about filesystem layout.

### Phase 2 — Studio swarm-builder

- **`/databases` page** — name input + optional path → Create. List of attached DBs with Active / Detach / Drop. Animated pulse on the newly-created row. Drop has a confirm dialog with "irreversible" wording.
- **Sidebar** — 🗃 Databases nav link + an active-database indicator block below the connection picker showing the default DB name and `+N` badge when multiple are attached. Gracefully hides when connected to a pre-#66 service.
- **`lib/api.ts`** — `listDatabases` / `createDatabase` / `deleteDatabase` / `setDefaultDatabase`.

## What's NOT in (deferred)

- **Phase 3**: lazy open + idle eviction + per-DB quotas (required for the small-tenant prod case to scale past ~10 DBs)
- **Phase 4**: Bearer auth scopes (`db:foo`) + scoped data-plane routes `/db/{name}/...` + cross-DB SELECTs
- Multi-tenant flat-route resolution (Phase 4) — for now `set-default` is the per-service "I'm working on DB X" switch. Fine for local dev + single-developer Studio sessions; replaced by per-request auth scoping in Phase 4.

## Test plan

- [x] **Phase 1**: 28 `DatabaseRegistryTests` — attach/create/attach-or-create/detach/drop/get/list/dispose, case-insensitive lookup, duplicate-path guards, default promotion on detach, invalid-name parametrized theory, dispose-frees-locks, idempotent dispose
- [x] **Phase 2**: 13 `DatabaseEndpointsHttpTests` — booting real Kestrel hosts, asserting status codes (201/200/404/409/400) and wire shape; `SwarmScenario_AttachThreeDropOne_StateConsistent` validates the full create→switch→drop sequence
- [x] **Full backend suite**: 260/260 pass (no regressions)
- [x] **Studio production build green** — `/databases` route weighs in at 4.82 kB
- [x] **End-to-end smoke** with `dfdb serve` + curl:
  - Created `tenant_a` / `tenant_b` / `tenant_c` with auto-derived paths
  - `set-default` flipped active to `tenant_b`
  - Drop with `deleteFiles=true` cleaned `tenant_a.dfdb` plus every sidecar (`.wal`, `.recovery`, `.lock`)
  - Final registry state: 3 DBs, `tenant_b` active, on-disk files exactly match

## Files

```
src/DocumentForge.Engine/DatabaseRegistry.cs         (new, 300 lines)
src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs  (new, 110 lines)
src/DocumentForge.Cli/Commands/ServeCommand.cs       (registry plumbing)
tests/DocumentForge.Tests/DatabaseRegistryTests.cs   (new, 28 tests)
tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs (new, 13 tests)
admin-ui/app/databases/page.tsx                      (new — the swarm-builder UI)
admin-ui/app/Sidebar.tsx                             (nav link + indicator)
admin-ui/app/globals.css                             (.db-indicator block)
admin-ui/lib/api.ts                                  (4 new verbs + types)
```

Refs #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)