### PR TITLE
feat(#73): persist scoped API keys in _system DB + /admin/keys CRUD

### DIFF
--- a/src/DocumentForge.Cli/Auth/KeyStore.cs
+++ b/src/DocumentForge.Cli/Auth/KeyStore.cs
@@ -1,0 +1,265 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using DocumentForge.Core;
+using DocumentForge.Engine;
+
+namespace DocumentForge.Cli.Auth;
+
+/// <summary>
+/// Issue #73 (follow-up to #72) — persistent storage for scoped API
+/// keys. Keys live in the auto-attached <c>_system</c> database's
+/// <c>_keys</c> collection (so they replicate + survive restarts like
+/// any other DocumentForge data) but are also held in an in-memory
+/// cache so the auth middleware does a single hash-table lookup per
+/// request, not a database query.
+///
+/// <para>
+/// Lifecycle:
+/// <list type="number">
+///   <item>Service startup → <see cref="Reload"/> reads every doc in
+///     <c>_keys</c> into the cache.</item>
+///   <item>Auth middleware → <see cref="TryAuthenticate"/> hashes the
+///     incoming Bearer token and looks it up in O(1).</item>
+///   <item><c>POST /admin/keys</c> → <see cref="CreateKey"/> writes
+///     to the collection and updates the cache. The plaintext secret
+///     is returned ONCE to the caller and never stored anywhere.</item>
+///   <item><c>DELETE /admin/keys/{id}</c> → <see cref="RevokeKey"/>
+///     deletes the doc and evicts the cache entry.</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Hashing: SHA-256 of the UTF-8 bytes of the token, hex-encoded. We
+/// don't bcrypt/argon2 because the tokens are 32-byte random secrets
+/// (256 bits of entropy); the slow-by-design KDFs exist to defeat
+/// dictionary attacks on low-entropy human-chosen passwords, which
+/// these aren't. SHA-256 is fast + collision-resistant + sufficient.
+/// </para>
+/// </summary>
+public sealed class KeyStore
+{
+    private const string SystemDbName = "_system";
+    // Collection name without underscore so the SQL lexer doesn't have
+    // to special-case identifier rules. The containing DB is _system,
+    // which already signals internal use.
+    private const string KeysCollection = "keys";
+
+    private readonly DatabaseRegistry _registry;
+    private readonly object _lock = new();
+    // hash → record. ConstantTimeEquals is only relevant against an
+    // attacker who can time the response — a HashSet lookup leaks
+    // existence-by-position-in-bucket but the bucket is one of many,
+    // and the lookup is followed by string compare in any case.
+    private readonly Dictionary<string, StoredKey> _byHash
+        = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, StoredKey> _byId
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public KeyStore(DatabaseRegistry registry)
+    {
+        _registry = registry;
+    }
+
+    /// <summary>True once the _system DB exists + reload has run at
+    /// least once. While false the auth middleware skips KeyStore
+    /// lookups (bootstrap window — only the config admin key works).</summary>
+    public bool Ready { get; private set; }
+
+    /// <summary>Read the entire <c>_keys</c> collection into the cache.
+    /// Called once at service startup. Cheap — keys are small docs and
+    /// even a thousand-key deployment is microseconds to load.</summary>
+    public void Reload()
+    {
+        var systemDb = _registry.TryGet(SystemDbName);
+        if (systemDb is null)
+        {
+            // No _system DB attached yet (e.g. first-boot before
+            // ServeCommand finishes wiring). Stay "not ready" and
+            // succeed silently — the next Reload() picks it up.
+            return;
+        }
+
+        lock (_lock)
+        {
+            _byHash.Clear();
+            _byId.Clear();
+            var result = systemDb.Execute($"SELECT * FROM {KeysCollection}");
+            if (result.Success && result.Documents is not null)
+            {
+                foreach (var doc in result.Documents)
+                {
+                    var stored = StoredKey.FromDocument(doc);
+                    if (stored is null) continue;
+                    _byHash[stored.KeyHash] = stored;
+                    _byId[stored.Id] = stored;
+                }
+            }
+            Ready = true;
+        }
+    }
+
+    /// <summary>O(1) lookup. Returns null when the token doesn't match
+    /// any stored key; otherwise an <see cref="AuthContext"/> built from
+    /// the stored scopes.</summary>
+    public AuthContext? TryAuthenticate(string token)
+    {
+        if (!Ready || string.IsNullOrEmpty(token)) return null;
+        var hash = HashToken(token);
+        lock (_lock)
+        {
+            if (!_byHash.TryGetValue(hash, out var stored)) return null;
+            return AuthContext.FromScopes(stored.Scopes, stored.Description ?? $"key:{stored.Id[..8]}");
+        }
+    }
+
+    /// <summary>Mint a new key with the given scopes. Returns the
+    /// plaintext secret — caller is responsible for showing it ONCE
+    /// to the operator. Never returned again; lost = revoke + recreate.</summary>
+    public CreateKeyResult CreateKey(IEnumerable<string> scopes, string? description)
+    {
+        var scopesList = scopes?.Where(s => !string.IsNullOrWhiteSpace(s)).Select(s => s.Trim()).ToList()
+            ?? new List<string>();
+        if (scopesList.Count == 0)
+            throw new ArgumentException("At least one scope is required.", nameof(scopes));
+
+        var systemDb = _registry.TryGet(SystemDbName)
+            ?? throw new InvalidOperationException(
+                "_system DB is not attached. Cannot persist keys.");
+
+        var secret = GenerateSecret();
+        var hash = HashToken(secret);
+        var id = Guid.NewGuid().ToString("N");
+
+        var stored = new StoredKey(id, hash, scopesList, description, DateTime.UtcNow);
+        var json = JsonSerializer.Serialize(new
+        {
+            id,
+            keyHash = hash,
+            scopes = scopesList,
+            description,
+            createdAt = stored.CreatedAt.ToString("O"),
+        });
+        systemDb.Insert(KeysCollection, json);
+
+        lock (_lock)
+        {
+            _byHash[hash] = stored;
+            _byId[id] = stored;
+        }
+
+        return new CreateKeyResult(id, secret, stored);
+    }
+
+    /// <summary>Revoke a key by id. Returns false when the id isn't
+    /// known. Effective immediately — the next request bearing that
+    /// token gets 401.</summary>
+    public bool RevokeKey(string id)
+    {
+        StoredKey? stored;
+        lock (_lock)
+        {
+            if (!_byId.TryGetValue(id, out stored)) return false;
+            _byHash.Remove(stored.KeyHash);
+            _byId.Remove(id);
+        }
+
+        var systemDb = _registry.TryGet(SystemDbName);
+        if (systemDb is not null)
+        {
+            // Remove from disk too. The SQL engine doesn't have parameterised
+            // queries yet so we inline the id — safe because GUIDs only
+            // contain hex characters, can't break out of the quote.
+            systemDb.Execute($"DELETE FROM {KeysCollection} WHERE id = '{id}'");
+        }
+        return true;
+    }
+
+    /// <summary>Public projection of every stored key — id + scopes +
+    /// description + createdAt. Never includes the hash or plaintext.</summary>
+    public IReadOnlyList<KeyInfo> List()
+    {
+        lock (_lock)
+        {
+            return _byId.Values
+                .Select(s => new KeyInfo(s.Id, s.Scopes.ToList(), s.Description, s.CreatedAt))
+                .OrderBy(k => k.CreatedAt)
+                .ToList();
+        }
+    }
+
+    public int Count
+    {
+        get { lock (_lock) return _byId.Count; }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>SHA-256(token) → lowercase hex. The tokens are 32-byte
+    /// random secrets so a fast hash is fine; slow KDFs (bcrypt, argon2)
+    /// solve a problem we don't have here.</summary>
+    public static string HashToken(string token)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>Generate a fresh 32-byte URL-safe secret. The "df_"
+    /// prefix makes leaked tokens recognisable in log scrapers + GitHub
+    /// secret scanners.</summary>
+    private static string GenerateSecret()
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return "df_" + Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+}
+
+public sealed record StoredKey(
+    string Id,
+    string KeyHash,
+    List<string> Scopes,
+    string? Description,
+    DateTime CreatedAt)
+{
+    public static StoredKey? FromDocument(Document.BsonDocument doc)
+    {
+        try
+        {
+            if (!doc.ContainsKey("id") || !doc.ContainsKey("keyHash") || !doc.ContainsKey("scopes"))
+                return null;
+            var id = doc["id"].AsString;
+            var hash = doc["keyHash"].AsString;
+            string? description = null;
+            if (doc.ContainsKey("description") && doc["description"].Type == Document.BsonType.String)
+                description = doc["description"].AsString;
+            // The engine recognises ISO 8601 strings and stores them as
+            // native DateTime — so the BsonValue could be either Type.String
+            // (we round-tripped a fresh insert via SQL) or Type.DateTime
+            // (we Insert()'d JSON and the parser typed it). Handle both.
+            DateTime createdAt;
+            var ca = doc["createdAt"];
+            if (ca.Type == Document.BsonType.DateTime)
+                createdAt = ca.AsDateTime.UtcDateTime;
+            else
+                createdAt = DateTime.Parse(ca.AsString,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind);
+            var scopes = new List<string>();
+            var scopesValue = doc["scopes"];
+            if (scopesValue.Type == Document.BsonType.Array)
+            {
+                foreach (var s in scopesValue.AsArray.Items)
+                    if (s.Type == Document.BsonType.String) scopes.Add(s.AsString);
+            }
+            if (string.IsNullOrEmpty(id) || string.IsNullOrEmpty(hash) || scopes.Count == 0)
+                return null;
+            return new StoredKey(id, hash, scopes, description, createdAt);
+        }
+        catch { return null; }
+    }
+}
+
+public sealed record KeyInfo(string Id, List<string> Scopes, string? Description, DateTime CreatedAt);
+
+public sealed record CreateKeyResult(string Id, string Secret, StoredKey Stored);

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -36,10 +36,14 @@ public static class DatabaseEndpoints
         // List every attached database. Stable shape across phases.
         // Admin-scoped: enumerating tenants would leak names to a
         // restricted key, which is what scoped keys exist to prevent.
+        // The _system DB (Issue #73) is hidden from this view — it's
+        // an implementation detail surfaced through /admin/* instead.
         app.MapGet("/databases", (HttpContext ctx) =>
         {
             if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
-            var entries = registry.List();
+            var entries = registry.List()
+                .Where(e => !IsInternalDatabase(e.Name))
+                .ToList();
             return Results.Ok(new
             {
                 @default = registry.DefaultDatabaseName,
@@ -96,6 +100,8 @@ public static class DatabaseEndpoints
         app.MapDelete("/databases/{name}", (HttpContext ctx, string name, bool? deleteFiles) =>
         {
             if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            if (IsInternalDatabase(name))
+                return Results.BadRequest(new { error = $"Database '{name}' is a system DB and cannot be detached or dropped." });
             try
             {
                 var drop = deleteFiles == true;
@@ -319,6 +325,12 @@ public static class DatabaseEndpoints
             catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
     }
+
+    // Issue #73 — names beginning with an underscore are reserved for
+    // internal use (currently just "_system"). The check is in one place
+    // so adding "_audit" / "_metrics" / etc. later only touches here.
+    private static bool IsInternalDatabase(string name) =>
+        !string.IsNullOrEmpty(name) && name.StartsWith("_", StringComparison.Ordinal);
 }
 
 // Phase 3a — scoped query body. Same field as the flat QueryRequest in

--- a/src/DocumentForge.Cli/Commands/KeysEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/KeysEndpoints.cs
@@ -1,0 +1,74 @@
+using DocumentForge.Cli.Auth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// Issue #73 — admin REST surface for managed (persisted) scoped API
+/// keys. The Studio "Keys" page calls these; operators with the admin
+/// bearer can also drive them by curl. Keys live in the auto-attached
+/// <c>_system._keys</c> collection via <see cref="KeyStore"/>; the
+/// in-memory cache means lookups stay O(1) on the hot path even with
+/// hundreds of keys.
+///
+/// <para>
+/// All endpoints are admin-scoped (the existing legacy <c>apiKey</c>
+/// or a key carrying <c>*</c>). Issuing a tenant key shouldn't be
+/// possible from a tenant-scoped key.
+/// </para>
+/// </summary>
+public static class KeysEndpoints
+{
+    public static void Map(IEndpointRouteBuilder app, KeyStore keyStore)
+    {
+        // List every stored key. Returns id + scopes + description +
+        // createdAt — never the hash, never the plaintext.
+        app.MapGet("/admin/keys", (HttpContext ctx) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            var entries = keyStore.List();
+            return Results.Ok(new { count = entries.Count, keys = entries });
+        });
+
+        // Mint a new key. The plaintext secret is in the response
+        // exactly ONCE — the operator must copy it now or rotate later.
+        // The hash is what's persisted; the secret never touches disk.
+        app.MapPost("/admin/keys", (HttpContext ctx, CreateKeyRequest req) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            try
+            {
+                var result = keyStore.CreateKey(req.Scopes ?? new(), req.Description);
+                return Results.Created($"/admin/keys/{result.Id}", new
+                {
+                    id = result.Id,
+                    // The ONE-TIME plaintext. Caller must store this now.
+                    secret = result.Secret,
+                    scopes = result.Stored.Scopes,
+                    description = result.Stored.Description,
+                    createdAt = result.Stored.CreatedAt,
+                    warning = "Store the 'secret' now — it cannot be retrieved later. Lost key = revoke + regenerate.",
+                });
+            }
+            catch (ArgumentException ex) { return Results.BadRequest(new { error = ex.Message }); }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // Revoke a key. Effective immediately — the next request bearing
+        // that secret gets 401. No undo; the only path back is to mint
+        // a fresh key with the same scopes.
+        app.MapDelete("/admin/keys/{id}", (HttpContext ctx, string id) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            var removed = keyStore.RevokeKey(id);
+            if (!removed)
+                return Results.NotFound(new { error = $"Key '{id}' not found." });
+            return Results.Ok(new { id, revoked = true });
+        });
+    }
+}
+
+/// <summary>Body for POST /admin/keys.</summary>
+public record CreateKeyRequest(List<string>? Scopes, string? Description = null);

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -65,6 +65,15 @@ public static class ServeCommand
         var registry = new DatabaseRegistry();
         var db = registry.AttachOrCreate("default", dbPath);
 
+        // Issue #73: auto-attach the _system DB alongside default. Holds
+        // managed keys, audit log (future), runtime config overrides
+        // (future). Treated as undeletable; hidden from /databases
+        // listings so it doesn't clutter the Studio sidebar.
+        var systemDbPath = Path.Combine(config.DataDir, "_system.dfdb");
+        registry.AttachOrCreate("_system", systemDbPath);
+        var keyStore = new Auth.KeyStore(registry);
+        keyStore.Reload();
+
         // Optional replication wiring - leader / follower / none
         var replicationSummary = StartReplication(db, config);
 
@@ -86,7 +95,13 @@ public static class ServeCommand
         // per-DB / admin / read-vs-write decisions.
         var adminKey = config.Security?.ApiKey;
         var scopedKeys = config.Security?.ScopedKeys ?? new List<ScopedApiKey>();
-        var devMode = string.IsNullOrEmpty(adminKey) && scopedKeys.Count == 0;
+        // Dev mode = nothing in node.json AND nothing in the _system
+        // DB. Computed lazily per request so that adding the first key
+        // via POST /admin/keys *immediately* closes the dev-mode door
+        // without restart. (Equivalent to SQL Server's "mixed auth"
+        // tipping into real auth the moment a sa login exists.)
+        Func<bool> isDevMode = () =>
+            string.IsNullOrEmpty(adminKey) && scopedKeys.Count == 0 && keyStore.Count == 0;
         app.Use(async (ctx, next) =>
         {
             if (ctx.Request.Method == "OPTIONS") { await next(); return; }
@@ -99,7 +114,7 @@ public static class ServeCommand
                 return;
             }
 
-            if (devMode)
+            if (isDevMode())
             {
                 ctx.Items[Auth.AuthContext.ContextKey] = Auth.AuthContext.DevMode();
                 await next();
@@ -123,9 +138,19 @@ public static class ServeCommand
                 return;
             }
 
-            // Scoped-key match. Iterate to keep constant-time per-key
-            // comparison; an attacker can't time-fingerprint which
-            // configured key they're closest to.
+            // Issue #73: persistent scoped keys. O(1) hash lookup against
+            // the KeyStore's in-memory cache; no DB round-trip per request.
+            var fromStore = keyStore.TryAuthenticate(token);
+            if (fromStore is not null)
+            {
+                ctx.Items[Auth.AuthContext.ContextKey] = fromStore;
+                await next();
+                return;
+            }
+
+            // Config-file scoped keys (back-compat for node.json users).
+            // Iterates because the list is tiny + constant-time per-key
+            // comparison removes timing side-channels.
             foreach (var sk in scopedKeys)
             {
                 if (string.IsNullOrEmpty(sk.Key)) continue;
@@ -226,6 +251,11 @@ public static class ServeCommand
         var serviceManager = new ServiceManager();
         ServiceEndpoints.Map(app, serviceManager, config.DataDir);
 
+        // Issue #73: managed (persisted) API keys. CRUD endpoints under
+        // /admin/keys — all admin-scoped, backed by _system._keys via
+        // the KeyStore set up above.
+        KeysEndpoints.Map(app, keyStore);
+
         // Dispose the registry on shutdown — it cascades to every attached
         // database, including the Phase 1 single "default" one. The service
         // manager is disposed first so child processes are reaped before
@@ -261,6 +291,7 @@ public static class ServeCommand
         Console.WriteLine("  databases: GET  /databases | POST /databases | DELETE /databases/{name}");
         Console.WriteLine("             POST /databases/{name}/set-default");
         Console.WriteLine("  services:  GET  /services | POST /services | DELETE /services/{port}");
+        Console.WriteLine("  keys:      GET  /admin/keys | POST /admin/keys | DELETE /admin/keys/{id}");
         Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
         Console.WriteLine("             POST /admin/compact/{collection}");
         Console.WriteLine("             POST /admin/rebuild-indexes/{collection}");

--- a/src/DocumentForge.Engine/DatabaseRegistry.cs
+++ b/src/DocumentForge.Engine/DatabaseRegistry.cs
@@ -318,10 +318,13 @@ public sealed class DatabaseRegistry : IDisposable
     }
 
     /// <summary>
-    /// Names must start with a letter and contain only letters, digits,
-    /// underscores, and dashes. Max 64 chars. Constrained on purpose —
-    /// names appear in URLs and SQL, so spaces / quotes / dots would be
-    /// nightmares. Operators wanting "My Database" should pick "my_database".
+    /// Names must start with a letter or underscore and contain only
+    /// letters, digits, underscores, and dashes. Max 64 chars. Constrained
+    /// on purpose — names appear in URLs and SQL, so spaces / quotes /
+    /// dots would be nightmares. Underscore-prefix is reserved by
+    /// convention for engine-internal databases (Issue #73 — _system);
+    /// the registry permits the syntax but the routing layer hides
+    /// underscore-prefixed names from the public /databases listing.
     /// </summary>
     private static void ValidateName(string name)
     {
@@ -330,9 +333,9 @@ public sealed class DatabaseRegistry : IDisposable
         if (name.Length > 64)
             throw new ArgumentException(
                 $"Database name '{name}' exceeds 64 characters.", nameof(name));
-        if (!char.IsLetter(name[0]))
+        if (!char.IsLetter(name[0]) && name[0] != '_')
             throw new ArgumentException(
-                $"Database name '{name}' must start with a letter.", nameof(name));
+                $"Database name '{name}' must start with a letter or underscore.", nameof(name));
         foreach (var c in name)
         {
             if (!(char.IsLetterOrDigit(c) || c == '_' || c == '-'))

--- a/tests/DocumentForge.Tests/DatabaseRegistryTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseRegistryTests.cs
@@ -272,7 +272,6 @@ public sealed class DatabaseRegistryTests
     [InlineData("")]
     [InlineData("  ")]
     [InlineData("1starts_with_digit")]
-    [InlineData("_starts_with_underscore")]
     [InlineData("has space")]
     [InlineData("has.dot")]
     [InlineData("has/slash")]
@@ -284,6 +283,23 @@ public sealed class DatabaseRegistryTests
             using var registry = new DatabaseRegistry();
             Assert.Throws<ArgumentException>(() =>
                 registry.Create(badName, Path.Combine(dir, "x.dfdb")));
+        }
+        finally { CleanupDir(dir); }
+    }
+
+    [Fact]
+    public void Create_UnderscorePrefixedName_IsAllowed()
+    {
+        // Issue #73 relaxed the name rule: engine-internal databases
+        // (the auto-attached _system) need an underscore prefix; the
+        // routing layer (DatabaseEndpoints) hides them from /databases.
+        var dir = FreshDir("underscore");
+        try
+        {
+            using var registry = new DatabaseRegistry();
+            var db = registry.Create("_system", Path.Combine(dir, "system.dfdb"));
+            Assert.NotNull(db);
+            Assert.NotNull(registry.TryGet("_system"));
         }
         finally { CleanupDir(dir); }
     }

--- a/tests/DocumentForge.Tests/KeyStoreTests.cs
+++ b/tests/DocumentForge.Tests/KeyStoreTests.cs
@@ -1,0 +1,228 @@
+using DocumentForge.Cli.Auth;
+using DocumentForge.Engine;
+using Xunit;
+
+namespace DocumentForge.Tests;
+
+/// <summary>
+/// Issue #73 — <see cref="KeyStore"/> integration tests. The store
+/// uses a real DocumentForge DB as its backing collection, so these
+/// tests boot an actual <see cref="DatabaseRegistry"/> with an attached
+/// <c>_system</c> DB on disk; failures point at real persistence bugs
+/// (lost docs, stale cache, dangling revokes), not mocks.
+/// </summary>
+public sealed class KeyStoreTests : IDisposable
+{
+    private readonly List<string> _dirs = new();
+
+    public void Dispose()
+    {
+        foreach (var d in _dirs)
+        {
+            try { Directory.Delete(d, recursive: true); } catch { }
+        }
+    }
+
+    private (DatabaseRegistry registry, string dir) FreshRegistry(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ks_{label}_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+
+        var registry = new DatabaseRegistry();
+        registry.AttachOrCreate("default", Path.Combine(dir, "default.dfdb"));
+        registry.AttachOrCreate("_system", Path.Combine(dir, "_system.dfdb"));
+        return (registry, dir);
+    }
+
+    [Fact]
+    public void CreateKey_PersistsAndAuthenticates()
+    {
+        var (registry, _) = FreshRegistry("create");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+
+        var result = store.CreateKey(new[] { "db:tenant_a" }, "test key");
+        Assert.NotNull(result.Secret);
+        Assert.StartsWith("df_", result.Secret);
+        Assert.Equal(1, store.Count);
+
+        // Authenticate via the returned plaintext.
+        var ctx = store.TryAuthenticate(result.Secret);
+        Assert.NotNull(ctx);
+        Assert.True(ctx!.CanReadDb("tenant_a"));
+        Assert.True(ctx.CanWriteDb("tenant_a"));
+        Assert.False(ctx.CanWriteDb("tenant_b"));
+    }
+
+    [Fact]
+    public void CreateKey_PlaintextNeverStoredInDb()
+    {
+        // The cache holds the hash, never the plaintext. Verify by
+        // walking the backing collection directly — there should be
+        // a `keyHash` field but no `key` / `secret`.
+        var (registry, _) = FreshRegistry("noplaintext");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        var result = store.CreateKey(new[] { "*" }, "admin-substitute");
+
+        var systemDb = registry.Get("_system");
+        var docs = systemDb.Execute("SELECT * FROM keys").Documents;
+        Assert.Single(docs);
+        var doc = docs[0];
+        Assert.True(doc.ContainsKey("keyHash"));
+        Assert.False(doc.ContainsKey("key"));
+        Assert.False(doc.ContainsKey("secret"));
+        // And it's not the plaintext.
+        Assert.NotEqual(result.Secret, doc["keyHash"].AsString);
+    }
+
+    [Fact]
+    public void Reload_ReadsKeysFromDisk()
+    {
+        // Simulate a service restart by recreating the KeyStore against
+        // the same registry. The keys must reappear.
+        var (registry, _) = FreshRegistry("reload");
+        using var _ = registry;
+
+        var store1 = new KeyStore(registry);
+        store1.Reload();
+        var minted = store1.CreateKey(new[] { "db:foo" }, "first store");
+
+        var store2 = new KeyStore(registry);
+        store2.Reload();
+        Assert.Equal(1, store2.Count);
+        var ctx = store2.TryAuthenticate(minted.Secret);
+        Assert.NotNull(ctx);
+        Assert.True(ctx!.CanReadDb("foo"));
+    }
+
+    [Fact]
+    public void RevokeKey_RemovesFromCacheAndDisk()
+    {
+        var (registry, _) = FreshRegistry("revoke");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        var minted = store.CreateKey(new[] { "db:bar" }, "throwaway");
+        Assert.Equal(1, store.Count);
+
+        Assert.True(store.RevokeKey(minted.Id));
+        Assert.Equal(0, store.Count);
+        Assert.Null(store.TryAuthenticate(minted.Secret));
+
+        // On reload, the revoke must have hit disk too — else a restart
+        // would resurrect the revoked key, which is a security regression.
+        var store2 = new KeyStore(registry);
+        store2.Reload();
+        Assert.Equal(0, store2.Count);
+        Assert.Null(store2.TryAuthenticate(minted.Secret));
+    }
+
+    [Fact]
+    public void RevokeKey_UnknownId_ReturnsFalse()
+    {
+        var (registry, _) = FreshRegistry("revokeghost");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        Assert.False(store.RevokeKey("does-not-exist"));
+    }
+
+    [Fact]
+    public void TryAuthenticate_WrongToken_ReturnsNull()
+    {
+        var (registry, _) = FreshRegistry("wrongtoken");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        store.CreateKey(new[] { "*" }, "real key");
+        // Looks like a valid token (df_ prefix + base64-ish) but isn't ours.
+        Assert.Null(store.TryAuthenticate("df_thiswillneverexistshouldnotmatch"));
+        Assert.Null(store.TryAuthenticate(""));
+    }
+
+    [Fact]
+    public void CreateKey_EmptyScopes_Throws()
+    {
+        var (registry, _) = FreshRegistry("noscopes");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        Assert.Throws<ArgumentException>(() =>
+            store.CreateKey(Array.Empty<string>(), "should fail"));
+        Assert.Throws<ArgumentException>(() =>
+            store.CreateKey(new[] { "", "   " }, "whitespace only"));
+    }
+
+    [Fact]
+    public void List_ReturnsKeyInfoWithoutHashOrSecret()
+    {
+        // The List() projection is what /admin/keys returns to the
+        // operator. It must NOT include the key hash, the plaintext,
+        // or anything else an attacker could use.
+        var (registry, _) = FreshRegistry("list");
+        using var _ = registry;
+
+        var store = new KeyStore(registry);
+        store.Reload();
+        store.CreateKey(new[] { "db:a" }, "alpha");
+        store.CreateKey(new[] { "db:b" }, "beta");
+
+        var entries = store.List();
+        Assert.Equal(2, entries.Count);
+        foreach (var info in entries)
+        {
+            Assert.False(string.IsNullOrEmpty(info.Id));
+            Assert.NotEmpty(info.Scopes);
+            // KeyInfo is the public projection. The record itself
+            // doesn't have a hash or secret field — that's the
+            // contract that's tested elsewhere by compile-time
+            // (the property doesn't exist).
+        }
+    }
+
+    [Fact]
+    public void Reload_NoSystemDb_StaysNotReadyButDoesNotThrow()
+    {
+        // The KeyStore is constructed BEFORE ServeCommand attaches
+        // _system in the bootstrap path. It must tolerate that
+        // window — Reload should silently do nothing and Ready
+        // should stay false.
+        var registryWithoutSystem = new DatabaseRegistry();
+        var dir = Path.Combine(Path.GetTempPath(), $"ks_no_system_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(dir);
+        _dirs.Add(dir);
+        registryWithoutSystem.AttachOrCreate("default", Path.Combine(dir, "default.dfdb"));
+        // NO _system attached.
+
+        using var _ = registryWithoutSystem;
+        var store = new KeyStore(registryWithoutSystem);
+        store.Reload();
+        Assert.False(store.Ready);
+        Assert.Equal(0, store.Count);
+        Assert.Null(store.TryAuthenticate("anything"));
+    }
+
+    [Fact]
+    public void HashToken_IsStableAndCaseSensitive()
+    {
+        // Same token → same hash; one byte difference → different hash.
+        // SHA-256 is the contract; this test pins the algorithm choice
+        // so a future swap to argon2/bcrypt is intentional, not silent.
+        var h1 = KeyStore.HashToken("df_abc");
+        var h2 = KeyStore.HashToken("df_abc");
+        var h3 = KeyStore.HashToken("df_abd");
+        Assert.Equal(h1, h2);
+        Assert.NotEqual(h1, h3);
+        Assert.Equal(64, h1.Length);  // 32 bytes → 64 hex chars
+    }
+}


### PR DESCRIPTION
Phase 7a of the post-1.0 work. Scoped API keys now live in an auto-attached \`_system\` database (eat-our-own-dog-food) and are minted / revoked through admin REST endpoints — no service restart needed.

Closes the open thread from #72 where keys had to be edited in node.json.

## Bootstrap model

```
node.json apiKey  (bootstrap admin / dev sa)
  → opens the door to /admin/keys
        → every other key lives in _system.keys
```

Mirrors SQL Server: one sa-account in config, all other logins managed via SQL. Tipping into multi-key mode is the moment the first scoped key is minted; \`isDevMode\` becomes false dynamically (no restart).

## Performance

**Zero hot-path regression.** The KeyStore holds an in-memory \`Dictionary<sha256(token), StoredKey>\`. Per-request auth = one hash + one O(1) lookup. The DB is consulted only at boot (Reload) and on key writes / revokes — so even a 10k-key deployment is ~bytes of memory and same latency as before.

## REST surface (admin-scoped)

```
GET    /admin/keys                → list (id + scopes + description; no secrets, no hash)
POST   /admin/keys                → mint; returns plaintext df_<base64> ONCE
DELETE /admin/keys/{id}           → revoke; effective immediately
```

## Security choices

- **Plaintext returned exactly once.** SHA-256 hash is what's persisted; if the operator loses the secret, the only recovery is mint + revoke.
- **SHA-256 not bcrypt/argon2** — keys are 32-byte random tokens (256 bits entropy). Slow KDFs defeat dictionary attacks on low-entropy human passwords, which these aren't.
- **\`df_\` token prefix** — recognisable in log scrapers and GitHub's secret scanner.
- **Underscore-prefix DBs are internal** — \`_system\` and any future \`_audit\` / \`_metrics\` are hidden from public \`/databases\` listings and refuse Detach / Drop.

## Files

- \`src/DocumentForge.Cli/Auth/KeyStore.cs\` — cache + persistence
- \`src/DocumentForge.Cli/Commands/KeysEndpoints.cs\` — admin REST
- \`src/DocumentForge.Cli/Commands/ServeCommand.cs\` — \`_system\` auto-attach + middleware wiring
- \`src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs\` — hide / protect internal DBs
- \`src/DocumentForge.Engine/DatabaseRegistry.cs\` — allow underscore-prefix names

## Test plan

- [x] 10 new \`KeyStoreTests\` (create, persist, reload, revoke, unknown id, wrong token, empty scopes, list-projection, no-_system tolerance, SHA-256 stability)
- [x] 305/305 backend tests pass (2 known flakies excluded — both unrelated)
- [x] Live smoke: 8-step lifecycle (no-bearer 401 → mint → tenant scope passes → cross-tenant 403 → admin-only 403 → revoke → revoked-token 401)

## Studio integration (next: Phase 7b)

Once this lands, Studio gets:
- \`/admin/keys\` page (list + Generate + Revoke)
- Inline "Generate matching keys?" prompt when creating a database in /topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)