### PR TITLE
feat(studio): friendlier API-key + sharding forms (dropdowns)

### DIFF
--- a/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
@@ -9,6 +9,13 @@ namespace DocumentForge.Studio.ViewModels;
 
 public sealed record ApiKeyRow(string Id, string Scopes, string? Description, string? CreatedAt);
 
+/// <summary>A friendly scope option. <see cref="Kind"/> is "*", "db:*",
+/// "db-rw" or "db-read"; the last two combine with a chosen database.</summary>
+public sealed record ScopeChoice(string Label, string Kind, bool NeedsDb)
+{
+    public override string ToString() => Label;
+}
+
 /// <summary>Manage a server's scoped API keys (a document tab): list, create
 /// (secret shown once), revoke.</summary>
 public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
@@ -22,6 +29,7 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
         _onSecure = onSecure;
         Title = $"API Keys — {connection.Descriptor.Name}";
         ContentId = $"keys:{connection.Descriptor.Id}";
+        _selectedScope = ScopeChoices[0];
     }
 
     /// <summary>True when this connection has no API key — i.e. the server is
@@ -36,7 +44,25 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
     [ObservableProperty] private bool _isBusy;
     [ObservableProperty] private string _statusMessage = "";
     [ObservableProperty] private string _newDescription = "";
-    [ObservableProperty] private string _newScopes = "";
+
+    // Guided scope selection instead of a raw scope string.
+    public IReadOnlyList<ScopeChoice> ScopeChoices { get; } = new[]
+    {
+        new ScopeChoice("Full admin — all access", "*", NeedsDb: false),
+        new ScopeChoice("One database — read & write", "db-rw", NeedsDb: true),
+        new ScopeChoice("One database — read only", "db-read", NeedsDb: true),
+        new ScopeChoice("All databases — read & write", "db:*", NeedsDb: false),
+    };
+
+    [ObservableProperty] private ScopeChoice _selectedScope;
+    [ObservableProperty] private string? _selectedDatabase;
+
+    public ObservableCollection<string> Databases { get; } = new();
+
+    /// <summary>Whether the current scope choice needs a database picked.</summary>
+    public bool NeedsDatabase => SelectedScope?.NeedsDb == true;
+
+    partial void OnSelectedScopeChanged(ScopeChoice value) => OnPropertyChanged(nameof(NeedsDatabase));
 
     // The one-time secret, shown after a successful create until dismissed.
     [ObservableProperty] private string _createdSecret = "";
@@ -51,6 +77,17 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
             Keys.Clear();
             foreach (var k in keys)
                 Keys.Add(new ApiKeyRow(k.Id, string.Join(", ", k.Scopes), k.Description, k.CreatedAt));
+
+            // Populate the database picker for db-scoped keys.
+            try
+            {
+                var dbs = await _connection.GetDatabasesAsync();
+                Databases.Clear();
+                foreach (var d in dbs) Databases.Add(d.Name);
+                SelectedDatabase ??= Databases.FirstOrDefault();
+            }
+            catch { /* keep any existing list */ }
+
             StatusMessage = $"{Keys.Count} key(s).";
         }
         catch (Exception ex)
@@ -66,21 +103,28 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
     [RelayCommand]
     private async Task CreateAsync()
     {
-        var scopes = NewScopes.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (scopes.Length == 0)
+        var choice = SelectedScope ?? ScopeChoices[0];
+        string scope;
+        if (choice.Kind == "*") scope = "*";
+        else if (choice.Kind == "db:*") scope = "db:*";
+        else
         {
-            StatusMessage = "Enter at least one scope (e.g. admin, or db:orders, or db:orders:read).";
-            return;
+            if (string.IsNullOrWhiteSpace(SelectedDatabase))
+            {
+                StatusMessage = "Pick a database for this scope.";
+                return;
+            }
+            scope = choice.Kind == "db-read" ? $"db:{SelectedDatabase}:read" : $"db:{SelectedDatabase}";
         }
+
         IsBusy = true;
         try
         {
             var created = await _connection.CreateApiKeyAsync(
-                string.IsNullOrWhiteSpace(NewDescription) ? null : NewDescription.Trim(), scopes);
+                string.IsNullOrWhiteSpace(NewDescription) ? null : NewDescription.Trim(), new[] { scope });
             CreatedSecret = created.Secret;
             NewDescription = "";
-            NewScopes = "";
-            StatusMessage = $"Created key {created.Id}. Copy the secret now — it can't be retrieved again.";
+            StatusMessage = $"Created key {created.Id} (scope {scope}). Copy the secret now — it can't be retrieved again.";
             await RefreshAsync();
         }
         catch (Exception ex)

--- a/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
@@ -69,6 +69,11 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
     [ObservableProperty] private ShardingStrategy _newCollectionStrategy;
     [ObservableProperty] private string _newCollectionShardKey = "";
 
