### PR TITLE
feat: secure an open server with an API key (one click)

### DIFF
--- a/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
@@ -14,13 +14,22 @@ public sealed record ApiKeyRow(string Id, string Scopes, string? Description, st
 public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
 {
     private readonly IDfConnection _connection;
+    private readonly Func<Task> _onSecure;
 
-    public ApiKeysDocumentViewModel(IDfConnection connection)
+    public ApiKeysDocumentViewModel(IDfConnection connection, Func<Task> onSecure)
     {
         _connection = connection;
+        _onSecure = onSecure;
         Title = $"API Keys — {connection.Descriptor.Name}";
         ContentId = $"keys:{connection.Descriptor.Id}";
     }
+
+    /// <summary>True when this connection has no API key — i.e. the server is
+    /// (probably) in open dev-mode. Drives the "secure this server" banner.</summary>
+    public bool IsUnsecured => _connection.Descriptor.ApiKeySecretId is null;
+
+    [RelayCommand]
+    private Task Secure() => _onSecure();
 
     public ObservableCollection<ApiKeyRow> Keys { get; } = new();
 

--- a/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
@@ -503,10 +503,63 @@ public sealed partial class MainViewModel : ObservableObject
         var existing = Documents.FirstOrDefault(d => d.ContentId == contentId);
         if (existing is not null) { ActiveDocument = existing; return; }
 
-        var document = new ApiKeysDocumentViewModel(server.Connection);
+        var document = new ApiKeysDocumentViewModel(server.Connection, () => SecureServerAsync(server));
         Documents.Add(document);
         ActiveDocument = document;
         StatusText = $"API Keys — {server.Connection.Descriptor.Name}";
+    }
+
+    /// <summary>Secures an open (dev-mode) server: mints an admin key, switches
+    /// THIS connection to use it, and reconnects — so you don't lock yourself
+    /// out (creating the first key ends dev-mode immediately).</summary>
+    public async Task SecureServerAsync(ServerNodeViewModel server)
+    {
+        var descriptor = server.Connection.Descriptor;
+        if (descriptor.ApiKeySecretId is not null)
+        {
+            _dialogs.ShowInfo("Already secured", "This connection already uses an API key.");
+            return;
+        }
+        if (!_dialogs.Confirm("Secure server",
+                "This creates an admin API key on the server and switches this connection to use it. " +
+                "The server will then require a key for every request.\n\nContinue?"))
+            return;
+
+        Core.Models.CreatedApiKey created;
+        // "*" is the admin scope in DocumentForge (see AuthContext.FromScopes).
+        try { created = await server.Connection.CreateApiKeyAsync("Studio admin key", new[] { "*" }); }
+        catch (Exception ex) { _dialogs.ShowError("Secure failed", ex.Message); return; }
+
+        // Persist the key onto the connection and reconnect with it.
+        var isSaved = _workspace.Connections.Any(c => c.Id == descriptor.Id);
+        descriptor.ApiKeySecretId = _workspace.Secrets.Set(descriptor.ApiKeySecretId, created.Secret);
+        if (isSaved) _workspace.SaveConnections();
+
+        // Close the API Keys tab bound to the now-stale connection.
+        if (Documents.FirstOrDefault(d => d.ContentId == $"keys:{descriptor.Id}") is { } keysDoc)
+            Documents.Remove(keysDoc);
+
+        await DisconnectAsync(server);
+        var connection = ConnectionFactory.Create(descriptor, created.Secret);
+        try
+        {
+            await connection.ConnectAsync();
+            var node = new ServerNodeViewModel(this, connection);
+            Servers.Add(node);
+            node.IsExpanded = true;
+            StatusText = $"Secured {descriptor.Name} and reconnected with the admin key.";
+            _dialogs.ShowInfo("Server secured",
+                "The server now requires an API key. This connection was updated to use the new admin key" +
+                (isSaved ? " and saved." : ".") +
+                "\n\nAdmin key (copy it now for other clients — it can't be shown again):\n\n" + created.Secret);
+        }
+        catch (Exception ex)
+        {
+            await connection.DisposeAsync();
+            _dialogs.ShowError("Reconnect failed",
+                $"The server was secured, but reconnecting with the new key failed: {ex.Message}\n\n" +
+                "Use Connect to reconnect with this key:\n" + created.Secret);
+        }
     }
 
     /// <summary>Opens (or re-focuses) the replication topology graph for a server.</summary>

--- a/src/DocumentForge.Studio/Views/ApiKeysView.xaml
+++ b/src/DocumentForge.Studio/Views/ApiKeysView.xaml
@@ -7,8 +7,23 @@
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance vm:ApiKeysDocumentViewModel}">
     <DockPanel Margin="14">
