### PR TITLE
ci: tag images with semver on v*.*.* push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ name: Build & publish dfdb images
 on:
   push:
     branches: [master]
+    # Versioned releases — push a v1.2.3 tag and the workflow tags the
+    # images with 1.2.3, 1.2, and 1 alongside the master `latest`.
+    tags: ['v*.*.*']
   workflow_dispatch:
 
 concurrency:
@@ -76,6 +79,10 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=master-,format=short
+            # Push-on-tag (e.g. v1.1.0) → 1.1.0 + 1.1 + 1.
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Lightweight workflow extension. When a `v1.2.3` tag is pushed, the existing release workflow also publishes `:1.2.3`, `:1.2`, and `:1` Docker image tags alongside the master `latest` + `master-<sha>`. So consumers can pin to any of the three semver tracks.

No effect on the master-push behaviour.