### PR TITLE
feat(#83): Browse & attach panel + bump to 1.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <!-- Shared NuGet metadata. Per-project csproj files control whether to pack. -->
   <PropertyGroup>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Authors>DocumentForge contributors</Authors>
     <Company>DocumentForge</Company>
     <Product>DocumentForge</Product>

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar() {
         marginTop: 'auto', fontSize: 11, color: '#666',
         fontFamily: 'var(--mono)', letterSpacing: '0.05em', paddingTop: 40
       }}>
-        v1.1.0 · MIT
+        v1.1.1 · MIT
       </div>
     </aside>
   );

--- a/admin-ui/app/databases/page.tsx
+++ b/admin-ui/app/databases/page.tsx
@@ -8,7 +8,9 @@ import {
   createDatabase,
   deleteDatabase,
   setDefaultDatabase,
+  listUnattachedDatabases,
   type DatabaseEntry,
+  type UnattachedFile,
 } from '@/lib/api';
 
 // Issue #66 Phase 2 — "create a swarm on one box" lives here. Drop a name
@@ -30,6 +32,17 @@ export default function DatabasesPage() {
   const [createError, setCreateError] = useState<string | null>(null);
   const [pulse, setPulse] = useState<string | null>(null);
 
+  // Issue #83 — "Browse & attach" panel state. Surfaces .dfdb files on
+  // disk that aren't currently attached, so the operator doesn't have to
+  // type absolute paths or wait for the next service restart.
+  const [unattached, setUnattached] = useState<UnattachedFile[]>([]);
+  const [unattachedDataDir, setUnattachedDataDir] = useState<string | null>(null);
+  const [scanRecursive, setScanRecursive] = useState(false);
+  const [scanning, setScanning] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [attaching, setAttaching] = useState<string | null>(null);
+  const [renameDrafts, setRenameDrafts] = useState<Record<string, string>>({});
+
   async function refresh() {
     setLoading(true);
     setError(null);
@@ -45,6 +58,48 @@ export default function DatabasesPage() {
   }
 
   useEffect(() => { refresh(); /* eslint-disable-next-line */ }, [active?.id]);
+
+  async function scanUnattached(recursive: boolean) {
+    setScanning(true);
+    setScanError(null);
+    setScanRecursive(recursive);
+    try {
+      const resp = await listUnattachedDatabases({ recursive });
+      setUnattached(resp.files);
+      setUnattachedDataDir(resp.dataDir);
+      // Seed rename inputs to the suggested name so the operator
+      // can attach without typing in the no-conflict case.
+      const drafts: Record<string, string> = {};
+      for (const f of resp.files) drafts[f.path] = f.suggestedName;
+      setRenameDrafts(drafts);
+    } catch (e: any) {
+      setScanError(e.message || String(e));
+    } finally {
+      setScanning(false);
+    }
+  }
+
+  async function attachUnattached(file: UnattachedFile) {
+    const name = (renameDrafts[file.path] || file.suggestedName).trim();
+    if (!name) {
+      setScanError('Pick a name first.');
+      return;
+    }
+    setAttaching(file.path);
+    setScanError(null);
+    try {
+      await createDatabase(name, { path: file.path, createIfMissing: false });
+      // Pulse the new row in the attached list, drop it from the scan results.
+      setPulse(name);
+      setTimeout(() => setPulse(p => (p === name ? null : p)), 900);
+      setUnattached(curr => curr.filter(f => f.path !== file.path));
+      await refresh();
+    } catch (e: any) {
+      setScanError(`Attach failed: ${e.message || String(e)}`);
+    } finally {
+      setAttaching(null);
+    }
+  }
 
   async function onCreate(e?: React.FormEvent) {
     e?.preventDefault();
@@ -160,6 +215,112 @@ export default function DatabasesPage() {
         {createError && (
           <div style={{ marginTop: 12, padding: 8, background: 'rgba(217,4,41,0.06)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12 }}>
             ✗ {createError}
+          </div>
+        )}
+      </div>
+
+      {/* Issue #83 — Browse & attach panel. Sits between the Add form
+          (operator-driven) and the attached-DBs list (state). Scans the
+          service's data-dir for *.dfdb files not currently attached and
+          lets the operator one-click attach them — useful for:
+          * 1.0.x → 1.1.x upgrades where attach state was lost
+          * dropping a backup .dfdb into a mounted volume
+          * recovering after an accidental Detach */}
+      <div className="card" style={{ marginBottom: 24 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.08em', textTransform: 'uppercase', color: 'var(--red)', fontWeight: 700, marginBottom: 4 }}>
+              ⌕ Browse & attach
+            </div>
+            <div style={{ fontSize: 12, color: 'var(--gray-500)' }}>
+              Scan the service's data dir for <code style={{ fontFamily: 'var(--mono)' }}>.dfdb</code> files that aren't attached yet. Pick a name + click Attach — no path typing needed.
+            </div>
+          </div>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'var(--gray-500)', cursor: 'pointer' }} title="Search subfolders too (useful for backup folders, container volumes with nested layouts).">
+            <input
+              type="checkbox"
+              checked={scanRecursive}
+              onChange={e => setScanRecursive(e.target.checked)}
+              disabled={scanning}
+            />
+            Recurse subfolders
+          </label>
+          <button
+            onClick={() => scanUnattached(scanRecursive)}
+            disabled={scanning}
+            style={ghostBtn()}
+          >
+            {scanning ? 'Scanning…' : '⌕ Scan'}
+          </button>
+        </div>
+
+        {unattachedDataDir && (
+          <div style={{ marginTop: 10, fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>
+            data dir: {unattachedDataDir}{scanRecursive ? ' (recursive)' : ''}
+          </div>
+        )}
+
+        {scanError && (
+          <div style={{ marginTop: 12, padding: 8, background: 'rgba(217,4,41,0.06)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12 }}>
+            ✗ {scanError}
+          </div>
+        )}
+
+        {unattachedDataDir !== null && !scanning && unattached.length === 0 && !scanError && (
+          <div style={{ marginTop: 12, fontSize: 13, color: 'var(--gray-500)' }}>
+            No unattached <code style={{ fontFamily: 'var(--mono)' }}>.dfdb</code> files found{scanRecursive ? ' (recursive scan)' : ''}. Everything on disk is already attached.
+          </div>
+        )}
+
+        {unattached.length > 0 && (
+          <div style={{ marginTop: 14, display: 'grid', gap: 8 }}>
+            {unattached.map(f => {
+              const isAttaching = attaching === f.path;
+              const draft = renameDrafts[f.path] ?? f.suggestedName;
+              return (
+                <div
+                  key={f.path}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 200px auto',
+                    gap: 10,
+                    alignItems: 'center',
+                    padding: 10,
+                    border: '1px solid var(--gray-200)',
+                    background: f.nameConflict ? 'rgba(217,4,41,0.03)' : 'white',
+                    opacity: isAttaching ? 0.5 : 1,
+                  }}
+                >
+                  <div>
+                    <div style={{ fontFamily: 'var(--mono)', fontSize: 12, wordBreak: 'break-all' }}>
+                      {f.path}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--gray-500)', marginTop: 2 }}>
+                      {(f.sizeBytes / 1024).toFixed(1)} KB · modified {new Date(f.modifiedUtc).toLocaleString()}
+                      {f.nameConflict && (
+                        <span style={{ color: 'var(--red)', marginLeft: 8 }}>
+                          ⚠ name <code style={{ fontFamily: 'var(--mono)' }}>{f.suggestedName}</code> already attached — pick another
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <input
+                    type="text"
+                    value={draft}
+                    onChange={e => setRenameDrafts(d => ({ ...d, [f.path]: e.target.value }))}
+                    placeholder="name"
+                    style={inputStyle()}
+                  />
+                  <button
+                    onClick={() => attachUnattached(f)}
+                    disabled={isAttaching || !draft.trim()}
+                    style={primaryBtn(isAttaching || !draft.trim())}
+                  >
+                    {isAttaching ? 'Attaching…' : '+ Attach'}
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -322,6 +322,32 @@ export async function setDefaultDatabase(name: string, opts?: CallOptions) {
   return handle(r);
 }
 
+// Issue #83 — list .dfdb files in data-dir that aren't currently attached.
+// Powers Studio's "Browse & attach" panel: orphan files from a stale
+// service restart, files dropped into a mounted volume, etc.
+export interface UnattachedFile {
+  suggestedName: string;
+  nameConflict: boolean;     // basename collides with an already-attached DB
+  path: string;
+  sizeBytes: number;
+  modifiedUtc: string;
+}
+export interface UnattachedResponse {
+  dataDir: string;
+  recursive: boolean;
+  count: number;
+  files: UnattachedFile[];
+}
+export async function listUnattachedDatabases(
+  options?: { recursive?: boolean } & CallOptions,
+): Promise<UnattachedResponse> {
+  const qs = options?.recursive ? '?recursive=true' : '';
+  const r = await fetch(urlFor(`/databases/unattached${qs}`, options), {
+    headers: authHeaders(options),
+  });
+  return handle(r);
+}
+
 // ---------- Per-DB replication (Issue #66 Phase 2.5) ----------
 // Phase 2.5 scoped endpoints under /db/{name}/replication/*. Each attached
 // DB has its own role; Studio's topology page uses these to render and

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "0.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Admin UI for DocumentForge clusters",
   "scripts": {

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -57,6 +57,63 @@ public static class DatabaseEndpoints
             });
         });
 
+        // Issue #83 — list .dfdb files in (or under) the data dir that
+        // AREN'T currently attached. Powers the Studio "Browse & attach"
+        // panel: the operator drops files into a mounted volume, the UI
+        // shows the leftovers, one click attaches them by path. Useful
+        // even with the #82 auto-discover because:
+        //   * recursive scan finds files in subfolders auto-discover skips
+        //   * surfaces tombstoned files (so the operator can intentionally
+        //     re-attach a previously-detached DB)
+        //   * fills the gap when the file lives OUTSIDE data-dir entirely
+        //     (handled via a follow-up "attach by absolute path" UX)
+        app.MapGet("/databases/unattached", (HttpContext ctx, bool? recursive) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            if (!Directory.Exists(defaultDataDir))
+                return Results.Ok(new { dataDir = defaultDataDir, count = 0, files = Array.Empty<object>() });
+
+            // Names already taken by attached engines — case-insensitive
+            // because that's how the registry stores them. Skip the
+            // implicit ones (data.dfdb, _system.dfdb) since they're
+            // never user-attached anyway.
+            var attachedNames = registry.List()
+                .Select(e => e.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var attachedPaths = registry.List()
+                .Select(e => Path.GetFullPath(e.FilePath))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            var searchOpt = recursive == true
+                ? SearchOption.AllDirectories
+                : SearchOption.TopDirectoryOnly;
+
+            var rows = new List<object>();
+            foreach (var path in Directory.EnumerateFiles(defaultDataDir, "*.dfdb", searchOpt))
+            {
+                var name = Path.GetFileNameWithoutExtension(path);
+                if (name == "data" || IsInternalDatabase(name)) continue;
+                if (attachedPaths.Contains(Path.GetFullPath(path))) continue;
+
+                var info = new FileInfo(path);
+                rows.Add(new
+                {
+                    suggestedName = name,
+                    nameConflict = attachedNames.Contains(name),
+                    path = Path.GetFullPath(path),
+                    sizeBytes = info.Length,
+                    modifiedUtc = info.LastWriteTimeUtc.ToString("O"),
+                });
+            }
+            return Results.Ok(new
+            {
+                dataDir = defaultDataDir,
+                recursive = recursive == true,
+                count = rows.Count,
+                files = rows,
+            });
+        });
+
         // Create-or-attach (Studio "+ Add Database").
         //   { "name": "acme" }                            -> {dataDir}/acme.dfdb, create-or-attach
         //   { "name": "acme", "path": "/abs/p.dfdb" }     -> use the supplied path, create-or-attach

--- a/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
@@ -89,7 +89,7 @@ public static class RouterEndpoints
             status = "ok",
             node = "router",
             role = "router",
-            version = "1.1.0",
+            version = "1.1.1",
             configPath = Path.GetFullPath(configPath),
             shards = router.Config.Shards.Count,
             collections = router.Config.Collections.Count,

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -943,7 +943,7 @@ public static class ServeCommand
             {
                 status = healthy ? "ok" : "degraded",
                 node = config.NodeName,
-                version = "1.1.0",
+                version = "1.1.1",
                 readOnly = db.IsReadOnly,
                 uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1),
                 health = healthy ? null : new

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -53,7 +53,7 @@ public class Program
 
     private static int PrintVersion()
     {
-        Console.WriteLine("dfdb 1.1.0");
+        Console.WriteLine("dfdb 1.1.1");
         Console.WriteLine("DocumentForge - embedded JSON document database with replication and sharding");
         return 0;
     }

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -370,7 +370,117 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
         Assert.DoesNotContain(final.Databases, d => d.Name == "tenant_a");
     }
 
+    // Issue #83 — /databases/unattached. The endpoint that powers the
+    // Studio "Browse & attach" panel.
+    [Fact]
+    public async Task GetUnattached_DropOrphanFiles_ListsThem()
+    {
+        var (_, baseUrl, dataDir) = BootServer();
+
+        // Drop a .dfdb file directly in data-dir, untouched by the registry.
+        var orphan = Path.Combine(dataDir, "orphan_tenant.dfdb");
+        File.WriteAllBytes(orphan, new byte[] { 0, 0, 0, 0 });
+
+        var list = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached");
+        Assert.NotNull(list);
+        Assert.Equal(1, list!.Count);
+        Assert.False(list.Recursive);
+        Assert.Equal(Path.GetFullPath(orphan), list.Files[0].Path);
+        Assert.Equal("orphan_tenant", list.Files[0].SuggestedName);
+        Assert.False(list.Files[0].NameConflict);
+    }
+
+    [Fact]
+    public async Task GetUnattached_AttachedFile_Excluded()
+    {
+        var (_, baseUrl, dataDir) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "live" });
+        // Drop a separate orphan so the response isn't empty.
+        File.WriteAllBytes(Path.Combine(dataDir, "ghost.dfdb"), new byte[] { 0 });
+
+        var list = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached");
+        Assert.Equal(1, list!.Count);
+        Assert.Equal("ghost", list.Files[0].SuggestedName);
+        Assert.DoesNotContain(list.Files, f => f.SuggestedName == "live");
+    }
+
+    [Fact]
+    public async Task GetUnattached_SkipsImplicitFiles()
+    {
+        // data.dfdb and _system.dfdb (had they been present) would be
+        // service implementation details — they must never appear as
+        // "unattached" candidates the operator could click.
+        var (_, baseUrl, dataDir) = BootServer();
+        File.WriteAllBytes(Path.Combine(dataDir, "data.dfdb"), new byte[] { 0 });
+        File.WriteAllBytes(Path.Combine(dataDir, "_system.dfdb"), new byte[] { 0 });
+        File.WriteAllBytes(Path.Combine(dataDir, "tenant_real.dfdb"), new byte[] { 0 });
+
+        var list = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached");
+        Assert.Equal(1, list!.Count);
+        Assert.Equal("tenant_real", list.Files[0].SuggestedName);
+    }
+
+    [Fact]
+    public async Task GetUnattached_RecursiveFlag_FindsSubfolderFiles()
+    {
+        // Container deployments often mount a volume containing nested
+        // folders; the recursive flag lets the operator surface those
+        // without manually typing paths.
+        var (_, baseUrl, dataDir) = BootServer();
+        var subdir = Path.Combine(dataDir, "_backup");
+        Directory.CreateDirectory(subdir);
+        File.WriteAllBytes(Path.Combine(subdir, "archived.dfdb"), new byte[] { 0 });
+
+        var nonRecursive = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached");
+        Assert.Equal(0, nonRecursive!.Count);
+
+        var recursive = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached?recursive=true");
+        Assert.Equal(1, recursive!.Count);
+        Assert.True(recursive.Recursive);
+        Assert.Equal("archived", recursive.Files[0].SuggestedName);
+    }
+
+    [Fact]
+    public async Task GetUnattached_NameConflictFlag_SurfacedOnDuplicate()
+    {
+        // If an orphan file's basename matches a name already in the
+        // registry, the UI needs to know — otherwise one-click attach
+        // would 409. Flag it so the panel can prompt for a rename.
+        var (_, baseUrl, dataDir) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "shared" });
+        // Drop a file at a different path with the SAME basename.
+        var other = Path.Combine(dataDir, "_archive", "shared.dfdb");
+        Directory.CreateDirectory(Path.GetDirectoryName(other)!);
+        File.WriteAllBytes(other, new byte[] { 0 });
+
+        var list = await _http.GetFromJsonAsync<UnattachedResponse>(
+            $"{baseUrl}/databases/unattached?recursive=true");
+        var conflictRow = list!.Files.Single(f => f.Path == Path.GetFullPath(other));
+        Assert.True(conflictRow.NameConflict);
+    }
+
     // Response DTOs — narrow shapes for deserialization in tests.
+    private sealed class UnattachedResponse
+    {
+        public string DataDir { get; set; } = "";
+        public bool Recursive { get; set; }
+        public int Count { get; set; }
+        public List<UnattachedRow> Files { get; set; } = new();
+    }
+    private sealed class UnattachedRow
+    {
+        public string SuggestedName { get; set; } = "";
+        public bool NameConflict { get; set; }
+        public string Path { get; set; } = "";
+        public long SizeBytes { get; set; }
+        public string ModifiedUtc { get; set; } = "";
+    }
+
     private sealed class DatabasesListResponse
     {
         public string? Default { get; set; }


### PR DESCRIPTION
## Summary

Closes the loop on #82 — gives operators a UI escape hatch when files
land somewhere the auto-discovery doesn't see them. Also bumps to
**1.1.1** so the Docker pipeline cuts a release that includes the #82
catalog fix from `master`.

## What ships

**New endpoint:** `GET /databases/unattached[?recursive=true]`
Lists `*.dfdb` files in data-dir whose canonical path isn't currently
attached. Returns size, mtime, suggested name, and a `nameConflict`
flag (set when the basename collides with an already-attached DB).
Admin-scoped. Implicit names (`data.dfdb`, `_system.dfdb`) excluded.

**New UI panel:** Studio `/databases` page gets a "Browse & attach"
card sitting above the attached list. Recurse-subfolders checkbox,
scan button, per-row rename input, one-click attach. All attaches go
through the existing `POST /databases` with `createIfMissing=false`
so this panel can't accidentally create a *new* DB.

**Version bump:** `1.1.0 → 1.1.1` in `Directory.Build.props`, `dfdb
--version`, `GET /health`, router `GET /health`, sidebar footer,
admin-ui `package.json` + lock.

## Why both at once

Tagging `v1.1.1` is the trigger that runs the release workflow's
`type=semver` Docker builds — pulling the #82 catalog fix into a
named release. Bundling the browse-and-attach feature in the same
release means the user gets both the durability fix and the manual
attach UI without two restarts.

## Test plan

- [x] 5 new HTTP integration tests:
  - `GetUnattached_DropOrphanFiles_ListsThem`
  - `GetUnattached_AttachedFile_Excluded`
  - `GetUnattached_SkipsImplicitFiles` (`data.dfdb`, `_system.dfdb`)
  - `GetUnattached_RecursiveFlag_FindsSubfolderFiles`
  - `GetUnattached_NameConflictFlag_SurfacedOnDuplicate`
- [x] Live smoke: start service, drop `orphan1.dfdb`, `orphan2.dfdb`,
  `_backup/old_tenant.dfdb`. Non-recursive scan returns 2; recursive
  returns 3. ✓
- [x] `/health` reports `version: "1.1.1"`
- [x] `dotnet test`: 317/318 (one unrelated flaky replication test)
- [x] `npm run build` admin-ui: clean

## Release follow-up (after merge)

Tag `v1.1.1` on `master`, push — fires `release.yml` which produces
`ghcr.io/aerotoysio/documentforge:1.1.1` + `1.1` + `1` images for both
engine and admin-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)