### PR TITLE
feat(#84): runtime scan & attach + bump to 1.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <!-- Shared NuGet metadata. Per-project csproj files control whether to pack. -->
   <PropertyGroup>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Authors>DocumentForge contributors</Authors>
     <Company>DocumentForge</Company>
     <Product>DocumentForge</Product>

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -106,7 +106,7 @@ export function Sidebar() {
         marginTop: 'auto', fontSize: 11, color: '#666',
         fontFamily: 'var(--mono)', letterSpacing: '0.05em', paddingTop: 40
       }}>
-        v1.1.1 · MIT
+        v1.1.2 · MIT
       </div>
     </aside>
   );

--- a/admin-ui/app/databases/page.tsx
+++ b/admin-ui/app/databases/page.tsx
@@ -9,6 +9,7 @@ import {
   deleteDatabase,
   setDefaultDatabase,
   listUnattachedDatabases,
+  discoverDatabases,
   type DatabaseEntry,
   type UnattachedFile,
 } from '@/lib/api';
@@ -43,6 +44,10 @@ export default function DatabasesPage() {
   const [attaching, setAttaching] = useState<string | null>(null);
   const [renameDrafts, setRenameDrafts] = useState<Record<string, string>>({});
 
+  // Issue #84 — runtime rescan + auto-attach (one-click bulk).
+  const [discovering, setDiscovering] = useState(false);
+  const [discoverBanner, setDiscoverBanner] = useState<string | null>(null);
+
   async function refresh() {
     setLoading(true);
     setError(null);
@@ -76,6 +81,34 @@ export default function DatabasesPage() {
       setScanError(e.message || String(e));
     } finally {
       setScanning(false);
+    }
+  }
+
+  async function discoverAndAttachAll(recursive: boolean) {
+    setDiscovering(true);
+    setDiscoverBanner(null);
+    setScanError(null);
+    try {
+      const resp = await discoverDatabases({ recursive });
+      // Refresh both the attached list AND the unattached panel so the
+      // user sees the new state immediately. If there's any unattached
+      // list visible, re-run that scan too to keep it consistent.
+      await refresh();
+      if (unattachedDataDir !== null) await scanUnattached(scanRecursive);
+      const errPart = resp.errors.length > 0 ? ` · ${resp.errors.length} error${resp.errors.length === 1 ? '' : 's'}` : '';
+      const tombPart = resp.skippedTombstoned > 0
+        ? ` · ${resp.skippedTombstoned} tombstoned skipped (use Scan + Attach to override)`
+        : '';
+      setDiscoverBanner(
+        resp.discovered > 0
+          ? `✓ Attached ${resp.discovered} database${resp.discovered === 1 ? '' : 's'}${tombPart}${errPart}`
+          : `No new databases found${tombPart}${errPart}`,
+      );
+      setTimeout(() => setDiscoverBanner(null), 5000);
+    } catch (e: any) {
+      setScanError(`Discover failed: ${e.message || String(e)}`);
+    } finally {
+      setDiscovering(false);
     }
   }
 
@@ -246,13 +279,28 @@ export default function DatabasesPage() {
             Recurse subfolders
           </label>
           <button
-            onClick={() => scanUnattached(scanRecursive)}
-            disabled={scanning}
-            style={ghostBtn()}
+            onClick={() => discoverAndAttachAll(scanRecursive)}
+            disabled={discovering || scanning}
+            style={primaryBtn(discovering || scanning)}
+            title="Scan the data dir AND auto-attach every .dfdb file found. Honours Detach tombstones — those need manual Attach via Scan."
           >
-            {scanning ? 'Scanning…' : '⌕ Scan'}
+            {discovering ? 'Discovering…' : '↻ Scan & attach all'}
+          </button>
+          <button
+            onClick={() => scanUnattached(scanRecursive)}
+            disabled={scanning || discovering}
+            style={ghostBtn()}
+            title="Just list unattached files — useful when you want to rename before attaching, or skip particular files."
+          >
+            {scanning ? 'Scanning…' : '⌕ Scan (preview)'}
           </button>
         </div>
+
+        {discoverBanner && (
+          <div style={{ marginTop: 10, padding: 8, background: discoverBanner.startsWith('✓') ? 'rgba(40,160,80,0.08)' : 'rgba(0,0,0,0.04)', color: 'var(--ink)', fontFamily: 'var(--mono)', fontSize: 12 }}>
+            {discoverBanner}
+          </div>
+        )}
 
         {unattachedDataDir && (
           <div style={{ marginTop: 10, fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -348,6 +348,28 @@ export async function listUnattachedDatabases(
   return handle(r);
 }
 
+// Issue #84 — runtime rescan + auto-attach. One-click "I dropped N
+// files into the volume, attach them all now." Honours Detach
+// tombstones (those need explicit re-attach via the Browse panel).
+export interface DiscoverResponse {
+  dataDir: string;
+  recursive: boolean;
+  discovered: number;
+  skippedTombstoned: number;
+  errors: string[];
+  attached: Array<{ name: string; path: string }>;
+}
+export async function discoverDatabases(
+  options?: { recursive?: boolean } & CallOptions,
+): Promise<DiscoverResponse> {
+  const qs = options?.recursive ? '?recursive=true' : '';
+  const r = await fetch(urlFor(`/databases/discover${qs}`, options), {
+    method: 'POST',
+    headers: authHeaders(options),
+  });
+  return handle(r);
+}
+
 // ---------- Per-DB replication (Issue #66 Phase 2.5) ----------
 // Phase 2.5 scoped endpoints under /db/{name}/replication/*. Each attached
 // DB has its own role; Studio's topology page uses these to render and

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": true,
   "description": "Admin UI for DocumentForge clusters",
   "scripts": {

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -114,6 +114,81 @@ public static class DatabaseEndpoints
             });
         });
 
+        // Issue #84 — runtime rescan + auto-attach. The boot-time
+        // auto-discover in DatabaseCatalog.Bootstrap only fires once at
+        // startup. After that, files dropped into data-dir are invisible
+        // until the next restart. This endpoint is the "I dropped 10
+        // tenant.dfdb files into the volume, attach them all now"
+        // workflow — same logic as the bootstrap, just at runtime.
+        //
+        // Respects:
+        //   * already-attached files (skipped, no double-attach error)
+        //   * implicit names (data.dfdb / _system.dfdb)
+        //   * Detach tombstones (catalog?.TombstonedNames())
+        //
+        // For one-off manual attach with a custom name, use the existing
+        // /databases/unattached + per-row POST /databases flow.
+        app.MapPost("/databases/discover", (HttpContext ctx, bool? recursive) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            if (!Directory.Exists(defaultDataDir))
+                return Results.Ok(new
+                {
+                    dataDir = defaultDataDir,
+                    discovered = 0,
+                    skippedTombstoned = 0,
+                    errors = Array.Empty<string>(),
+                    attached = Array.Empty<object>(),
+                });
+
+            var attachedPaths = registry.List()
+                .Select(e => Path.GetFullPath(e.FilePath))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var tombstoned = catalog?.TombstonedNames()
+                ?? new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var searchOpt = recursive == true
+                ? SearchOption.AllDirectories
+                : SearchOption.TopDirectoryOnly;
+
+            var attached = new List<object>();
+            var errors = new List<string>();
+            var skippedTombstoned = 0;
+
+            foreach (var path in Directory.EnumerateFiles(defaultDataDir, "*.dfdb", searchOpt))
+            {
+                var name = Path.GetFileNameWithoutExtension(path);
+                if (name == "data" || IsInternalDatabase(name)) continue;
+                var fullPath = Path.GetFullPath(path);
+                if (attachedPaths.Contains(fullPath)) continue;
+                if (tombstoned.Contains(name))
+                {
+                    skippedTombstoned++;
+                    continue;
+                }
+                try
+                {
+                    registry.AttachOrCreate(name, fullPath);
+                    catalog?.RecordAttach(name, fullPath);
+                    attached.Add(new { name, path = fullPath });
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"'{name}' @ {path}: {ex.Message}");
+                }
+            }
+
+            return Results.Ok(new
+            {
+                dataDir = defaultDataDir,
+                recursive = recursive == true,
+                discovered = attached.Count,
+                skippedTombstoned,
+                errors,
+                attached,
+            });
+        });
+
         // Create-or-attach (Studio "+ Add Database").
         //   { "name": "acme" }                            -> {dataDir}/acme.dfdb, create-or-attach
         //   { "name": "acme", "path": "/abs/p.dfdb" }     -> use the supplied path, create-or-attach

--- a/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
@@ -89,7 +89,7 @@ public static class RouterEndpoints
             status = "ok",
             node = "router",
             role = "router",
-            version = "1.1.1",
+            version = "1.1.2",
             configPath = Path.GetFullPath(configPath),
             shards = router.Config.Shards.Count,
             collections = router.Config.Collections.Count,

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -943,7 +943,7 @@ public static class ServeCommand
             {
                 status = healthy ? "ok" : "degraded",
                 node = config.NodeName,
-                version = "1.1.1",
+                version = "1.1.2",
                 readOnly = db.IsReadOnly,
                 uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1),
                 health = healthy ? null : new

--- a/src/DocumentForge.Cli/DatabaseCatalog.cs
+++ b/src/DocumentForge.Cli/DatabaseCatalog.cs
@@ -214,6 +214,17 @@ public sealed class DatabaseCatalog
         .Select(e => new CatalogEntry(e.Name, e.Path))
         .ToList();
 
+    /// <summary>Names operators have explicitly Detached. Issue #84 —
+    /// the runtime <c>/databases/discover</c> rescan honours these
+    /// (same as the boot-time auto-discover): an operator's explicit
+    /// "remove this from the registry" decision shouldn't be reverted
+    /// by a refresh button. Manual one-click Attach on the Browse &amp;
+    /// attach panel still works — that overwrites the tombstone.</summary>
+    public IReadOnlySet<string> TombstonedNames() => ReadCatalogAll()
+        .Where(e => e.Detached)
+        .Select(e => e.Name)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
     // ----------------------------------------------------------------
 
     /// <summary>Reads everything — live records AND tombstones. The

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -53,7 +53,7 @@ public class Program
 
     private static int PrintVersion()
     {
-        Console.WriteLine("dfdb 1.1.1");
+        Console.WriteLine("dfdb 1.1.2");
         Console.WriteLine("DocumentForge - embedded JSON document database with replication and sharding");
         return 0;
     }

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Json;
 using System.Net.Sockets;
+using DocumentForge.Cli;
 using DocumentForge.Cli.Auth;
 using DocumentForge.Cli.Commands;
 using DocumentForge.Engine;
@@ -25,6 +26,12 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
 
     private (DatabaseRegistry registry, string baseUrl, string dataDir) BootServer()
     {
+        var (r, url, d, _) = BootServerWithCatalog(includeCatalog: false);
+        return (r, url, d);
+    }
+
+    private (DatabaseRegistry registry, string baseUrl, string dataDir, DatabaseCatalog? catalog) BootServerWithCatalog(bool includeCatalog)
+    {
         var port = FindFreePort();
         var dataDir = Path.Combine(Path.GetTempPath(), $"dbep_{Guid.NewGuid():N}");
         Directory.CreateDirectory(dataDir);
@@ -32,6 +39,18 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
 
         var registry = new DatabaseRegistry();
         _disposables.Add(registry);
+
+        // Catalog requires the _system DB to be attached on the registry
+        // before any RecordAttach / TombstonedNames call. ServeCommand
+        // does this before constructing the catalog; mirror that here
+        // for the subset of tests that exercise the runtime discover
+        // endpoint with tombstone semantics.
+        DatabaseCatalog? catalog = null;
+        if (includeCatalog)
+        {
+            registry.AttachOrCreate("_system", Path.Combine(dataDir, "_system.dfdb"));
+            catalog = new DatabaseCatalog(registry);
+        }
 
         var builder = WebApplication.CreateBuilder();
         builder.Logging.ClearProviders();
@@ -47,12 +66,12 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
             ctx.Items[AuthContext.ContextKey] = AuthContext.DevMode();
             await next();
         });
