### PR TITLE
feat(studio): key-creation lock-out guard + Description label

### DIFF
--- a/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ApiKeysDocumentViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DocumentForge.Studio.Core.Connections;
 using DocumentForge.Studio.Core.Models;
+using DocumentForge.Studio.Services;
 
 namespace DocumentForge.Studio.ViewModels;
 
@@ -22,11 +23,13 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
 {
     private readonly IDfConnection _connection;
     private readonly Func<Task> _onSecure;
+    private readonly IDialogService _dialogs;
 
-    public ApiKeysDocumentViewModel(IDfConnection connection, Func<Task> onSecure)
+    public ApiKeysDocumentViewModel(IDfConnection connection, Func<Task> onSecure, IDialogService dialogs)
     {
         _connection = connection;
         _onSecure = onSecure;
+        _dialogs = dialogs;
         Title = $"API Keys — {connection.Descriptor.Name}";
         ContentId = $"keys:{connection.Descriptor.Id}";
         _selectedScope = ScopeChoices[0];
@@ -115,6 +118,27 @@ public sealed partial class ApiKeysDocumentViewModel : DocumentViewModel
                 return;
             }
             scope = choice.Kind == "db-read" ? $"db:{SelectedDatabase}:read" : $"db:{SelectedDatabase}";
+        }
+
+        // Lock-out protection: on an open (dev-mode) server, the first key ends
+        // dev-mode immediately. A non-admin first key locks you out of admin.
+        if (IsUnsecured)
+        {
+            var isAdmin = scope == "*";
+            var message = isAdmin
+                ? "This server is currently open (no auth). Creating this admin key will make it require a key for every request.\n\n" +
+                  "This connection isn't using a key yet, so you'd need to reconnect with the new key afterwards. The " +
+                  "\"Secure this server\" button does that for you automatically — prefer it unless you have a reason not to.\n\n" +
+                  "Create this admin key anyway?"
+                : "⚠  LOCK-OUT RISK\n\n" +
+                  "This server is open (no auth). Creating the first key locks it down immediately — and because this key " +
+                  "is NOT full admin, you will lose the ability to manage this server from here (and there's no undo without " +
+                  "server-side access).\n\n" +
+                  "Strongly recommended: Cancel, then use \"Secure this server\" at the top to create an admin key that keeps " +
+                  "you connected. You can add scoped keys like this one afterwards.\n\n" +
+                  "Create this non-admin key anyway?";
+            if (!_dialogs.Confirm("Create key — please read", message))
+                return;
         }
 
         IsBusy = true;

--- a/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
@@ -503,7 +503,7 @@ public sealed partial class MainViewModel : ObservableObject
         var existing = Documents.FirstOrDefault(d => d.ContentId == contentId);
         if (existing is not null) { ActiveDocument = existing; return; }
 
-        var document = new ApiKeysDocumentViewModel(server.Connection, () => SecureServerAsync(server));
+        var document = new ApiKeysDocumentViewModel(server.Connection, () => SecureServerAsync(server), _dialogs);
         Documents.Add(document);
         ActiveDocument = document;
         StatusText = $"API Keys — {server.Connection.Descriptor.Name}";

--- a/src/DocumentForge.Studio/Views/ApiKeysView.xaml
+++ b/src/DocumentForge.Studio/Views/ApiKeysView.xaml
@@ -52,6 +52,7 @@
                         <ColumnDefinition Width="220"/>
                         <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="180"/>
+                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
                     </Grid.ColumnDefinitions>
@@ -66,10 +67,11 @@
                               VerticalAlignment="Center"
                               Visibility="{Binding NeedsDatabase, Converter={StaticResource BoolToVis}}"/>
 
-                    <TextBox Grid.Column="4" Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
-                             Margin="12,0,0,0" VerticalContentAlignment="Center"
-                             ToolTip="Description (optional)"/>
-                    <Button Grid.Column="5" Content="Create key" Padding="12,3" Margin="8,0,0,0"
+                    <TextBlock Grid.Column="4" Text="Description:" VerticalAlignment="Center" Margin="12,0,6,0"/>
+                    <TextBox Grid.Column="5" Text="{Binding NewDescription, UpdateSourceTrigger=PropertyChanged}"
+                             VerticalContentAlignment="Center"
+                             ToolTip="A label to remember what this key is for (optional)"/>
+                    <Button Grid.Column="6" Content="Create key" Padding="12,3" Margin="8,0,0,0"
                             Command="{Binding CreateCommand}"/>
                 </Grid>
             </StackPanel>


### PR DESCRIPTION
Follow-up to the friendlier key form: creating a key on an **open (dev-mode) server** now shows a **modal confirmation** first — a strong LOCK-OUT RISK warning for a non-admin first key (recommending 'Secure this server'), and a milder heads-up for an admin key. The old passive red text wasn't enough (easy to lock yourself out). Also labels the description field 'Description:'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)