### PR TITLE
feat(#86): catalog rebuild tool — bump to 1.2.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
   <!-- Shared NuGet metadata. Per-project csproj files control whether to pack. -->
   <PropertyGroup>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>DocumentForge contributors</Authors>
     <Company>DocumentForge</Company>
     <Product>DocumentForge</Product>

--- a/admin-ui/app/Sidebar.tsx
+++ b/admin-ui/app/Sidebar.tsx
@@ -107,7 +107,7 @@ export function Sidebar() {
         marginTop: 'auto', fontSize: 11, color: '#666',
         fontFamily: 'var(--mono)', letterSpacing: '0.05em', paddingTop: 40
       }}>
-        v1.2.0 · MIT
+        v1.2.1 · MIT
       </div>
     </aside>
   );

--- a/admin-ui/app/databases/page.tsx
+++ b/admin-ui/app/databases/page.tsx
@@ -11,9 +11,13 @@ import {
   listUnattachedDatabases,
   discoverDatabases,
   getDatabaseHealth,
+  previewRebuildCatalog,
+  executeRebuildCatalog,
   type DatabaseEntry,
   type UnattachedFile,
   type DatabaseHealth,
+  type RebuildPlan,
+  type RebuildResult,
 } from '@/lib/api';
 
 // Issue #66 Phase 2 — "create a swarm on one box" lives here. Drop a name