-        <TextBlock DockPanel.Dock="Top" Text="API Keys" FontSize="18" FontWeight="Light"/>
+        <TextBlock DockPanel.Dock="Top" Text="API Keys &amp; security" FontSize="18" FontWeight="Light"/>
         <TextBlock DockPanel.Dock="Bottom" Text="{Binding StatusMessage}" Margin="0,8,0,0" TextWrapping="Wrap"/>
+
+        <!-- Security state banner (shown when this connection has no key = open server) -->
+        <Border DockPanel.Dock="Top" Background="#FDECEA" BorderBrush="#C0392B" BorderThickness="1"
+                CornerRadius="5" Padding="12,8" Margin="0,10,0,0"
+                Visibility="{Binding IsUnsecured, Converter={StaticResource BoolToVis}}">
+            <DockPanel>
+                <Button DockPanel.Dock="Right" Content="🔒 Secure this server" Padding="12,4" Margin="10,0,0,0"
+                        VerticalAlignment="Center" Command="{Binding SecureCommand}"/>
+                <StackPanel VerticalAlignment="Center">
+                    <TextBlock Text="⚠ This server is not secured" FontWeight="SemiBold" Foreground="#C0392B"/>
+                    <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="#7A2018" Margin="0,2,0,0"
+                               Text="No API key is set, so anyone who can reach it can read and write all data. Click 'Secure this server' to mint an admin key, apply it to this connection, and reconnect (no lock-out)."/>
+                </StackPanel>
+            </DockPanel>
+        </Border>
 
         <!-- One-time secret banner -->
         <Border DockPanel.Dock="Top" Background="#E6F7EC" BorderBrush="#2E8B57" BorderThickness="1"
@@ -30,9 +45,9 @@
             <StackPanel>
                 <TextBlock Text="Create a key" FontWeight="SemiBold"/>
                 <TextBlock Foreground="Gray" FontSize="11" Margin="0,2,0,2" TextWrapping="Wrap"
-                           Text="Scopes (comma-separated): admin (full access), db:&lt;name&gt; (read+write one DB), db:&lt;name&gt;:read (read-only)."/>
+                           Text="Scopes (comma-separated): * (full admin), db:&lt;name&gt; (read+write one DB), db:&lt;name&gt;:read (read-only), db:* (all DBs)."/>
                 <TextBlock Foreground="#B00" FontSize="11" Margin="0,0,0,6" TextWrapping="Wrap"
-                           Text="⚠ On a dev-mode server (no auth yet), creating the FIRST key immediately locks the server down. Include an 'admin' scope (or reconnect with the new key) or you'll lose admin access."/>
+                           Text="⚠ On a dev-mode server (no auth yet), creating the FIRST key immediately locks the server down. Include the * (admin) scope (or reconnect with the new key) or you'll lose admin access. Tip: use 'Secure this server' above."/>
                 <DockPanel>
                     <Button DockPanel.Dock="Right" Content="Create key" Padding="12,3" Margin="8,0,0,0"
                             Command="{Binding CreateCommand}"/>


### PR DESCRIPTION
Adds a **'🔒 Secure this server'** flow to the API Keys panel: when the connection has no key (open/dev-mode server), a banner offers a one-click secure that mints an admin key, applies it to the connection, reconnects, and shows the key once. Closes the dev-mode lock-out footgun. Also fixes a real bug found live — DocumentForge's admin scope is `*`, not `admin` (a key with `admin` authenticates but is denied everything), so the flow + help text now use `*`. Verified: `*` key grants full admin; keyless request to a secured server is 401. 🤖 Generated with [Claude Code](https://claude.com/claude-code)