-        DatabaseEndpoints.Map(app, registry, dataDir);
+        DatabaseEndpoints.Map(app, registry, dataDir, catalog);
 
         app.StartAsync().GetAwaiter().GetResult();
         _disposables.Add(new HostStopper(app));
 
-        return (registry, $"http://127.0.0.1:{port}", dataDir);
+        return (registry, $"http://127.0.0.1:{port}", dataDir, catalog);
     }
 
     private static int FindFreePort()
@@ -462,6 +481,140 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
             $"{baseUrl}/databases/unattached?recursive=true");
         var conflictRow = list!.Files.Single(f => f.Path == Path.GetFullPath(other));
         Assert.True(conflictRow.NameConflict);
+    }
+
+    /// <summary>Stamp a real .dfdb file on disk and immediately close it,
+    /// so an Attach against the same path succeeds (vs. a 1-byte stub
+    /// which would throw on header validation and silently land in the
+    /// endpoint's errors list).</summary>
+    private static void MakeRealDfdbFile(string path)
+    {
+        using var db = DocumentForgeDb.Create(path);
+        // Sidecar files (.lock, .wal, .recovery) get dropped next to it
+        // — that's fine, the endpoint only globs *.dfdb.
+    }
+
+    // Issue #84 — POST /databases/discover. Runtime rescan + auto-attach.
+    [Fact]
+    public async Task PostDiscover_DropOrphanFiles_AttachesAndReportsThem()
+    {
+        // The "I dropped a file into the volume, no restart needed"
+        // workflow. Same shape as boot-time auto-discover.
+        var (registry, baseUrl, dataDir) = BootServer();
+
+        MakeRealDfdbFile(Path.Combine(dataDir, "orphan_a.dfdb"));
+        MakeRealDfdbFile(Path.Combine(dataDir, "orphan_b.dfdb"));
+
+        var resp = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DiscoverResponse>();
+
+        Assert.Equal(2, body!.Discovered);
+        Assert.Equal(0, body.SkippedTombstoned);
+        Assert.NotNull(registry.TryGet("orphan_a"));
+        Assert.NotNull(registry.TryGet("orphan_b"));
+    }
+
+    [Fact]
+    public async Task PostDiscover_AlreadyAttached_Skipped()
+    {
+        // A second call shouldn't re-attach anything (idempotent) and
+        // shouldn't 409 on the in-registry entries.
+        var (_, baseUrl, dataDir) = BootServer();
+        MakeRealDfdbFile(Path.Combine(dataDir, "tenant_x.dfdb"));
+
+        var first = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        var firstBody = await first.Content.ReadFromJsonAsync<DiscoverResponse>();
+        Assert.Equal(1, firstBody!.Discovered);
+
+        var second = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        second.EnsureSuccessStatusCode();
+        var secondBody = await second.Content.ReadFromJsonAsync<DiscoverResponse>();
+        Assert.Equal(0, secondBody!.Discovered);
+        Assert.Empty(secondBody.Errors);
+    }
+
+    [Fact]
+    public async Task PostDiscover_RecursiveFlag_AttachesSubfolderFiles()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        var subdir = Path.Combine(dataDir, "_volume_b");
+        Directory.CreateDirectory(subdir);
+        MakeRealDfdbFile(Path.Combine(subdir, "tenant_nested.dfdb"));
+
+        var nonRecursive = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        var nrBody = await nonRecursive.Content.ReadFromJsonAsync<DiscoverResponse>();
+        Assert.Equal(0, nrBody!.Discovered);
+        Assert.Null(registry.TryGet("tenant_nested"));
+
+        var recursive = await _http.PostAsync($"{baseUrl}/databases/discover?recursive=true", content: null);
+        var rBody = await recursive.Content.ReadFromJsonAsync<DiscoverResponse>();
+        Assert.Equal(1, rBody!.Discovered);
+        Assert.NotNull(registry.TryGet("tenant_nested"));
+    }
+
+    [Fact]
+    public async Task PostDiscover_HonoursTombstones()
+    {
+        // Detach intent must survive a runtime rescan. Otherwise pressing
+        // "Refresh & attach all" would silently undo a deliberate detach
+        // — surprising and risky. Manual one-click Attach via the
+        // /databases/unattached + per-row attach flow still works because
+        // that's an explicit operator decision per file.
+        var (registry, baseUrl, dataDir, catalog) = BootServerWithCatalog(includeCatalog: true);
+        Assert.NotNull(catalog);
+
+        // Attach + Detach to produce a tombstone for "drained".
+        await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "drained", path = Path.Combine(dataDir, "drained.dfdb") });
+        await _http.DeleteAsync($"{baseUrl}/databases/drained");
+        // File still on disk (Detach != Drop).
+        Assert.True(File.Exists(Path.Combine(dataDir, "drained.dfdb")));
+        // And there's a fresh tenant to discover.
+        MakeRealDfdbFile(Path.Combine(dataDir, "fresh.dfdb"));
+
+        var resp = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DiscoverResponse>();
+
+        Assert.Equal(1, body!.Discovered);            // fresh attached
+        Assert.Equal(1, body.SkippedTombstoned);      // drained skipped
+        Assert.NotNull(registry.TryGet("fresh"));
+        Assert.Null(registry.TryGet("drained"));
+    }
+
+    [Fact]
+    public async Task PostDiscover_SkipsImplicitFiles()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        // Stubs are fine here — we never try to Attach data.dfdb or
+        // _system.dfdb via this endpoint (they're explicitly skipped).
+        File.WriteAllBytes(Path.Combine(dataDir, "data.dfdb"), new byte[] { 0 });
+        File.WriteAllBytes(Path.Combine(dataDir, "_system.dfdb"), new byte[] { 0 });
+        MakeRealDfdbFile(Path.Combine(dataDir, "tenant_real.dfdb"));
+
+        var resp = await _http.PostAsync($"{baseUrl}/databases/discover", content: null);
+        var body = await resp.Content.ReadFromJsonAsync<DiscoverResponse>();
+        Assert.Equal(1, body!.Discovered);
+        // data + _system should remain untouched (not auto-attached as tenants).
+        Assert.Null(registry.TryGet("data"));
+        Assert.Null(registry.TryGet("_system"));
+        Assert.NotNull(registry.TryGet("tenant_real"));
+    }
+
+    private sealed class DiscoverResponse
+    {
+        public string DataDir { get; set; } = "";
+        public bool Recursive { get; set; }
+        public int Discovered { get; set; }
+        public int SkippedTombstoned { get; set; }
+        public List<string> Errors { get; set; } = new();
+        public List<DiscoveredEntry> Attached { get; set; } = new();
+    }
+    private sealed class DiscoveredEntry
+    {
+        public string Name { get; set; } = "";
+        public string Path { get; set; } = "";
     }
 
     // Response DTOs — narrow shapes for deserialization in tests.