@@ -54,6 +58,16 @@ export default function DatabasesPage() {
   // main list comes back so the page paints fast and badges fill in.
   const [healthByName, setHealthByName] = useState<Record<string, DatabaseHealth>>({});
   const [healthInspect, setHealthInspect] = useState<DatabaseHealth | null>(null);
+
+  // Issue #86 — rebuild-catalog wizard state. Operator picks a file
+  // (typically from the health modal's "Rebuild catalog" CTA), we
+  // detach it if attached, fetch the plan, show the chain preview,
+  // and on confirm POST the execute.
+  const [rebuildPath, setRebuildPath] = useState<string | null>(null);
+  const [rebuildPlan, setRebuildPlan] = useState<RebuildPlan | null>(null);
+  const [rebuildResult, setRebuildResult] = useState<RebuildResult | null>(null);
+  const [rebuildError, setRebuildError] = useState<string | null>(null);
+  const [rebuildBusy, setRebuildBusy] = useState(false);
 
   async function refresh() {
     setLoading(true);
@@ -125,6 +139,52 @@ export default function DatabasesPage() {
     } finally {
       setDiscovering(false);
     }
+  }
+
+  async function openRebuildWizard(path: string, attachedAs: string | null) {
+    setRebuildBusy(true);
+    setRebuildError(null);
+    setRebuildPlan(null);
+    setRebuildResult(null);
+    setRebuildPath(path);
+    try {
+      // If the DB is currently attached, the rebuilder will refuse —
+      // detach first so the operator doesn't bounce off a 409.
+      if (attachedAs) {
+        await deleteDatabase(attachedAs);  // detach (not drop)
+      }
+      const plan = await previewRebuildCatalog(path);
+      setRebuildPlan(plan);
+      await refresh();
+    } catch (e: any) {
+      setRebuildError(e.message || String(e));
+    } finally {
+      setRebuildBusy(false);
+    }
+  }
+
+  async function confirmRebuild() {
+    if (!rebuildPath) return;
+    setRebuildBusy(true);
+    setRebuildError(null);
+    try {
+      const r = await executeRebuildCatalog(rebuildPath);
+      setRebuildResult(r);
+      // Health badges should refresh once the operator re-attaches —
+      // they can do that with the existing Browse & Attach panel.
+      await refresh();
+    } catch (e: any) {
+      setRebuildError(e.message || String(e));
+    } finally {
+      setRebuildBusy(false);
+    }
+  }
+
+  function closeRebuildWizard() {
+    setRebuildPath(null);
+    setRebuildPlan(null);
+    setRebuildResult(null);
+    setRebuildError(null);
   }
 
   async function attachUnattached(file: UnattachedFile) {
@@ -626,11 +686,162 @@ export default function DatabasesPage() {
             </table>
             {healthInspect.recommendation === 'rebuild-catalog' && (
               <div style={{ marginTop: 16, padding: 12, background: 'rgba(217,4,41,0.04)', border: '1px solid rgba(217,4,41,0.15)' }}>
-                <div style={{ fontWeight: 600, marginBottom: 6 }}>How to recover (manual, until #86 ships)</div>
-                <div style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--gray-700)' }}>
-                  Your data pages are likely intact but the catalog page (page 1 of the .dfdb file) that lists collection names + their first page IDs is empty. A reconstruct-from-data-pages CLI is coming in 1.2.1 (issue #86). Until then: keep this file <strong>read-only</strong>, copy it to a safe backup (<code style={{ fontFamily: 'var(--mono)' }}>cp {healthInspect.filePath} {healthInspect.filePath}.frozen</code>), and ping the team. Don't INSERT or run rebuild-index against it — that could overwrite still-recoverable pages.
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>Recover this database</div>
+                <div style={{ fontSize: 12, lineHeight: 1.5, color: 'var(--gray-700)', marginBottom: 10 }}>
+                  Your data pages are likely intact but the catalog page (page 1 of the .dfdb file) that names collections is empty. The rebuilder scans the data pages, reconstructs the catalog, and writes a <code style={{ fontFamily: 'var(--mono)' }}>.page1.backup</code> sidecar first so the operation is reversible. The database will be detached briefly; you'll re-attach it once rebuild completes.
                 </div>
+                <button
+                  onClick={() => {
+                    const path = healthInspect.filePath;
+                    const name = healthInspect.database;
+                    setHealthInspect(null);
+                    openRebuildWizard(path, name);
+                  }}
+                  style={primaryBtn(false)}
+                >
+                  ⚙ Rebuild catalog
+                </button>
               </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Issue #86 — rebuild-catalog wizard. Multi-stage modal:
+            Loading → Plan preview → (optionally) Result
+          Backdrop click dismisses unless we're mid-execute. */}
+      {rebuildPath && (
+        <div
+          onClick={() => { if (!rebuildBusy) closeRebuildWizard(); }}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            zIndex: 60,
+          }}
+        >
+          <div
+            onClick={e => e.stopPropagation()}
+            style={{
+              background: 'white', padding: 24, maxWidth: 720, width: '92vw',
+              maxHeight: '85vh', overflow: 'auto',
+              border: '1px solid var(--gray-200)',
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 12 }}>
+              <h2 style={{ margin: 0, fontSize: 20 }}>⚙ Rebuild catalog</h2>
+              <button
+                onClick={closeRebuildWizard}
+                disabled={rebuildBusy}
+                style={ghostBtn()}
+              >✕ Close</button>
+            </div>
+            <div style={{ fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)', marginBottom: 14, wordBreak: 'break-all' }}>
+              {rebuildPath}
+            </div>
+
+            {rebuildError && (
+              <div style={{ padding: 10, marginBottom: 14, background: 'rgba(217,4,41,0.08)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12 }}>
+                ✗ {rebuildError}
+              </div>
+            )}
+
+            {!rebuildPlan && !rebuildResult && rebuildBusy && (
+              <div style={{ padding: 24, textAlign: 'center', color: 'var(--gray-500)' }}>
+                Detaching and scanning…
+              </div>
+            )}
+
+            {rebuildPlan && !rebuildResult && (
+              <>
+                <div style={{ marginBottom: 14 }}>
+                  {rebuildPlan.safeToRebuild ? (
+                    <>
+                      <div style={{ padding: 10, background: 'rgba(40,160,80,0.08)', color: 'rgb(20,120,60)', fontFamily: 'var(--mono)', fontSize: 12, marginBottom: 10 }}>
+                        ✓ Safe to rebuild · {rebuildPlan.chains.length} data chain{rebuildPlan.chains.length === 1 ? '' : 's'} discovered
+                      </div>
+                      <div style={{ fontSize: 13, color: 'var(--gray-700)', lineHeight: 1.5 }}>
+                        The current page-1 contents will be backed up to
+                        <code style={{ fontFamily: 'var(--mono)', fontSize: 12, margin: '0 4px' }}>.page1.backup</code>
+                        next to the data file. Recovered collections get auto-generated names — rename them with
+                        <code style={{ fontFamily: 'var(--mono)', fontSize: 12, margin: '0 4px' }}>RENAME COLLECTION recovered_pN TO real_name</code>
+                        once you identify each one.
+                      </div>
+                    </>
+                  ) : (
+                    <div style={{ padding: 10, background: 'rgba(217,4,41,0.08)', color: 'var(--red)', fontFamily: 'var(--mono)', fontSize: 12 }}>
+                      ⚠ Rebuilder refused: {rebuildPlan.refusalReason}
+                    </div>
+                  )}
+                </div>
+
+                {rebuildPlan.chains.length > 0 && (
+                  <table style={{ width: '100%', fontSize: 13, borderCollapse: 'collapse', marginBottom: 14 }}>
+                    <thead>
+                      <tr style={{ borderBottom: '2px solid var(--gray-200)' }}>
+                        <th style={{ padding: '8px 0', textAlign: 'left', fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--gray-500)' }}>Suggested name</th>
+                        <th style={{ padding: '8px 0', textAlign: 'right', fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--gray-500)' }}>Pages</th>
+                        <th style={{ padding: '8px 0', textAlign: 'right', fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--gray-500)' }}>Docs</th>
+                        <th style={{ padding: '8px 0', textAlign: 'right', fontFamily: 'var(--mono)', fontSize: 11, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--gray-500)' }}>First page</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {rebuildPlan.chains.map(c => (
+                        <tr key={c.firstPageId} style={{ borderBottom: '1px solid var(--gray-100)' }}>
+                          <td style={{ padding: '8px 0', fontFamily: 'var(--mono)', fontSize: 12 }}>{c.suggestedName}</td>
+                          <td style={{ padding: '8px 0', textAlign: 'right' }}>{c.pageCount}</td>
+                          <td style={{ padding: '8px 0', textAlign: 'right' }}>{c.documentCount.toLocaleString()}</td>
+                          <td style={{ padding: '8px 0', textAlign: 'right', fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>#{c.firstPageId}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+
+                {rebuildPlan.safeToRebuild && (
+                  <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+                    <button onClick={closeRebuildWizard} disabled={rebuildBusy} style={ghostBtn()}>Cancel</button>
+                    <button onClick={confirmRebuild} disabled={rebuildBusy} style={primaryBtn(rebuildBusy)}>
+                      {rebuildBusy ? 'Rebuilding…' : '⚙ Commit rebuild'}
+                    </button>
+                  </div>
+                )}
+              </>
+            )}
+
+            {rebuildResult && (
+              <>
+                <div style={{ padding: 10, background: 'rgba(40,160,80,0.1)', color: 'rgb(20,120,60)', fontFamily: 'var(--mono)', fontSize: 12, marginBottom: 14 }}>
+                  ✓ Rebuilt · {rebuildResult.recovered.length} collection{rebuildResult.recovered.length === 1 ? '' : 's'} recovered
+                </div>
+                <div style={{ fontSize: 13, lineHeight: 1.6, color: 'var(--gray-700)' }}>
+                  <strong>Backup written:</strong>{' '}
+                  <code style={{ fontFamily: 'var(--mono)', fontSize: 12 }}>{rebuildResult.backupPath}</code>{' '}
+                  ({rebuildResult.backedUpPage1Bytes.toLocaleString()} bytes). To revert: overwrite page 1 of the .dfdb with this file's contents.
+                </div>
+                <table style={{ width: '100%', fontSize: 13, borderCollapse: 'collapse', margin: '14px 0' }}>
+                  <thead>
+                    <tr style={{ borderBottom: '2px solid var(--gray-200)' }}>
+                      <th style={{ padding: '8px 0', textAlign: 'left', fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>Recovered as</th>
+                      <th style={{ padding: '8px 0', textAlign: 'right', fontFamily: 'var(--mono)', fontSize: 11, color: 'var(--gray-500)' }}>Docs</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rebuildResult.recovered.map(r => (
+                      <tr key={r.firstPageId} style={{ borderBottom: '1px solid var(--gray-100)' }}>
+                        <td style={{ padding: '8px 0', fontFamily: 'var(--mono)', fontSize: 12 }}>{r.name}</td>
+                        <td style={{ padding: '8px 0', textAlign: 'right' }}>{r.documentCount.toLocaleString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div style={{ fontSize: 12, color: 'var(--gray-500)', lineHeight: 1.5, marginBottom: 14 }}>
+                  <strong>Next step:</strong> Re-attach the database via the "+ Add Database" form above (it's currently detached), then inspect each recovered collection to identify it. Rename with{' '}
+                  <code style={{ fontFamily: 'var(--mono)', fontSize: 12 }}>RENAME COLLECTION recovered_pN TO real_name</code>.
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                  <button onClick={closeRebuildWizard} style={primaryBtn(false)}>Done</button>
+                </div>
+              </>
             )}
           </div>
         </div>

--- a/admin-ui/lib/api.ts
+++ b/admin-ui/lib/api.ts
@@ -405,6 +405,42 @@ export async function getDatabaseHealth(
   return handle(r);
 }
 
+// Issue #86 — catalog rebuild. Operator workflow: Detach → preview →
+// confirm → execute → re-Attach. The rebuilder refuses to touch a
+// healthy catalog AND requires the file is not currently attached
+// (exclusive file access).
+export interface RebuildPlanChain {
+  suggestedName: string;
+  firstPageId: number;
+  documentCount: number;
+  pageCount: number;
+}
+export interface RebuildPlan {
+  path: string;
+  safeToRebuild: boolean;
+  refusalReason: string | null;
+  chains: RebuildPlanChain[];
+}
+export interface RebuildResult {
+  path: string;
+  backupPath: string;
+  backedUpPage1Bytes: number;
+  recovered: Array<{ name: string; firstPageId: number; documentCount: number }>;
+}
+export async function previewRebuildCatalog(path: string, opts?: CallOptions): Promise<RebuildPlan> {
+  const r = await fetch(urlFor(`/databases/rebuild-catalog/preview?path=${encodeURIComponent(path)}`, opts), {
+    headers: authHeaders(opts),
+  });
+  return handle(r);
+}
+export async function executeRebuildCatalog(path: string, opts?: CallOptions): Promise<RebuildResult> {
+  const r = await fetch(urlFor(`/databases/rebuild-catalog?path=${encodeURIComponent(path)}`, opts), {
+    method: 'POST',
+    headers: authHeaders(opts),
+  });
+  return handle(r);
+}
+
 // ---------- Per-DB replication (Issue #66 Phase 2.5) ----------
 // Phase 2.5 scoped endpoints under /db/{name}/replication/*. Each attached
 // DB has its own role; Studio's topology page uses these to render and

--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "documentforge-admin",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "description": "Admin UI for DocumentForge clusters",
   "scripts": {

--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using DocumentForge.Cli.Auth;
 using DocumentForge.Core;
 using DocumentForge.Engine;
+using DocumentForge.Storage;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -354,6 +355,122 @@ public static class DatabaseEndpoints
                 recommendation,
                 recommendationDetail,
             });
+        });
+
+        // Issue #86 — catalog rebuild. Two endpoints: GET preview (Studio
+        // confirmation dialog uses this to show what would be rebuilt
+        // BEFORE writing anything), POST commit (does the actual rebuild).
+        //
+        // Operator workflow:
+        //   1. Health endpoint flags recommendation = "rebuild-catalog"
+        //   2. Operator Detaches the DB (rebuilder needs exclusive file access)
+        //   3. POST /databases/discover-rebuild?path=... → preview
+        //   4. Confirm
+        //   5. POST /databases/discover-rebuild?path=...&execute=true → write
+        //   6. Re-attach the DB via existing POST /databases
+        //
+        // The endpoint operates on a FILE PATH rather than a registry name
+        // because the DB has to be detached first; there's nothing in the
+        // registry to address. Admin-scoped.
+        app.MapGet("/databases/rebuild-catalog/preview", (HttpContext ctx, string path) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            if (string.IsNullOrWhiteSpace(path))
+                return Results.BadRequest(new { error = "Missing 'path' query parameter." });
+            if (!File.Exists(path))
+                return Results.NotFound(new { error = $"No file at '{path}'." });
+            var canonical = Path.GetFullPath(path);
+
+            // Refuse if the file is still attached. Plan() opens read-only
+            // so it'd succeed, but offering a plan when the operator
+            // hasn't detached yet is misleading — Execute would fail.
+            var attached = registry.List().FirstOrDefault(e =>
+                string.Equals(Path.GetFullPath(e.FilePath), canonical,
+                    StringComparison.OrdinalIgnoreCase));
+            if (attached is not null)
+            {
+                return Results.Conflict(new
+                {
+                    error = $"Database is currently attached as '{attached.Name}'. " +
+                            "DELETE /databases/" + attached.Name + " first (detach without --drop), then preview.",
+                });
+            }
+
+            try
+            {
+                using var rb = CatalogRebuilder.Open(canonical);
+                var plan = rb.Plan();
+                return Results.Ok(new
+                {
+                    path = canonical,
+                    safeToRebuild = plan.SafeToRebuild,
+                    refusalReason = plan.RefusalReason,
+                    chains = plan.Chains.Select(c => new
+                    {
+                        suggestedName = c.SuggestedName,
+                        firstPageId = c.FirstPageId.Value,
+                        documentCount = c.DocumentCount,
+                        pageCount = c.PageCount,
+                    }),
+                });
+            }
+            catch (IOException ex)
+            {
+                return Results.Conflict(new { error = $"Could not open file for inspection: {ex.Message}" });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        app.MapPost("/databases/rebuild-catalog", (HttpContext ctx, string path) =>
+        {
+            if (ScopeCheck.RequireAdmin(ctx) is { } deny) return deny;
+            if (string.IsNullOrWhiteSpace(path))
+                return Results.BadRequest(new { error = "Missing 'path' query parameter." });
+            if (!File.Exists(path))
+                return Results.NotFound(new { error = $"No file at '{path}'." });
+            var canonical = Path.GetFullPath(path);
+
+            var attached = registry.List().FirstOrDefault(e =>
+                string.Equals(Path.GetFullPath(e.FilePath), canonical,
+                    StringComparison.OrdinalIgnoreCase));
+            if (attached is not null)
+            {
+                return Results.Conflict(new
+                {
+                    error = $"Database is currently attached as '{attached.Name}'. " +
+                            "DELETE /databases/" + attached.Name + " first (detach without --drop), then rebuild.",
+                });
+            }
+
+            try
+            {
+                using var rb = CatalogRebuilder.Open(canonical);
+                var result = rb.Execute();
+                return Results.Ok(new
+                {
+                    path = result.FilePath,
+                    backupPath = result.BackupPath,
+                    backedUpPage1Bytes = result.BackedUpPage1Bytes,
+                    recovered = result.Recovered.Select(r => new
+                    {
+                        name = r.Name,
+                        firstPageId = r.FirstPageId.Value,
+                        documentCount = r.DocumentCount,
+                    }),
+                });
+            }
+            catch (CatalogRebuildException ex)
+            {
+                // The rebuilder's safety invariants kicked in. 409 Conflict
+                // is the right shape — the operation is well-formed but
+                // refused given the current state.
+                return Results.Conflict(new { error = ex.Message });
+            }
+            catch (IOException ex)
+            {
+                return Results.Conflict(new { error = $"Could not open file for rebuild: {ex.Message}" });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
         // Phase 2 stopgap for "I'm working on DB X now" — Phase 4 will

--- a/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/RouterEndpoints.cs
@@ -89,7 +89,7 @@ public static class RouterEndpoints
             status = "ok",
             node = "router",
             role = "router",
-            version = "1.2.0",
+            version = "1.2.1",
             configPath = Path.GetFullPath(configPath),
             shards = router.Config.Shards.Count,
             collections = router.Config.Collections.Count,

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -943,7 +943,7 @@ public static class ServeCommand
             {
                 status = healthy ? "ok" : "degraded",
                 node = config.NodeName,
-                version = "1.2.0",
+                version = "1.2.1",
                 readOnly = db.IsReadOnly,
                 uptimeSeconds = Math.Round((DateTime.UtcNow - _startedAt).TotalSeconds, 1),
                 health = healthy ? null : new

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -53,7 +53,7 @@ public class Program
 
     private static int PrintVersion()
     {
-        Console.WriteLine("dfdb 1.2.0");
+        Console.WriteLine("dfdb 1.2.1");
         Console.WriteLine("DocumentForge - embedded JSON document database with replication and sharding");
         return 0;
     }

--- a/src/DocumentForge.Storage/CatalogRebuilder.cs
+++ b/src/DocumentForge.Storage/CatalogRebuilder.cs
@@ -1,0 +1,373 @@
+using DocumentForge.Core;
+
+namespace DocumentForge.Storage;
+
+/// <summary>
+/// Issue #86 — rebuilds the collection catalog (page 1) of a damaged
+/// <c>.dfdb</c> file by scanning data-page chains and synthesising
+/// <c>recovered_&lt;FirstPageId&gt;</c> entries. The operator renames
+/// them afterwards once they inspect a few documents to identify each
+/// collection.
+///
+/// <para>
+/// Safety invariants (the rebuilder REFUSES to run otherwise — never
+/// silently clobbers a working catalog):
+/// <list type="bullet">
+///   <item>Catalog page (page 1) must currently be empty or only-deleted-slots.</item>
+///   <item>File must have at least one discoverable data chain.</item>
+///   <item>File must not be locked by another process (we open with FileShare.None — fails fast otherwise).</item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Safety scaffolding the rebuilder DOES (every Execute):
+/// <list type="bullet">
+///   <item>Writes the existing page-1 bytes to <c>{path}.page1.backup</c> BEFORE touching the data file. If rebuild goes wrong, the backup is a literal byte-for-byte restore source.</item>
+///   <item>Stamps the new page's CRC32 so it verifies on subsequent Opens.</item>
+///   <item>Calls <c>FileStream.Flush(true)</c> to fsync before reporting success.</item>
+/// </list>
+/// </para>
+/// </summary>
+public sealed class CatalogRebuilder : IDisposable
+{
+    private readonly FileStream _stream;
+    private readonly string _filePath;
+    private readonly uint _pageCount;
+    private bool _disposed;
+
+    private CatalogRebuilder(FileStream stream, string filePath)
+    {
+        _stream = stream;
+        _filePath = filePath;
+        _pageCount = (uint)(stream.Length / Constants.PageSize);
+    }
+
+    /// <summary>Open the file for the rebuild operation. Uses
+    /// <see cref="FileShare.Read"/> rather than <c>None</c> so the
+    /// rebuilder can use its own stream for both inspection and write
+    /// without conflicting with itself, but other writers are still
+    /// blocked (FileShare.Read forbids concurrent <see cref="FileAccess.Write"/>).
+    /// Throws <see cref="IOException"/> if another writer holds the
+    /// file open — that's the right outcome (the operator must Detach
+    /// the DB from the live engine before rebuilding).</summary>
+    public static CatalogRebuilder Open(string filePath)
+    {
+        var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite,
+            FileShare.Read, Constants.PageSize, FileOptions.RandomAccess);
+        return new CatalogRebuilder(stream, filePath);
+    }
+
+    /// <summary>Inspect without writing. Returns what the rebuild WOULD do
+    /// if invoked. Studio's confirmation dialog calls this first so the
+    /// operator can see the discovered chains before committing.</summary>
+    public RebuildPlan Plan()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(CatalogRebuilder));
+        var (chains, catalogEntries, catalogEmpty) = ScanFile();
+        return BuildPlan(chains, catalogEntries, catalogEmpty);
+    }
+
+    /// <summary>Read a page from our own stream. Avoids holding a second
+    /// file handle the way a <see cref="DatabaseInspector"/> would.</summary>
+    private byte[] ReadPageRaw(PageId pageId)
+    {
+        var buf = new byte[Constants.PageSize];
+        long offset = (long)pageId.Value * Constants.PageSize;
+        if (offset + Constants.PageSize > _stream.Length)
+            throw new EndOfStreamException(
+                $"Page {pageId.Value} is past end of file (offset {offset}, file size {_stream.Length}).");
+        lock (_stream)
+        {
+            _stream.Seek(offset, SeekOrigin.Begin);
+            int read = 0;
+            while (read < buf.Length)
+            {
+                int n = _stream.Read(buf, read, buf.Length - read);
+                if (n <= 0) throw new EndOfStreamException(
+                    $"Short read on page {pageId.Value}: got {read} of {Constants.PageSize} bytes.");
+                read += n;
+            }
+        }
+        return buf;
+    }
+
+    /// <summary>Single-pass scan reused by both Plan() and Execute(). Walks
+    /// every page once, finds data chain heads, and tries to read existing
+    /// catalog entries — mirrors <see cref="DatabaseInspector"/>'s logic
+    /// but on our own stream so we don't double-open the file.</summary>
+    private (List<DataChain> Chains, List<CatalogEntry> CatalogEntries, bool CatalogEmpty) ScanFile()
+    {
+        // Discover data-chain heads.
+        var heads = new List<(PageId Id, PageHeader Header)>();
+        for (uint i = 2; i < _pageCount; i++)
+        {
+            byte[] raw;
+            try { raw = ReadPageRaw(new PageId(i)); }
+            catch { continue; }
+            if (!PageChecksum.Verify(raw)) continue;
+            var ph = PageHeader.ReadFrom(raw);
+            if (ph.PageType != PageType.Data) continue;
+            if (ph.PrevPageId.Value != Constants.InvalidPageId) continue;
+            heads.Add((new PageId(i), ph));
+        }
+
+        // Walk each head's chain.
+        var chains = new List<DataChain>(heads.Count);
+        foreach (var (headId, headPh) in heads)
+        {
+            var visited = new HashSet<uint> { headId.Value };
+            long docCount = headPh.ItemCount;
+            int pageCount = 1;
+            var cursor = headPh.NextPageId;
+            while (cursor.Value != Constants.InvalidPageId
+                   && cursor.Value < _pageCount
+                   && visited.Add(cursor.Value))
+            {
+                byte[] raw;
+                try { raw = ReadPageRaw(cursor); }
+                catch { break; }
+                if (!PageChecksum.Verify(raw)) break;
+                var ph = PageHeader.ReadFrom(raw);
+                if (ph.PageType != PageType.Data) break;
+                docCount += ph.ItemCount;
+                pageCount++;
+                cursor = ph.NextPageId;
+            }
+            chains.Add(new DataChain
+            {
+                FirstPageId = headId,
+                PageCount = pageCount,
+                DocumentCount = docCount,
+                AssociatedCollection = null,
+            });
+        }
+
+        // Read existing catalog entries (if any) so the safety guard can
+        // refuse on a healthy catalog.
+        var catalogEntries = new List<CatalogEntry>();
+        bool catalogEmpty = true;
+        if (_pageCount >= 2)
+        {
+            byte[] raw;
+            try { raw = ReadPageRaw(PageId.CollectionCatalog); }
+            catch { return (chains, catalogEntries, catalogEmpty); }
+            var ph = PageHeader.ReadFrom(raw);
+            if (ph.ItemCount > 0)
+            {
+                for (int i = 0; i < ph.ItemCount; i++)
+                {
+                    int slotOffset = Constants.PageHeaderSize + (i * Constants.SlotEntrySize);
+                    if (slotOffset + Constants.SlotEntrySize > raw.Length) break;
+                    ushort dataOffset = BitConverter.ToUInt16(raw, slotOffset);
+                    ushort dataLength = BitConverter.ToUInt16(raw, slotOffset + 2);
+                    if (dataLength == 0) continue;
+                    if (dataOffset + dataLength > raw.Length) continue;
+
+                    int p = dataOffset;
+                    ushort nameLen = BitConverter.ToUInt16(raw, p); p += 2;
+                    if (p + nameLen + 12 > dataOffset + dataLength) continue;
+                    string name = System.Text.Encoding.UTF8.GetString(raw, p, nameLen); p += nameLen;
+                    uint firstPage = BitConverter.ToUInt32(raw, p); p += 4;
+                    long dc = BitConverter.ToInt64(raw, p);
+                    catalogEntries.Add(new CatalogEntry
+                    {
+                        CollectionName = name,
+                        FirstPageId = new PageId(firstPage),
+                        DocumentCount = dc,
+                    });
+                }
+                catalogEmpty = catalogEntries.Count == 0;
+            }
+        }
+        return (chains, catalogEntries, catalogEmpty);
+    }
+
+    /// <summary>Back up page 1 and stamp the rebuilt catalog. Returns the
+    /// same shape as <see cref="Plan"/> for parity, plus where the backup
+    /// landed. Throws <see cref="CatalogRebuildException"/> if any safety
+    /// invariant is violated.</summary>
+    public RebuildResult Execute()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(CatalogRebuilder));
+        var (chains, catalogEntries, catalogEmpty) = ScanFile();
+        var plan = BuildPlan(chains, catalogEntries, catalogEmpty);
+
+        // Refuse on any safety violation. The exception's Reason field
+        // tells the caller WHY so the UI can surface a useful message
+        // (don't just say "rebuild failed").
+        if (!plan.SafeToRebuild)
+            throw new CatalogRebuildException(plan.RefusalReason!);
+
+        // Backup the existing page-1 bytes. Even if it's empty, we want
+        // the EXACT pre-rebuild state on disk in case anything goes wrong.
+        var backupPath = _filePath + ".page1.backup";
+        byte[] currentPage1;
+        lock (_stream)
+        {
+            _stream.Seek(Constants.PageSize, SeekOrigin.Begin);
+            currentPage1 = new byte[Constants.PageSize];
+            int read = 0;
+            while (read < currentPage1.Length)
+            {
+                int n = _stream.Read(currentPage1, read, currentPage1.Length - read);
+                if (n <= 0) throw new InvalidOperationException("Short read on page 1 backup.");
+                read += n;
+            }
+        }
+        File.WriteAllBytes(backupPath, currentPage1);
+
+        // Synthesise the new catalog page. Same on-disk format the engine
+        // writes: PageType=CollectionCatalog, slotted layout, each slot
+        // is [NameLen:2][Name:N][FirstPageId:4][DocCount:8]. The recovered
+        // names are guaranteed unique because they include the page id.
+        var newPage = new byte[Constants.PageSize];
+        var header = new PageHeader
+        {
+            PageId = PageId.CollectionCatalog,
+            PageType = PageType.CollectionCatalog,
+            ItemCount = 0,
+            FreeSpaceStart = (ushort)Constants.PageHeaderSize,
+            FreeSpaceEnd = (ushort)Constants.PageSize,
+            NextPageId = PageId.Invalid,
+            PrevPageId = PageId.Invalid,
+            TransactionId = 0,
+            Flags = 0,
+            Checksum = 0,
+        };
+        header.WriteTo(newPage);
+        var dp = new DataPage(newPage);
+
+        var recovered = new List<RecoveredCollection>();
+        foreach (var chain in plan.Chains)
+        {
+            var name = chain.SuggestedName;
+            var nameBytes = System.Text.Encoding.UTF8.GetBytes(name);
+            var entrySize = 2 + nameBytes.Length + 4 + 8;
+            var entry = new byte[entrySize];
+            int offset = 0;
+            BitConverter.TryWriteBytes(entry.AsSpan(offset), (short)nameBytes.Length); offset += 2;
+            nameBytes.CopyTo(entry.AsSpan(offset)); offset += nameBytes.Length;
+            BitConverter.TryWriteBytes(entry.AsSpan(offset), chain.FirstPageId.Value); offset += 4;
+            BitConverter.TryWriteBytes(entry.AsSpan(offset), chain.DocumentCount);
+
+            int slot = dp.Insert(entry);
+            if (slot < 0)
+                throw new CatalogRebuildException(
+                    $"Too many collections to fit in a single 8 KB catalog page. " +
+                    $"Discovered {plan.Chains.Count} chains; stopped after writing {recovered.Count}.");
+            recovered.Add(new RecoveredCollection
+            {
+                Name = name,
+                FirstPageId = chain.FirstPageId,
+                DocumentCount = chain.DocumentCount,
+            });
+        }
+
+        // Stamp the CRC and write atomically (single write, then fsync).
+        PageChecksum.Stamp(dp.RawData);
+        lock (_stream)
+        {
+            _stream.Seek(Constants.PageSize, SeekOrigin.Begin);
+            _stream.Write(dp.RawData, 0, dp.RawData.Length);
+            _stream.Flush(flushToDisk: true);
+        }
+
+        return new RebuildResult
+        {
+            FilePath = _filePath,
+            BackupPath = backupPath,
+            Recovered = recovered,
+            BackedUpPage1Bytes = currentPage1.Length,
+        };
+    }
+
+    private static RebuildPlan BuildPlan(List<DataChain> chains, List<CatalogEntry> catalogEntries, bool catalogEmpty)
+    {
+        // Catalog must be effectively empty. If it has live entries
+        // already, the rebuild would destroy them.
+        if (!catalogEmpty && catalogEntries.Count > 0)
+        {
+            return new RebuildPlan
+            {
+                SafeToRebuild = false,
+                RefusalReason = $"Catalog page is not empty — it already lists {catalogEntries.Count} collection(s). " +
+                                "Rebuild would destroy them. Use Detach + manual recovery if you really want this.",
+                Chains = new(),
+            };
+        }
+        if (chains.Count == 0)
+        {
+            return new RebuildPlan
+            {
+                SafeToRebuild = false,
+                RefusalReason = "No data-page chains discovered — there's nothing to recover. The data file " +
+                                "is either empty or its data pages are damaged beyond what page-walking can find.",
+                Chains = new(),
+            };
+        }
+        var planChains = chains
+            .OrderBy(c => c.FirstPageId.Value)
+            .Select(c => new RebuildPlanChain
+            {
+                FirstPageId = c.FirstPageId,
+                DocumentCount = c.DocumentCount,
+                PageCount = c.PageCount,
+                SuggestedName = $"recovered_p{c.FirstPageId.Value}",
+            })
+            .ToList();
+        return new RebuildPlan
+        {
+            SafeToRebuild = true,
+            RefusalReason = null,
+            Chains = planChains,
+        };
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { _stream.Dispose(); } catch { }
+    }
+}
+
+/// <summary>What the rebuild WOULD do. Returned by Plan() so the UI can
+/// show a confirmation dialog before any bytes are written. Same shape
+/// as the rebuild result minus the post-write fields.</summary>
+public sealed record RebuildPlan
+{
+    public bool SafeToRebuild { get; init; }
+    public string? RefusalReason { get; init; }
+    public List<RebuildPlanChain> Chains { get; init; } = new();
+}
+
+public sealed record RebuildPlanChain
+{
+    public PageId FirstPageId { get; init; }
+    public long DocumentCount { get; init; }
+    public int PageCount { get; init; }
+    public string SuggestedName { get; init; } = "";
+}
+
+/// <summary>What actually got rebuilt. Returned by Execute(). The backup
+/// path tells the operator where to find the pre-rebuild page-1 bytes
+/// in case they need to revert by overwriting page 1 with that file.</summary>
+public sealed record RebuildResult
+{
+    public string FilePath { get; init; } = "";
+    public string BackupPath { get; init; } = "";
+    public int BackedUpPage1Bytes { get; init; }
+    public List<RecoveredCollection> Recovered { get; init; } = new();
+}
+
+public sealed record RecoveredCollection
+{
+    public string Name { get; init; } = "";
+    public PageId FirstPageId { get; init; }
+    public long DocumentCount { get; init; }
+}
+
+public sealed class CatalogRebuildException : Exception
+{
+    public CatalogRebuildException(string message) : base(message) { }
+}

--- a/src/DocumentForge.Storage/DatabaseInspector.cs
+++ b/src/DocumentForge.Storage/DatabaseInspector.cs
@@ -1,0 +1,314 @@
+using DocumentForge.Core;
+
+namespace DocumentForge.Storage;
+
+/// <summary>
+/// Issue #86 — read-only page walker for forensic inspection and recovery
+/// scaffolding. Opens a <c>.dfdb</c> file with <c>FileShare.Read</c> so
+/// it works alongside an attached engine (for inspection) AND on a
+/// completely orphaned file (for rebuild prep). Does NOT touch the
+/// <c>.lock</c> sidecar — this is read-only metadata extraction and
+/// shouldn't disturb the engine's locking state.
+///
+/// <para>
+/// Doubles as the foundation for: <c>dfdb inspect</c>, <c>dfdb verify</c>,
+/// <c>dfdb dump</c>, and the catalog rebuilder (which uses
+/// <see cref="FindDataChains"/> to discover collections when the catalog
+/// page is damaged).
+/// </para>
+///
+/// <para>
+/// Why bypass <see cref="DataFile"/> directly: <c>DataFile.Open</c> calls
+/// <see cref="DataFile.ValidateHeader"/> which throws on certain header
+/// damage. For forensics we want to surface that damage rather than
+/// refuse — corrupted headers are exactly the case operators need
+/// visibility into. We open the file ourselves and tolerate partial
+/// reads.
+/// </para>
+/// </summary>
+public sealed class DatabaseInspector : IDisposable
+{
+    private readonly FileStream _stream;
+    private bool _disposed;
+
+    public string FilePath { get; }
+    public long FileSizeBytes { get; }
+    public uint PageCount { get; }
+    public bool HasValidHeader { get; }
+
+    private DatabaseInspector(FileStream stream, string filePath)
+    {
+        _stream = stream;
+        FilePath = filePath;
+        FileSizeBytes = stream.Length;
+        PageCount = (uint)(stream.Length / Constants.PageSize);
+
+        // Best-effort header check. Doesn't throw on failure — the caller
+        // can see HasValidHeader and decide what to do.
+        try
+        {
+            var hdr = ReadPageRaw(PageId.Header);
+            HasValidHeader = hdr.Length == Constants.PageSize
+                && hdr[0] == 'D' && hdr[1] == 'F' && hdr[2] == 'D' && hdr[3] == 'B';
+        }
+        catch { HasValidHeader = false; }
+    }
+
+    /// <summary>Open a <c>.dfdb</c> file for read-only inspection. Compatible
+    /// with concurrent readers; non-disruptive to a running engine that
+    /// has the file open. Does NOT acquire the engine lock.</summary>
+    public static DatabaseInspector OpenReadOnly(string filePath)
+    {
+        if (!File.Exists(filePath))
+            throw new FileNotFoundException("Database file not found.", filePath);
+        var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read,
+            FileShare.ReadWrite, Constants.PageSize, FileOptions.RandomAccess);
+        try { return new DatabaseInspector(stream, filePath); }
+        catch { stream.Dispose(); throw; }
+    }
+
+    /// <summary>Read a single page's raw bytes. No checksum verification —
+    /// the caller decides what to do with broken pages.</summary>
+    public byte[] ReadPageRaw(PageId pageId)
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DatabaseInspector));
+        var buf = new byte[Constants.PageSize];
+        long offset = (long)pageId.Value * Constants.PageSize;
+        if (offset + Constants.PageSize > _stream.Length)
+            throw new EndOfStreamException(
+                $"Page {pageId.Value} is past end of file (offset {offset}, file size {_stream.Length}).");
+        lock (_stream)
+        {
+            _stream.Seek(offset, SeekOrigin.Begin);
+            int read = 0;
+            while (read < buf.Length)
+            {
+                int n = _stream.Read(buf, read, buf.Length - read);
+                if (n <= 0) throw new EndOfStreamException(
+                    $"Short read on page {pageId.Value}: got {read} of {Constants.PageSize} bytes.");
+                read += n;
+            }
+        }
+        return buf;
+    }
+
+    /// <summary>Walk every page in the file and produce a structural report.
+    /// Heavy operation (reads every page once) — intended for diagnostics,
+    /// not a hot path. Per-page checksum verification is included.</summary>
+    public InspectionReport Inspect()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DatabaseInspector));
+        var byType = new Dictionary<PageType, int>();
+        var checksumFailures = new List<uint>();
+        int unreadable = 0;
+
+        // Pages 0..PageCount-1. Page 0 is the file header; page 1 is the
+        // collection catalog; everything else is data / btree / overflow /
+        // freelist.
+        for (uint i = 0; i < PageCount; i++)
+        {
+            byte[] raw;
+            try { raw = ReadPageRaw(new PageId(i)); }
+            catch { unreadable++; continue; }
+
+            // Header page (0) has a different layout — skip the page-header
+            // typed parse and don't checksum-verify it (file header has its
+            // own format).
+            if (i == 0)
+            {
+                byType[PageType.Header] = byType.GetValueOrDefault(PageType.Header) + 1;
+                continue;
+            }
+
+            // For non-header pages, parse the standard page header and
+            // verify the page-level CRC32.
+            var ph = PageHeader.ReadFrom(raw);
+            byType[ph.PageType] = byType.GetValueOrDefault(ph.PageType) + 1;
+            if (!PageChecksum.Verify(raw)) checksumFailures.Add(i);
+        }
+
+        // Discover data-page chains. A chain head is a data page whose
+        // PrevPageId is Invalid; the chain extends forward via NextPageId.
+        var chains = FindDataChains();
+
+        // Try to parse the catalog page so we can correlate chain heads
+        // with collection names when the catalog IS intact.
+        var (catalogEntries, catalogEmpty) = TryReadCatalogEntries();
+
+        // Cross-link: for each chain head, see if any catalog entry points
+        // at it. Unlinked chain heads are what the rebuilder synthesises
+        // recovered_<id> names for.
+        var entriesByFirstPage = catalogEntries.ToDictionary(e => e.FirstPageId.Value);
+        foreach (var c in chains)
+        {
+            if (entriesByFirstPage.TryGetValue(c.FirstPageId.Value, out var entry))
+                c.AssociatedCollection = entry.CollectionName;
+        }
+
+        return new InspectionReport
+        {
+            FilePath = FilePath,
+            FileSizeBytes = FileSizeBytes,
+            PageCount = PageCount,
+            HasValidHeader = HasValidHeader,
+            PageCountByType = byType,
+            ChecksumFailures = checksumFailures,
+            UnreadablePages = unreadable,
+            Chains = chains,
+            CatalogEntries = catalogEntries,
+            CatalogPageEmpty = catalogEmpty,
+        };
+    }
+
+    /// <summary>Scan every page and return the heads of all data-page
+    /// chains. A chain head is a <see cref="PageType.Data"/> page whose
+    /// <c>PrevPageId</c> is <see cref="PageId.Invalid"/>. This is how the
+    /// rebuilder finds collections when the catalog page is corrupt — the
+    /// catalog stores name→firstPageId but the data pages themselves
+    /// (linked-list) survive independently.</summary>
+    public List<DataChain> FindDataChains()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DatabaseInspector));
+        var heads = new List<(PageId Id, PageHeader Header)>();
+        for (uint i = 2; i < PageCount; i++)
+        {
+            byte[] raw;
+            try { raw = ReadPageRaw(new PageId(i)); }
+            catch { continue; }
+            if (!PageChecksum.Verify(raw)) continue;  // skip damaged pages
+            var ph = PageHeader.ReadFrom(raw);
+            if (ph.PageType != PageType.Data) continue;
+            if (ph.PrevPageId.Value != Constants.InvalidPageId) continue;
+            heads.Add((new PageId(i), ph));
+        }
+
+        // Walk each head's chain to count documents and total page span.
+        // Documents-per-page is approximated by ItemCount; that's
+        // slot-count-including-deleted-slots, so the real number is
+        // ItemCount minus slots whose length is zero. For the rebuilder's
+        // purposes (auto-naming + sanity check) ItemCount is sufficient.
+        var result = new List<DataChain>(heads.Count);
+        foreach (var (headId, headPh) in heads)
+        {
+            var visited = new HashSet<uint> { headId.Value };
+            long docCount = headPh.ItemCount;
+            int pageCount = 1;
+            var cursor = headPh.NextPageId;
+            // Cycle defense: bounded by total page count + visited set.
+            while (cursor.Value != Constants.InvalidPageId
+                   && cursor.Value < PageCount
+                   && visited.Add(cursor.Value))
+            {
+                byte[] raw;
+                try { raw = ReadPageRaw(cursor); }
+                catch { break; }
+                if (!PageChecksum.Verify(raw)) break;
+                var ph = PageHeader.ReadFrom(raw);
+                if (ph.PageType != PageType.Data) break;
+                docCount += ph.ItemCount;
+                pageCount++;
+                cursor = ph.NextPageId;
+            }
+            result.Add(new DataChain
+            {
+                FirstPageId = headId,
+                PageCount = pageCount,
+                DocumentCount = docCount,
+                AssociatedCollection = null,  // filled in by Inspect() if catalog has it
+            });
+        }
+        return result;
+    }
+
+    /// <summary>Parse the catalog page (page 1) entries if intact. The
+    /// rebuilder uses this to verify "catalog is genuinely empty" before
+    /// it agrees to write a new one — never clobbers a working catalog.</summary>
+    public (List<CatalogEntry> Entries, bool CatalogEmpty) TryReadCatalogEntries()
+    {
+        if (_disposed) throw new ObjectDisposedException(nameof(DatabaseInspector));
+        if (PageCount < 2) return (new(), true);
+
+        byte[] raw;
+        try { raw = ReadPageRaw(PageId.CollectionCatalog); }
+        catch { return (new(), true); }
+
+        // If the page header reports zero items, the catalog is empty.
+        var ph = PageHeader.ReadFrom(raw);
+        if (ph.ItemCount == 0) return (new(), true);
+
+        // Use the same slotted-page layout the engine writes: each slot
+        // record holds [NameLen:2][Name:N][FirstPageId:4][DocCount:8].
+        var entries = new List<CatalogEntry>(ph.ItemCount);
+        for (int i = 0; i < ph.ItemCount; i++)
+        {
+            int slotOffset = Constants.PageHeaderSize + (i * Constants.SlotEntrySize);
+            if (slotOffset + Constants.SlotEntrySize > raw.Length) break;
+            ushort dataOffset = BitConverter.ToUInt16(raw, slotOffset);
+            ushort dataLength = BitConverter.ToUInt16(raw, slotOffset + 2);
+            if (dataLength == 0) continue;  // deleted slot
+            if (dataOffset + dataLength > raw.Length) continue;  // corrupt slot
+
+            int p = dataOffset;
+            ushort nameLen = BitConverter.ToUInt16(raw, p); p += 2;
+            if (p + nameLen + 12 > dataOffset + dataLength) continue;
+            string name = System.Text.Encoding.UTF8.GetString(raw, p, nameLen); p += nameLen;
+            uint firstPage = BitConverter.ToUInt32(raw, p); p += 4;
+            long docCount = BitConverter.ToInt64(raw, p);
+
+            entries.Add(new CatalogEntry
+            {
+                CollectionName = name,
+                FirstPageId = new PageId(firstPage),
+                DocumentCount = docCount,
+            });
+        }
+        return (entries, entries.Count == 0);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        try { _stream.Dispose(); } catch { }
+    }
+}
+
+/// <summary>Structural snapshot of a <c>.dfdb</c> file. Returned by
+/// <see cref="DatabaseInspector.Inspect"/>; consumed by the health endpoint
+/// for deep diagnostics and by the catalog rebuilder for its dry-run preview.</summary>
+public sealed record InspectionReport
+{
+    public string FilePath { get; init; } = "";
+    public long FileSizeBytes { get; init; }
+    public uint PageCount { get; init; }
+    public bool HasValidHeader { get; init; }
+    public Dictionary<PageType, int> PageCountByType { get; init; } = new();
+    public List<uint> ChecksumFailures { get; init; } = new();
+    public int UnreadablePages { get; init; }
+    public List<DataChain> Chains { get; init; } = new();
+    public List<CatalogEntry> CatalogEntries { get; init; } = new();
+    public bool CatalogPageEmpty { get; init; }
+}
+
+/// <summary>One linked list of <see cref="PageType.Data"/> pages discovered
+/// during inspection. If the catalog page is intact, <see cref="AssociatedCollection"/>
+/// is the name from the catalog entry; otherwise null and the rebuilder
+/// will synthesise a <c>recovered_&lt;FirstPageId&gt;</c> name.</summary>
+public sealed class DataChain
+{
+    public PageId FirstPageId { get; init; }
+    public int PageCount { get; init; }
+    public long DocumentCount { get; init; }
+    public string? AssociatedCollection { get; set; }
+}
+
+/// <summary>A parsed entry from the on-disk catalog page (page 1). Used
+/// by the inspector to correlate chain heads with their collection names
+/// when the catalog IS intact; not the same shape as the engine's
+/// in-memory catalog object.</summary>
+public sealed record CatalogEntry
+{
+    public string CollectionName { get; init; } = "";
+    public PageId FirstPageId { get; init; }
+    public long DocumentCount { get; init; }
+}

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using DocumentForge.Cli;
 using DocumentForge.Cli.Auth;
 using DocumentForge.Cli.Commands;
+using DocumentForge.Core;
 using DocumentForge.Engine;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -492,6 +493,166 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
         using var db = DocumentForgeDb.Create(path);
         // Sidecar files (.lock, .wal, .recovery) get dropped next to it
         // — that's fine, the endpoint only globs *.dfdb.
+    }
+
+    // Issue #86 — rebuild-catalog. Plan + execute against a real DB
+    // whose catalog page has been zeroed out (simulating the bbqdubai
+    // scenario). The rebuilder discovers the data chain and reconstructs
+    // a catalog entry pointing at it.
+    [Fact]
+    public async Task RebuildCatalogPreview_FileWithDataButZeroedCatalog_ReportsRecoverableChains()
+    {
+        var (_, baseUrl, dataDir) = BootServer();
+        var dbPath = Path.Combine(dataDir, "broken.dfdb");
+
+        // Build a real DB with data, then close it.
+        await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "broken", path = dbPath });
+        // Drop several docs to ensure data pages get linked into a chain.
+        for (int i = 0; i < 30; i++)
+        {
+            var body = new StringContent($$"""{"pnr":"P-{{i:D4}}"}""",
+                System.Text.Encoding.UTF8, "application/json");
+            await _http.PostAsync($"{baseUrl}/db/broken/collections/orders", body);
+        }
+        await _http.DeleteAsync($"{baseUrl}/databases/broken");
+
+        // Zero out page 1 to simulate catalog corruption. Page 0 (header)
+        // + data pages stay intact. After this, attaching reports "no
+        // collections" even though the documents are still on disk.
+        ZeroPage1(dbPath);
+
+        var preview = await _http.GetFromJsonAsync<RebuildPlanResponse>(
+            $"{baseUrl}/databases/rebuild-catalog/preview?path={Uri.EscapeDataString(dbPath)}");
+        Assert.NotNull(preview);
+        Assert.True(preview!.SafeToRebuild);
+        Assert.NotEmpty(preview.Chains);
+        // The orders collection's chain should be discovered. Document
+        // count is approximate (ItemCount includes deleted slots) but
+        // for a fresh insert run with no deletes it should equal 30.
+        Assert.Contains(preview.Chains, c => c.DocumentCount >= 30);
+    }
+
+    [Fact]
+    public async Task RebuildCatalog_Execute_WritesCatalogAndAllowsReattach()
+    {
+        var (_, baseUrl, dataDir) = BootServer();
+        var dbPath = Path.Combine(dataDir, "fix-me.dfdb");
+
+        await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "fix_me", path = dbPath });
+        for (int i = 0; i < 12; i++)
+        {
+            var body = new StringContent($$"""{"id":{{i}}}""",
+                System.Text.Encoding.UTF8, "application/json");
+            await _http.PostAsync($"{baseUrl}/db/fix_me/collections/widgets", body);
+        }
+        await _http.DeleteAsync($"{baseUrl}/databases/fix_me");
+
+        ZeroPage1(dbPath);
+
+        var resp = await _http.PostAsync(
+            $"{baseUrl}/databases/rebuild-catalog?path={Uri.EscapeDataString(dbPath)}",
+            content: null);
+        resp.EnsureSuccessStatusCode();
+        var result = await resp.Content.ReadFromJsonAsync<RebuildResultResponse>();
+        Assert.NotEmpty(result!.Recovered);
+        Assert.True(File.Exists(result.BackupPath));
+
+        // Re-attach with the rebuilt catalog and confirm the engine sees
+        // the synthesised collection name with the expected doc count.
+        var reattach = await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "fix_me_again", path = dbPath });
+        Assert.Equal(System.Net.HttpStatusCode.Created, reattach.StatusCode);
+        var recoveredName = result.Recovered[0].Name;
+        var q = await _http.PostAsJsonAsync($"{baseUrl}/db/fix_me_again/query",
+            new { sql = $"SELECT * FROM {recoveredName}" });
+        q.EnsureSuccessStatusCode();
+        var json = await q.Content.ReadAsStringAsync();
+        // Should contain at least one of our inserted docs.
+        Assert.Contains("\"id\"", json);
+    }
+
+    [Fact]
+    public async Task RebuildCatalogPreview_StillAttached_Returns409()
+    {
+        // The rebuilder needs exclusive access. If the operator hasn't
+        // Detached yet, the endpoint refuses with a clear message instead
+        // of "could not open file" — telling them what to do.
+        var (_, baseUrl, dataDir) = BootServer();
+        var dbPath = Path.Combine(dataDir, "still-live.dfdb");
+        await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "still_live", path = dbPath });
+
+        var resp = await _http.GetAsync(
+            $"{baseUrl}/databases/rebuild-catalog/preview?path={Uri.EscapeDataString(dbPath)}");
+        Assert.Equal(System.Net.HttpStatusCode.Conflict, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("still_live", body);  // mentions the name to detach
+    }
+
+    [Fact]
+    public async Task RebuildCatalog_HealthyCatalog_Refuses()
+    {
+        // A working catalog (with entries) must NOT be clobbered by an
+        // accidental rebuild request. The rebuilder's invariant catches
+        // this; the endpoint surfaces it as 409 with the refusal reason.
+        var (_, baseUrl, dataDir) = BootServer();
+        var dbPath = Path.Combine(dataDir, "healthy.dfdb");
+        await _http.PostAsJsonAsync($"{baseUrl}/databases",
+            new { name = "healthy", path = dbPath });
+        var body = new StringContent("""{"x":1}""", System.Text.Encoding.UTF8, "application/json");
+        await _http.PostAsync($"{baseUrl}/db/healthy/collections/things", body);
+        await _http.DeleteAsync($"{baseUrl}/databases/healthy");
+
+        // Note: catalog is INTACT here — we did not zero page 1.
+        var resp = await _http.PostAsync(
+            $"{baseUrl}/databases/rebuild-catalog?path={Uri.EscapeDataString(dbPath)}",
+            content: null);
+        Assert.Equal(System.Net.HttpStatusCode.Conflict, resp.StatusCode);
+        var json = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("not empty", json);
+    }
+
+    /// <summary>Overwrite page 1 (the collection catalog page) of a
+    /// .dfdb file with zeros to simulate the corruption seen in the
+    /// Issue #86 scenario. Header page 0 and data pages 2+ stay intact.</summary>
+    private static void ZeroPage1(string dbPath)
+    {
+        using var fs = new FileStream(dbPath, FileMode.Open, FileAccess.ReadWrite,
+            FileShare.None);
+        fs.Seek(Constants.PageSize, SeekOrigin.Begin);
+        var zeros = new byte[Constants.PageSize];
+        fs.Write(zeros, 0, zeros.Length);
+        fs.Flush(true);
+    }
+
+    private sealed class RebuildPlanResponse
+    {
+        public string Path { get; set; } = "";
+        public bool SafeToRebuild { get; set; }
+        public string? RefusalReason { get; set; }
+        public List<PlanChainRow> Chains { get; set; } = new();
+    }
+    private sealed class PlanChainRow
+    {
+        public string SuggestedName { get; set; } = "";
+        public uint FirstPageId { get; set; }
+        public long DocumentCount { get; set; }
+        public int PageCount { get; set; }
+    }
+    private sealed class RebuildResultResponse
+    {
+        public string Path { get; set; } = "";
+        public string BackupPath { get; set; } = "";
+        public int BackedUpPage1Bytes { get; set; }
+        public List<RecoveredRow> Recovered { get; set; } = new();
+    }
+    private sealed class RecoveredRow
+    {
+        public string Name { get; set; } = "";
+        public uint FirstPageId { get; set; }
+        public long DocumentCount { get; set; }
     }
 
     // Issue #85 — GET /databases/{name}/health. Diagnostic surface.


### PR DESCRIPTION
## Summary

The recovery path for catalog corruption. Scans data pages, finds
chain heads, synthesises a new catalog page, backs up the old one.
Built as the foundation of a forensics toolkit — `DatabaseInspector`
(read-only page walker) will also power future `dfdb inspect / verify
/ dump` CLIs.

## End-to-end live test (the bbqdubai scenario)

1. Created DB with 5 docs in 'orders' collection
2. Detached
3. **Zeroed page 1** (catalog corruption — exactly the bbqdubai symptom)
4. `GET /databases/rebuild-catalog/preview` → discovered 1 chain w/ 5 docs at firstPageId=2
5. `POST /databases/rebuild-catalog` → wrote new catalog as `recovered_p2`, backup at `.page1.backup`
6. Re-attached
7. `SELECT * FROM recovered_p2` → **returned all 5 original docs with identical `_id` + `_etag`**

## Safety invariants enforced

All surface as 409 Conflict with human-readable reasons:

- Refuses if the catalog already has live entries (won't clobber working data)
- Refuses if no data-page chains were discovered (nothing to recover)
- Refuses if the file is currently attached (rebuilder needs exclusive access)
- Always writes `.page1.backup` BEFORE touching page 1 (operation is reversible by overwriting page 1 with the backup file)
- Stamps CRC32 on the new page so subsequent Opens verify it

## What ships

- **`DatabaseInspector`** — `DocumentForge.Storage`. Tolerates partial reads and damaged headers; doesn't touch the engine's locking.
- **`CatalogRebuilder`** — same project. Single FileStream (avoids self-conflict), FileShare.Read.
- **2 REST endpoints** — preview + execute. Operator workflow: Detach → preview → confirm → execute → re-attach.
- **Studio rebuild wizard** — multi-stage modal launched from the health modal's CTA when recommendation === "rebuild-catalog". Chain preview table, confirmation, result with backup path + recovered collection list + next-step guidance.

## Test plan

- [x] 4 new endpoint tests: preview-zeroed-DB, full roundtrip with reattach + query, conflict when attached, refuse-on-healthy-catalog
- [x] Full backend suite: 331/331 passing
- [x] `npm run build` admin-ui: clean
- [x] End-to-end live walkthrough above

## Out of scope (future)

- `dfdb inspect file.dfdb` CLI — page-by-page structure dump (uses DatabaseInspector)
- `dfdb verify file.dfdb` — checksum every page
- `dfdb dump file.dfdb` — last-resort export to JSON
- Recovered-collection RENAME helper (currently SQL: `RENAME COLLECTION recovered_pN TO real`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)