### PR TITLE
feat(studio): cluster editor picks shard endpoints & suggests collection names

### DIFF
--- a/src/DocumentForge.Studio.Core/Cluster/ClusterHealth.cs
+++ b/src/DocumentForge.Studio.Core/Cluster/ClusterHealth.cs
@@ -13,6 +13,27 @@ public sealed record ShardHealth(bool Reachable, bool Healthy, string Status, st
 /// <c>dfdb health</c>.</summary>
 public static class ClusterHealth
 {
+    /// <summary>Best-effort: the collection names on a shard's default database,
+    /// so the cluster editor can suggest them. Empty on any failure.</summary>
+    public static async Task<IReadOnlyList<string>> TryGetCollectionsAsync(string endpoint, TimeSpan timeout, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(endpoint)) return Array.Empty<string>();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        cts.CancelAfter(timeout);
+        try
+        {
+            var descriptor = new ConnectionDescriptor { Name = endpoint, Kind = ConnectionKind.Http, Url = endpoint };
+            await using var connection = new HttpConnection(descriptor, apiKey: null);
+            var dbs = await connection.GetDatabasesAsync(cts.Token);
+            var target = dbs.FirstOrDefault(d => d.IsDefault) ?? dbs.FirstOrDefault();
+            return target is null ? Array.Empty<string>() : await connection.GetCollectionNamesAsync(target.Name, cts.Token);
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+
     public static async Task<ShardHealth> PingAsync(string endpoint, TimeSpan timeout, CancellationToken ct = default)
     {
         if (string.IsNullOrWhiteSpace(endpoint)) return ShardHealth.Down("no endpoint");

--- a/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
@@ -41,7 +41,8 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
     private readonly ClusterConfig _config;
     private readonly IDialogService _dialogs;
 
-    public ClusterDocumentViewModel(ClusterConfig config, string? filePath, IDialogService dialogs)
+    public ClusterDocumentViewModel(ClusterConfig config, string? filePath, IDialogService dialogs,
+        IReadOnlyList<string>? knownEndpoints = null)
     {
         _config = config;
         _dialogs = dialogs;
@@ -50,11 +51,25 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
         UpdateTitle();
         ReloadRows();
         NewCollectionStrategy = ShardingStrategy.Hash;
+
+        // Suggest shard endpoints from the user's saved connections + any endpoints
+        // already in this config, so they can pick instead of typing a URL.
+        foreach (var e in (knownEndpoints ?? Array.Empty<string>())
+                     .Concat(_config.Shards.Select(s => s.LeaderEndpoint))
+                     .Where(e => !string.IsNullOrWhiteSpace(e))
+                     .Distinct(StringComparer.OrdinalIgnoreCase))
+            ShardEndpointSuggestions.Add(e);
     }
 
     public ObservableCollection<ClusterShardRow> Shards { get; } = new();
     public ObservableCollection<ClusterCollectionRow> Collections { get; } = new();
     public IReadOnlyList<ShardingStrategy> Strategies { get; } = new[] { ShardingStrategy.Hash, ShardingStrategy.Replicated };
+
+    /// <summary>Endpoint URLs offered in the "add shard" box (saved connections + existing shards).</summary>
+    public ObservableCollection<string> ShardEndpointSuggestions { get; } = new();
+
+    /// <summary>Collection names discovered on healthy shards during a health check.</summary>
+    public ObservableCollection<string> CollectionSuggestions { get; } = new();
 
     [ObservableProperty] private string? _filePath;
     [ObservableProperty] private string _statusMessage = "";
@@ -176,6 +191,7 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
         var up = 0;
         try
         {
+            var discovered = new SortedSet<string>(CollectionSuggestions, StringComparer.OrdinalIgnoreCase);
             foreach (var row in Shards)
             {
                 row.Health = "checking…";
@@ -184,6 +200,10 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
                 {
                     up++;
                     row.Health = $"🟢 up{(h.Version is null ? "" : $" · v{h.Version}")}";
+                    // Best-effort: learn the collection names living on this shard
+                    // so the "add collection" box can suggest them.
+                    foreach (var c in await ClusterHealth.TryGetCollectionsAsync(row.LeaderEndpoint, TimeSpan.FromSeconds(5)))
+                        discovered.Add(c);
                 }
                 else if (h.Reachable)
                 {
@@ -193,6 +213,11 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
                 {
                     row.Health = $"🔴 unreachable · {h.Error}";
                 }
+            }
+            if (discovered.Count != CollectionSuggestions.Count)
+            {
+                CollectionSuggestions.Clear();
+                foreach (var c in discovered) CollectionSuggestions.Add(c);
             }
             StatusMessage = Shards.Count == 0
                 ? "No shards to check — add some first."

--- a/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
@@ -429,7 +429,11 @@ public sealed partial class MainViewModel : ObservableObject
             var existing = Documents.FirstOrDefault(d => d.ContentId == contentId);
             if (existing is not null) { ActiveDocument = existing; return; }
         }
-        var document = new ClusterDocumentViewModel(config, path, _dialogs);
+        var knownEndpoints = _workspace.Connections
+            .Where(c => c.Kind == Core.Connections.ConnectionKind.Http && !string.IsNullOrWhiteSpace(c.Url))
+            .Select(c => c.Url!)
+            .ToList();
+        var document = new ClusterDocumentViewModel(config, path, _dialogs, knownEndpoints);
         Documents.Add(document);
         ActiveDocument = document;
         StatusText = path is null ? "New cluster config" : $"Cluster — {System.IO.Path.GetFileName(path)}";

--- a/src/DocumentForge.Studio/Views/ClusterView.xaml
+++ b/src/DocumentForge.Studio/Views/ClusterView.xaml
@@ -47,8 +47,9 @@
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
                     <TextBox Text="{Binding NewShardName, UpdateSourceTrigger=PropertyChanged}" Width="140"
                              ToolTip="Shard name"/>
-                    <TextBox Text="{Binding NewShardEndpoint, UpdateSourceTrigger=PropertyChanged}" Width="240" Margin="8,0,0,0"
-                             ToolTip="Leader endpoint, e.g. http://shard-a:5001"/>
+                    <ComboBox IsEditable="True" Text="{Binding NewShardEndpoint, UpdateSourceTrigger=PropertyChanged}"
+                              ItemsSource="{Binding ShardEndpointSuggestions}" Width="240" Margin="8,0,0,0"
+                              ToolTip="Leader endpoint — pick a saved server or type one, e.g. http://shard-a:5001"/>
                     <Button Content="Add shard" Command="{Binding AddShardCommand}" Padding="10,2" Margin="8,0,0,0"/>
                 </StackPanel>
 
@@ -75,8 +76,9 @@
                     </DataGrid.Columns>
                 </DataGrid>
                 <StackPanel Orientation="Horizontal" Margin="0,6,0,0">
-                    <TextBox Text="{Binding NewCollectionName, UpdateSourceTrigger=PropertyChanged}" Width="180"
-                             ToolTip="Collection name"/>
+                    <ComboBox IsEditable="True" Text="{Binding NewCollectionName, UpdateSourceTrigger=PropertyChanged}"
+                              ItemsSource="{Binding CollectionSuggestions}" Width="180"
+                              ToolTip="Collection name — suggestions come from healthy shards after a health check"/>
                     <ComboBox ItemsSource="{Binding Strategies}" SelectedItem="{Binding NewCollectionStrategy}"
                               Width="120" Margin="8,0,0,0"/>
                     <TextBox Text="{Binding NewCollectionShardKey, UpdateSourceTrigger=PropertyChanged}" Width="160" Margin="8,0,0,0"


### PR DESCRIPTION
feat(studio): cluster editor picks shard endpoints & suggests collections

The cluster (sharding) editor no longer makes you type raw endpoints and
collection names from memory.

- Shard "Leader endpoint" is now an editable ComboBox seeded from your saved
  HTTP connections plus any endpoints already in the config. You can still
  type a free-form endpoint.
- Collection "name" is an editable ComboBox. Running "Check health" now also
  best-effort fetches the collection names living on each healthy shard's
  default database and offers them as suggestions.
- New Core helper ClusterHealth.TryGetCollectionsAsync (returns empty on any
  failure, 5s timeout) keeps the HTTP plumbing out of the view model.

Client-only. Studio builds clean; all 56 Studio.Core tests pass.
