### PR TITLE
chore(release): cut 1.1.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <!-- Shared NuGet metadata. Per-project csproj files control whether to pack. -->
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>DocumentForge contributors</Authors>
     <Company>DocumentForge</Company>
     <Product>DocumentForge</Product>

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar() {
         marginTop: 'auto', fontSize: 11, color: '#666',
         fontFamily: 'var(--mono)', letterSpacing: '0.05em', paddingTop: 40
       }}>
-        v1.0.0 · MIT
+        v1.1.0 · MIT
       </div>
     </aside>
   );

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Admin UI for DocumentForge clusters",
   "scripts": {

--- a/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
@@ -89,7 +89,7 @@ public static class RouterEndpoints
             status = "ok",
             node = "router",
             role = "router",
-            version = "1.0.0",
+            version = "1.1.0",
             configPath = Path.GetFullPath(configPath),
             shards = router.Config.Shards.Count,
             collections = router.Config.Collections.Count,

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -928,7 +928,7 @@ public static class ServeCommand
             {
                 status = healthy ? "ok" : "degraded",
                 node = config.NodeName,
-                version = "1.0.0",
+                version = "1.1.0",
                 readOnly = db.IsReadOnly,
                 uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1),
                 health = healthy ? null : new

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -53,7 +53,7 @@ public class Program
 
     private static int PrintVersion()
     {
-        Console.WriteLine("dfdb 1.0.0");
+        Console.WriteLine("dfdb 1.1.0");
         Console.WriteLine("DocumentForge - embedded JSON document database with replication and sharding");
         return 0;
     }


### PR DESCRIPTION
Version bump from 1.0.0 → 1.1.0. Binaries built; tag + GitHub release follow merge.