### PR DESCRIPTION
## Summary

Closes the auto-discover gap from #82 + #83: that work covered boot-
time catalog replay and a preview panel, but **runtime** discovery
still required a service restart. After this PR you drop a file
into the data dir, click one button, it's attached.

## What ships

**New endpoint:** `POST /databases/discover[?recursive=true]`

Identical logic to boot-time auto-discover, just at runtime. Skips:
- Files already attached (no double-attach error)
- Implicit names (`data.dfdb`, `_system.dfdb`)
- Detach tombstones (explicit operator decisions stay honoured)

Returns concrete counts so the UI can banner `Attached 2 databases · 1 tombstoned skipped · 0 errors`.

**New UI button:** Red primary `↻ Scan & attach all` in the Browse &
attach panel — sits next to the existing `⌕ Scan (preview)` (kept for
rename-before-attach). Shares the Recurse subfolders checkbox.

**Catalog API:** `DatabaseCatalog.TombstonedNames()` exposes detach
tombstones to the endpoint without leaking the internal row shape.

**Version:** `1.1.1 → 1.1.2`.

## Test plan

- [x] 5 new HTTP integration tests:
  - `PostDiscover_DropOrphanFiles_AttachesAndReportsThem`
  - `PostDiscover_AlreadyAttached_Skipped` (idempotent)
  - `PostDiscover_RecursiveFlag_AttachesSubfolderFiles`
  - `PostDiscover_SkipsImplicitFiles` (`data.dfdb`, `_system.dfdb`)
  - `PostDiscover_HonoursTombstones`
- [x] Live walkthrough on a running 1.1.2 build:
  1. `cp tenant.dfdb /data/just_dropped.dfdb` → click button → ✓ Attached 1
  2. drop one in `/data/_old_backup/` + enable Recurse → click → ✓ Attached 1
  3. click a third time → "No new databases found" (idempotent)
- [x] `dotnet test` targeted: 16/16 pass
- [x] `npm run build` admin-ui: clean

## Release follow-up

Tag `v1.1.2` on `master` → release.yml builds `:1.1.2` + `:1.1` + `:1`
images for both engine and admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)