+    /// <summary>Only a hash-sharded collection needs a shard key.</summary>
+    public bool NeedsShardKey => NewCollectionStrategy == ShardingStrategy.Hash;
+
+    partial void OnNewCollectionStrategyChanged(ShardingStrategy value) => OnPropertyChanged(nameof(NeedsShardKey));
+
     public string SummaryText =>
         $"{Shards.Count} shard(s) · {Collections.Count} collection policy(ies) · {_config.VirtualNodesPerShard} vnodes/shard";
 

--- a/src/DocumentForge.Studio/Views/ApiKeysView.xaml
+++ b/src/DocumentForge.Studio/Views/ApiKeysView.xaml
@@ -44,18 +44,34 @@
         <Border DockPanel.Dock="Top" BorderBrush="#E4E4E4" BorderThickness="1" CornerRadius="5" Padding="12" Margin="0,10,0,10">
             <StackPanel>
                 <TextBlock Text="Create a key" FontWeight="SemiBold"/>
-                <TextBlock Foreground="Gray" FontSize="11" Margin="0,2,0,2" TextWrapping="Wrap"
-                           Text="Scopes (comma-separated): * (full admin), db:&lt;name&gt; (read+write one DB), db:&lt;name&gt;:read (read-only), db:* (all DBs)."/>
-                <TextBlock Foreground="#B00" FontSize="11" Margin="0,0,0,6" TextWrapping="Wrap"
-                           Text="⚠ On a dev-mode server (no auth yet), creating the FIRST key immediately locks the server down. Include the * (admin) scope (or reconnect with the new key) or you'll lose admin access. Tip: use 'Secure this server' above."/>
-                <DockPanel>
-                    <Button DockPanel.Dock="Right" Content="Create key" Padding="12,3" Margin="8,0,0,0"
-                            Command="{Binding CreateCommand}"/>
-                    <TextBox Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}" Width="180"
+                <TextBlock Foreground="#B00" FontSize="11" Margin="0,2,0,8" TextWrapping="Wrap"
+                           Text="⚠ On a dev-mode server (no auth yet), creating the FIRST key immediately locks the server down. Use a Full-admin key (or 'Secure this server' above) so you don't lose access."/>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="220"/>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="180"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Grid.Column="0" Text="Access:" VerticalAlignment="Center" Margin="0,0,6,0"/>
+                    <ComboBox Grid.Column="1" ItemsSource="{Binding ScopeChoices}" SelectedItem="{Binding SelectedScope}"
+                              VerticalAlignment="Center"/>
+
+                    <TextBlock Grid.Column="2" Text="Database:" VerticalAlignment="Center" Margin="12,0,6,0"
+                               Visibility="{Binding NeedsDatabase, Converter={StaticResource BoolToVis}}"/>
+                    <ComboBox Grid.Column="3" ItemsSource="{Binding Databases}" SelectedItem="{Binding SelectedDatabase}"
+                              VerticalAlignment="Center"
+                              Visibility="{Binding NeedsDatabase, Converter={StaticResource BoolToVis}}"/>
+
+                    <TextBox Grid.Column="4" Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
+                             Margin="12,0,0,0" VerticalContentAlignment="Center"
                              ToolTip="Description (optional)"/>
-                    <TextBox Text="{Binding NewScopes, UpdateSourceTrigger=PropertyChanged}" Margin="8,0,0,0"
-                             ToolTip="Scopes, e.g. db:orders, db:crm:read"/>
-                </DockPanel>
+                    <Button Grid.Column="5" Content="Create key" Padding="12,3" Margin="8,0,0,0"
+                            Command="{Binding CreateCommand}"/>
+                </Grid>
             </StackPanel>
         </Border>
 

--- a/src/DocumentForge.Studio/Views/ClusterView.xaml
+++ b/src/DocumentForge.Studio/Views/ClusterView.xaml
@@ -80,7 +80,8 @@
                     <ComboBox ItemsSource="{Binding Strategies}" SelectedItem="{Binding NewCollectionStrategy}"
                               Width="120" Margin="8,0,0,0"/>
                     <TextBox Text="{Binding NewCollectionShardKey, UpdateSourceTrigger=PropertyChanged}" Width="160" Margin="8,0,0,0"
-                             ToolTip="Shard key path (hash strategy only), e.g. customerId"/>
+                             IsEnabled="{Binding NeedsShardKey}"
+                             ToolTip="Shard key path — required for hash, ignored for replicated (e.g. customerId)"/>
                     <Button Content="Add / update" Command="{Binding AddCollectionCommand}" Padding="10,2" Margin="8,0,0,0"/>
                 </StackPanel>
 


### PR DESCRIPTION
Per feedback that the API Keys form was hard to use: replaces the hand-typed scope string with **dropdowns** — an *Access* level (Full admin / one DB read-write / one DB read-only / all DBs) plus a *Database* picker (from the server's databases) shown only when needed. The tool builds the correct scope (`*`, `db:<name>`, `db:<name>:read`, `db:*`). Sharding: the shard-key field is now disabled for the Replicated strategy (only Hash uses it). 🤖 Generated with [Claude Code](https://claude.com/claude-code)