### PR TITLE
build: installer option — run the service at Windows startup

### DIFF
--- a/installer/DocumentForgeStudio.iss
+++ b/installer/DocumentForgeStudio.iss
@@ -63,6 +63,7 @@ Name: "{group}\Uninstall DocumentForge Studio"; Filename: "{uninstallexe}"
 
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Components: studio; Flags: unchecked
+Name: "startupservice"; Description: "Run the DocumentForge service automatically at Windows startup (background, as SYSTEM — needs admin approval)"; GroupDescription: "Service:"; Components: service; Flags: unchecked
 
 [Registry]
 ; Per-user .dfdb file association -> opens Studio (only if the client is installed).
@@ -115,9 +116,44 @@ begin
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
+var
+  Ps1, Content: String;
+  ResultCode: Integer;
 begin
+  if CurStep <> ssPostInstall then
+    Exit;
+
   // Record the chosen port next to the app so Studio's first-run connection
   // and the service shortcut agree.
-  if CurStep = ssPostInstall then
-    SaveStringToFile(ExpandConstant('{app}\port.txt'), GetPort(''), False);
+  SaveStringToFile(ExpandConstant('{app}\port.txt'), GetPort(''), False);
+
+  // Optional: register a startup Scheduled Task (runs the service at boot as
+  // SYSTEM). Elevated via a UAC prompt because the installer itself is per-user.
+  if WizardIsComponentSelected('service') and WizardIsTaskSelected('startupservice') then
+  begin
+    Ps1 := ExpandConstant('{app}\install-service-task.ps1');
+    Content :=
+      '$exe = ''' + ExpandConstant('{app}\service\dfdb.exe') + '''' + #13#10 +
+      '$arg = ''serve --port ' + GetPort('') + ' --data-dir "{#DataDir}"''' + #13#10 +
+      '$a = New-ScheduledTaskAction -Execute $exe -Argument $arg' + #13#10 +
+      '$t = New-ScheduledTaskTrigger -AtStartup' + #13#10 +
+      '$p = New-ScheduledTaskPrincipal -UserId ''SYSTEM'' -RunLevel Highest' + #13#10 +
+      '$s = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)' + #13#10 +
+      'Register-ScheduledTask -TaskName ''DocumentForge Service'' -Action $a -Trigger $t -Principal $p -Settings $s -Force' + #13#10;
+    SaveStringToFile(Ps1, Content, False);
+    if not ShellExec('runas', 'powershell.exe',
+        '-NoProfile -ExecutionPolicy Bypass -File "' + Ps1 + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+       or (ResultCode <> 0) then
+      MsgBox('The startup service task could not be registered (you may have declined the admin prompt). ' +
+             'You can still start the service from the Start Menu shortcut, or re-run setup.', mbInformation, MB_OK);
+  end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+var
+  ResultCode: Integer;
+begin
+  // Only prompt for elevation if we actually created the startup task.
+  if (CurUninstallStep = usUninstall) and FileExists(ExpandConstant('{app}\install-service-task.ps1')) then
+    ShellExec('runas', 'schtasks.exe', '/delete /tn "DocumentForge Service" /f', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;


### PR DESCRIPTION
Adds a **'Run the DocumentForge service automatically at Windows startup'** option to the installer (service component). When ticked, it elevates via UAC and registers a boot Scheduled Task running `dfdb serve` as SYSTEM (restart-on-failure) with the chosen port + data dir. Uninstall removes the task. `dfdb serve` isn't a native Windows service, so a boot task is the clean auto-start without engine changes (a true services.msc entry is filed as an engine enhancement). 🤖 Generated with [Claude Code](https://claude.com/claude-code)