### PR TITLE
feat(#124): native Windows service for dfdb + installer integration

### DIFF
--- a/installer/DocumentForgeStudio.iss
+++ b/installer/DocumentForgeStudio.iss
@@ -63,7 +63,7 @@ Name: "{group}\Uninstall DocumentForge Studio"; Filename: "{uninstallexe}"
 
 [Tasks]
 Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription: "Additional shortcuts:"; Components: studio; Flags: unchecked
-Name: "startupservice"; Description: "Run the DocumentForge service automatically at Windows startup (background, as SYSTEM — needs admin approval)"; GroupDescription: "Service:"; Components: service; Flags: unchecked
+Name: "startupservice"; Description: "Install as a Windows service (auto-start on boot, managed in services.msc — needs admin approval)"; GroupDescription: "Service:"; Components: service; Flags: unchecked
 
 [Registry]
 ; Per-user .dfdb file association -> opens Studio (only if the client is installed).
@@ -117,7 +117,7 @@ end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 var
-  Ps1, Content: String;
+  Exe, Params: String;
   ResultCode: Integer;
 begin
   if CurStep <> ssPostInstall then
@@ -127,25 +127,20 @@ begin
   // and the service shortcut agree.
   SaveStringToFile(ExpandConstant('{app}\port.txt'), GetPort(''), False);
 
-  // Optional: register a startup Scheduled Task (runs the service at boot as
-  // SYSTEM). Elevated via a UAC prompt because the installer itself is per-user.
+  // Optional: register a real Windows service (dfdb service install, which also
+  // starts it). Elevated via UAC because the installer itself is per-user.
   if WizardIsComponentSelected('service') and WizardIsTaskSelected('startupservice') then
   begin
-    Ps1 := ExpandConstant('{app}\install-service-task.ps1');
-    Content :=
-      '$exe = ''' + ExpandConstant('{app}\service\dfdb.exe') + '''' + #13#10 +
-      '$arg = ''serve --port ' + GetPort('') + ' --data-dir "{#DataDir}"''' + #13#10 +
-      '$a = New-ScheduledTaskAction -Execute $exe -Argument $arg' + #13#10 +
-      '$t = New-ScheduledTaskTrigger -AtStartup' + #13#10 +
-      '$p = New-ScheduledTaskPrincipal -UserId ''SYSTEM'' -RunLevel Highest' + #13#10 +
-      '$s = New-ScheduledTaskSettingsSet -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)' + #13#10 +
-      'Register-ScheduledTask -TaskName ''DocumentForge Service'' -Action $a -Trigger $t -Principal $p -Settings $s -Force' + #13#10;
-    SaveStringToFile(Ps1, Content, False);
-    if not ShellExec('runas', 'powershell.exe',
-        '-NoProfile -ExecutionPolicy Bypass -File "' + Ps1 + '"', '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
+    Exe := ExpandConstant('{app}\service\dfdb.exe');
+    Params := 'service install --port ' + GetPort('') + ' --data-dir "{#DataDir}"';
+    if not ShellExec('runas', Exe, Params, '', SW_HIDE, ewWaitUntilTerminated, ResultCode)
        or (ResultCode <> 0) then
-      MsgBox('The startup service task could not be registered (you may have declined the admin prompt). ' +
-             'You can still start the service from the Start Menu shortcut, or re-run setup.', mbInformation, MB_OK);
+      MsgBox('The Windows service could not be installed (you may have declined the admin prompt). ' +
+             'You can install it later from an elevated prompt with:  dfdb service install, ' +
+             'or run it manually from the Start Menu shortcut.', mbInformation, MB_OK)
+    else
+      // Marker so uninstall knows to remove the service.
+      SaveStringToFile(ExpandConstant('{app}\service-installed.txt'), 'DocumentForge', False);
   end;
 end;
 
@@ -153,7 +148,7 @@ procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
   ResultCode: Integer;
 begin
-  // Only prompt for elevation if we actually created the startup task.
-  if (CurUninstallStep = usUninstall) and FileExists(ExpandConstant('{app}\install-service-task.ps1')) then
-    ShellExec('runas', 'schtasks.exe', '/delete /tn "DocumentForge Service" /f', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
+  // Remove the Windows service before the files go (only if we installed it).
+  if (CurUninstallStep = usUninstall) and FileExists(ExpandConstant('{app}\service-installed.txt')) then
+    ShellExec('runas', ExpandConstant('{app}\service\dfdb.exe'), 'service uninstall', '', SW_HIDE, ewWaitUntilTerminated, ResultCode);
 end;

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -4,6 +4,7 @@ using DocumentForge.Core;
 using DocumentForge.Document;
 using DocumentForge.Engine;
 using DocumentForge.Index;
+using Microsoft.Extensions.Hosting;
 
 namespace DocumentForge.Cli.Commands;
 
@@ -18,6 +19,10 @@ public static class ServeCommand
         var config = NodeConfig.Load(args);
 
         var builder = WebApplication.CreateBuilder(args);
+
+        // Run happily as a Windows service when launched by the SCM (via
+        // `dfdb service install`); a no-op for normal console `serve`.
+        builder.Host.UseWindowsService(options => options.ServiceName = "DocumentForge");
 
         // Sensible default logging - quiet the per-request ASP.NET Core chatter
         // (4-5 lines per request swamps real signal at any traffic) but keep the

--- a/src/DocumentForge.Cli/Commands/ServiceCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServiceCommand.cs
@@ -1,0 +1,160 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace DocumentForge.Cli.Commands;
+
+/// <summary>
+/// `dfdb service ...` — install/manage DocumentForge as a native Windows
+/// service (visible in services.msc, auto-start on boot). Wraps <c>sc.exe</c>,
+/// so create/delete/start/stop require an elevated (admin) prompt.
+///
+/// <para>
+/// The installed service runs <c>dfdb serve</c> with the port/data-dir/api-key
+/// you pass here. Because `serve` calls <c>UseWindowsService()</c>, the process
+/// speaks the Service Control Manager protocol properly (no wrapper needed).
+/// </para>
+/// </summary>
+public static class ServiceCommand
+{
+    private const string DefaultServiceName = "DocumentForge";
+    private const string DisplayName = "DocumentForge Database Service";
+
+    public static int Run(string[] args)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            Console.Error.WriteLine("`dfdb service` manages a Windows service and is only available on Windows.");
+            Console.Error.WriteLine("On Linux/macOS, run `dfdb serve ...` under systemd/launchd instead.");
+            return 1;
+        }
+
+        if (args.Length == 0)
+        {
+            PrintHelp();
+            return 0;
+        }
+
+        var action = args[0].ToLowerInvariant();
+        var rest = args.Skip(1).ToArray();
+        return action switch
+        {
+            "install" => Install(rest),
+            "uninstall" or "remove" or "delete" => Uninstall(rest),
+            "start" => Sc($"start \"{GetName(rest)}\""),
+            "stop" => Sc($"stop \"{GetName(rest)}\""),
+            "status" => Sc($"query \"{GetName(rest)}\""),
+            "help" or "--help" or "-h" => PrintHelp(),
+            _ => Unknown(action),
+        };
+    }
+
+    private static int Install(string[] args)
+    {
+        var name = GetName(args);
+        var exe = Environment.ProcessPath
+                  ?? throw new InvalidOperationException("Could not resolve the dfdb executable path.");
+
+        var port = GetOpt(args, "--port") ?? "4300";
+        var dataDir = GetOpt(args, "--data-dir") ?? @"C:\data\documentForge";
+        var apiKey = GetOpt(args, "--api-key");
+        var bindAll = args.Contains("--bind-all-interfaces");
+
+        Directory.CreateDirectory(dataDir);
+
+        // The command line the service runs. sc.exe wants the whole thing as one
+        // quoted binPath value, with inner quotes doubled.
+        var serveArgs = $"serve --port {port} --data-dir \"{dataDir}\"";
+        if (bindAll) serveArgs += " --bind-all-interfaces";
+        if (!string.IsNullOrWhiteSpace(apiKey)) serveArgs += $" --api-key \"{apiKey}\"";
+        var binPath = $"\"{exe}\" {serveArgs}";
+
+        // sc create: escape inner quotes by doubling them inside the outer binPath= "...".
+        var escaped = binPath.Replace("\"", "\\\"");
+        var createArgs =
+            $"create \"{name}\" binPath= \"{escaped}\" start= auto DisplayName= \"{DisplayName}\"";
+
+        Console.WriteLine($"Installing service '{name}' → {binPath}");
+        var rc = Sc(createArgs);
+        if (rc != 0) return rc;
+
+        Sc($"description \"{name}\" \"DocumentForge JSON document database (dfdb serve on port {port}).\"");
+        // Restart the service on failure (3 attempts, 5s apart).
+        Sc($"failure \"{name}\" reset= 86400 actions= restart/5000/restart/5000/restart/5000");
+
+        // Start it now (best-effort — if it can't start, e.g. the data dir is
+        // locked by another process, it's still installed and starts on boot).
+        Console.WriteLine("Starting service…");
+        if (Sc($"start \"{name}\"") != 0)
+            Console.WriteLine("Service installed but did not start now — it will start on next boot, or run `dfdb service start`.");
+        else
+            Console.WriteLine("Installed and started.");
+        return 0;
+    }
+
+    private static int Uninstall(string[] args)
+    {
+        var name = GetName(args);
+        // Best-effort stop first so delete succeeds immediately.
+        Sc($"stop \"{name}\"", ignoreErrors: true);
+        return Sc($"delete \"{name}\"");
+    }
+
+    /// <summary>Runs sc.exe with the given argument string. Returns its exit code.</summary>
+    private static int Sc(string arguments, bool ignoreErrors = false)
+    {
+        var psi = new ProcessStartInfo("sc.exe", arguments)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        using var p = Process.Start(psi)!;
+        var stdout = p.StandardOutput.ReadToEnd();
+        var stderr = p.StandardError.ReadToEnd();
+        p.WaitForExit();
+
+        if (!string.IsNullOrWhiteSpace(stdout)) Console.Write(stdout);
+        if (!ignoreErrors && p.ExitCode != 0)
+        {
+            if (!string.IsNullOrWhiteSpace(stderr)) Console.Error.Write(stderr);
+            if (p.ExitCode == 5)
+                Console.Error.WriteLine("Access denied — run this from an elevated (Administrator) prompt.");
+        }
+        return ignoreErrors ? 0 : p.ExitCode;
+    }
+
+    private static string GetName(string[] args) => GetOpt(args, "--name") ?? DefaultServiceName;
+
+    private static string? GetOpt(string[] args, string flag)
+    {
+        var i = Array.IndexOf(args, flag);
+        return i >= 0 && i + 1 < args.Length ? args[i + 1] : null;
+    }
+
+    private static int Unknown(string action)
+    {
+        Console.Error.WriteLine($"Unknown service action: '{action}'.");
+        PrintHelp();
+        return 1;
+    }
+
+    private static int PrintHelp()
+    {
+        Console.WriteLine();
+        Console.WriteLine("  dfdb service — run DocumentForge as a Windows service (needs admin)");
+        Console.WriteLine();
+        Console.WriteLine("    install   [--name N] [--port 4300] [--data-dir DIR] [--api-key KEY] [--bind-all-interfaces]");
+        Console.WriteLine("    uninstall [--name N]");
+        Console.WriteLine("    start     [--name N]");
+        Console.WriteLine("    stop      [--name N]");
+        Console.WriteLine("    status    [--name N]");
+        Console.WriteLine();
+        Console.WriteLine("  Default service name: DocumentForge   ·   default port: 4300");
+        Console.WriteLine();
+        Console.WriteLine("  EXAMPLE (elevated prompt):");
+        Console.WriteLine("    dfdb service install --port 4300 --data-dir C:\\data\\documentForge --api-key s3cret");
+        Console.WriteLine("    dfdb service start");
+        Console.WriteLine();
+        return 0;
+    }
+}

--- a/src/DocumentForge.Cli/DocumentForge.Cli.csproj
+++ b/src/DocumentForge.Cli/DocumentForge.Cli.csproj
@@ -14,6 +14,13 @@
     <ProjectReference Include="..\DocumentForge.Engine\DocumentForge.Engine.csproj" />
   </ItemGroup>
 
+  <!-- Windows service host support: UseWindowsService() is a no-op unless the
+       process is actually launched by the Service Control Manager, so this
+       stays safe for console `serve` and for Linux/macOS builds. -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.*" />
+  </ItemGroup>
+
   <!-- Pull in the airline seed data file so `dfdb seed` works out of the box -->
   <ItemGroup>
     <Compile Include="..\..\samples\DocumentForge.AirlineDemo\SeedData.cs" Link="SeedData.cs" />

--- a/src/DocumentForge.Cli/Program.cs
+++ b/src/DocumentForge.Cli/Program.cs
@@ -20,6 +20,7 @@ public class Program
             return sub switch
             {
                 "serve"     => ServeCommand.Run(rest),
+                "service"   => ServiceCommand.Run(rest),
                 "router"    => RouterCommand.Run(rest),
                 "repl"      => ReplCommand.Run(rest),
                 "inspect"   => InspectCommand.Run(rest),
@@ -72,6 +73,11 @@ public class Program
         Console.WriteLine("           --leader-host H --leader-port N --auto-failover-seconds N]");
         Console.WriteLine("        Start the REST API for one node. Pairs with the admin UI.");
         Console.WriteLine("        Optional replication flags stand up a leader listener or follower loop.");
+        Console.WriteLine();
+        Console.WriteLine("  RUN AS A WINDOWS SERVICE (needs admin)");
+        Console.WriteLine("    service install [--port 4300 --data-dir DIR --api-key KEY]");
+        Console.WriteLine("    service uninstall | start | stop | status");
+        Console.WriteLine("        Register/manage dfdb as a native Windows service (services.msc).");
         Console.WriteLine();
         Console.WriteLine("  QUERY LOCAL DATABASE");
         Console.WriteLine("    inspect <file>                       Show stats, collections, indexes");


### PR DESCRIPTION
Adds native Windows service support to the engine and wires it into the installer.

**Engine/CLI:** `serve` calls `UseWindowsService()` (no-op for console/Linux/macOS); new `dfdb service install/uninstall/start/stop/status` verb wraps `sc.exe` (auto-start, restart-on-failure, runs `dfdb serve` with the chosen port/data-dir/api-key).

**Installer:** the 'run at startup' option now installs a **real Windows service** (services.msc) via `dfdb service install` (elevated), instead of the Scheduled Task workaround. Uninstall removes it.

**Verified:** service reaches STATE=RUNNING and serves HTTP (health ok), stop/uninstall clean; console `serve` unaffected; all 341 engine tests pass. Closes #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)