### PR TITLE
feat(studio): cluster editor — hide .json, export, load live config from router

### DIFF
--- a/src/DocumentForge.Studio.Core/Cluster/ClusterConfig.cs
+++ b/src/DocumentForge.Studio.Core/Cluster/ClusterConfig.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -33,6 +35,26 @@ public sealed class ClusterConfig
 
     public static ClusterConfig Load(string path) => FromJson(File.ReadAllText(path));
     public void Save(string path) => File.WriteAllText(path, ToJson());
+
+    /// <summary>Pull the live cluster config from a running <c>dfdb router</c>'s
+    /// <c>GET /cluster/config</c> endpoint, so you can edit what the cluster is
+    /// actually running instead of hunting for the file on disk. The router owns
+    /// the config; Studio can read it but cannot (yet) push changes back — save
+    /// the result to a file and restart the router to apply.</summary>
+    public static async Task<ClusterConfig> LoadFromRouterAsync(
+        string routerEndpoint, string? apiKey = null, TimeSpan? timeout = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(routerEndpoint))
+            throw new ArgumentException("Router endpoint is required.", nameof(routerEndpoint));
+
+        var baseUrl = routerEndpoint.Trim().TrimEnd('/');
+        using var http = new HttpClient { Timeout = timeout ?? TimeSpan.FromSeconds(10) };
+        if (!string.IsNullOrWhiteSpace(apiKey))
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        var json = await http.GetStringAsync($"{baseUrl}/cluster/config", ct);
+        return FromJson(json);
+    }
 }
 
 public sealed class ShardDescriptor

--- a/src/DocumentForge.Studio/MainWindow.xaml
+++ b/src/DocumentForge.Studio/MainWindow.xaml
@@ -178,8 +178,8 @@
                 <MenuItem Header="_Refresh All" Command="{Binding RefreshAllCommand}" InputGestureText="F5"/>
             </MenuItem>
             <MenuItem Header="_Cluster">
-                <MenuItem Header="_Open cluster.json…" Command="{Binding OpenClusterFileCommand}"/>
-                <MenuItem Header="_New cluster.json…" Command="{Binding NewClusterFileCommand}"/>
+                <MenuItem Header="_New cluster…" Command="{Binding NewClusterFileCommand}"/>
+                <MenuItem Header="_Open cluster…" Command="{Binding OpenClusterFileCommand}"/>
             </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem Header="_SQL Reference…" Command="{Binding OpenSqlReferenceCommand}"/>

--- a/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ClusterDocumentViewModel.cs
@@ -33,12 +33,13 @@ public sealed class ClusterCollectionRow
     public string ShardKeyPath { get; }
 }
 
-/// <summary>Edits a DocumentForge cluster.json (shards + per-collection sharding
-/// strategy) and health-checks each shard. Client-only: it manipulates the file
-/// and pings endpoints; the engine still owns cluster behaviour.</summary>
+/// <summary>Edits a DocumentForge cluster config (shards + per-collection sharding
+/// strategy), health-checks each shard, and can pull the live config from a
+/// running router. Client-only: it manipulates the config and pings endpoints;
+/// the engine still owns cluster behaviour.</summary>
 public sealed partial class ClusterDocumentViewModel : DocumentViewModel
 {
-    private readonly ClusterConfig _config;
+    private ClusterConfig _config;
     private readonly IDialogService _dialogs;
 
     public ClusterDocumentViewModel(ClusterConfig config, string? filePath, IDialogService dialogs,
@@ -54,11 +55,15 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
 
         // Suggest shard endpoints from the user's saved connections + any endpoints
         // already in this config, so they can pick instead of typing a URL.
-        foreach (var e in (knownEndpoints ?? Array.Empty<string>())
-                     .Concat(_config.Shards.Select(s => s.LeaderEndpoint))
-                     .Where(e => !string.IsNullOrWhiteSpace(e))
-                     .Distinct(StringComparer.OrdinalIgnoreCase))
-            ShardEndpointSuggestions.Add(e);
+        AddEndpointSuggestions((knownEndpoints ?? Array.Empty<string>())
+            .Concat(_config.Shards.Select(s => s.LeaderEndpoint)));
+    }
+
+    private void AddEndpointSuggestions(IEnumerable<string> endpoints)
+    {
+        foreach (var e in endpoints.Where(e => !string.IsNullOrWhiteSpace(e)))
+            if (!ShardEndpointSuggestions.Contains(e, StringComparer.OrdinalIgnoreCase))
+                ShardEndpointSuggestions.Add(e);
     }
 
     public ObservableCollection<ClusterShardRow> Shards { get; } = new();
@@ -90,6 +95,9 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
     [ObservableProperty] private ShardingStrategy _newCollectionStrategy;
     [ObservableProperty] private string _newCollectionShardKey = "";
 
+    // "Load from live cluster" input — a running `dfdb router` endpoint.
+    [ObservableProperty] private string _routerEndpoint = "";
+
     /// <summary>Only a hash-sharded collection needs a shard key.</summary>
     public bool NeedsShardKey => NewCollectionStrategy == ShardingStrategy.Hash;
 
@@ -109,7 +117,7 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
 
     private void UpdateTitle()
     {
-        var baseTitle = FilePath is null ? "Cluster (unsaved)" : $"Cluster — {Path.GetFileName(FilePath)}";
+        var baseTitle = FilePath is null ? "Cluster (unsaved)" : $"Cluster — {Path.GetFileNameWithoutExtension(FilePath)}";
         Title = IsDirty ? $"{baseTitle} *" : baseTitle;
     }
 
@@ -143,7 +151,7 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
         NewShardEndpoint = "";
         ReloadRows();
         MarkDirty();
-        StatusMessage = $"Added shard '{name}'. Save to write cluster.json.";
+        StatusMessage = $"Added shard '{name}'. Save to write the cluster config.";
     }
 
     [RelayCommand]
@@ -177,7 +185,7 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
         NewCollectionShardKey = "";
         ReloadRows();
         MarkDirty();
-        StatusMessage = $"{(isUpdate ? "Updated" : "Added")} '{name}' → {NewCollectionStrategy}. Save to write cluster.json.";
+        StatusMessage = $"{(isUpdate ? "Updated" : "Added")} '{name}' → {NewCollectionStrategy}. Save to write the cluster config.";
     }
 
     [RelayCommand]
@@ -206,6 +214,59 @@ public sealed partial class ClusterDocumentViewModel : DocumentViewModel
         catch (Exception ex)
         {
             _dialogs.ShowError("Save failed", ex.Message);
+        }
+    }
+
+    /// <summary>Write a copy to a chosen location without adopting it as this
+    /// tab's file (a plain "export a copy").</summary>
+    [RelayCommand]
+    private void Export()
+    {
+        var suggested = FilePath is null ? "cluster.json" : Path.GetFileName(FilePath);
+        var path = _dialogs.PickSaveFile("DocumentForge cluster (*.json)|*.json|All files (*.*)|*.*", suggested);
+        if (path is null) return;
+        try
+        {
+            _config.Save(path);
+            StatusMessage = $"Exported a copy to {path}";
+        }
+        catch (Exception ex)
+        {
+            _dialogs.ShowError("Export failed", ex.Message);
+        }
+    }
+
+    /// <summary>Pull the live config from a running <c>dfdb router</c> so you can
+    /// edit what the cluster is actually running. It's read-only on the engine
+    /// side: Studio loads a copy, and applying changes still means saving a file
+    /// and restarting the router.</summary>
+    [RelayCommand]
+    private async Task LoadFromRouterAsync()
+    {
+        var endpoint = RouterEndpoint.Trim();
+        if (endpoint.Length == 0)
+        {
+            StatusMessage = "Enter the endpoint of a running `dfdb router` to load its live config.";
+            return;
+        }
+        IsBusy = true;
+        try
+        {
+            _config = await ClusterConfig.LoadFromRouterAsync(endpoint);
+            ReloadRows();
+            AddEndpointSuggestions(_config.Shards.Select(s => s.LeaderEndpoint));
+            MarkDirty();
+            StatusMessage = $"Loaded live config from {endpoint} (v{_config.Version}, {_config.Shards.Count} shard(s)). " +
+                            "This is a working copy — Save it to a file and restart the router to apply edits.";
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Couldn't load from {endpoint}: {ex.Message}. " +
+                            "It must be a running `dfdb router` exposing GET /cluster/config.";
+        }
+        finally
+        {
+            IsBusy = false;
         }
     }
 

--- a/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
@@ -436,7 +436,7 @@ public sealed partial class MainViewModel : ObservableObject
         var document = new ClusterDocumentViewModel(config, path, _dialogs, knownEndpoints);
         Documents.Add(document);
         ActiveDocument = document;
-        StatusText = path is null ? "New cluster config" : $"Cluster — {System.IO.Path.GetFileName(path)}";
+        StatusText = path is null ? "New cluster config" : $"Cluster — {System.IO.Path.GetFileNameWithoutExtension(path)}";
     }
 
     [RelayCommand]

--- a/src/DocumentForge.Studio/Views/ClusterView.xaml
+++ b/src/DocumentForge.Studio/Views/ClusterView.xaml
@@ -11,6 +11,9 @@
         <ToolBarTray DockPanel.Dock="Top" IsLocked="True">
             <ToolBar>
                 <Button Content="💾 Save" Command="{Binding SaveCommand}" Padding="8,2"/>
+                <Button Content="⬇ Export…" Command="{Binding ExportCommand}" Padding="8,2"
+                        ToolTip="Write a copy of this cluster config to another file"/>
+                <Separator/>
                 <Button Content="🩺 Check health" Command="{Binding CheckHealthCommand}" Padding="8,2"/>
                 <Separator/>
                 <TextBlock Text="{Binding SummaryText}" VerticalAlignment="Center" Margin="4,0"/>
@@ -21,6 +24,24 @@
 
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="14">
+                <!-- Load the live config from a running router instead of hunting for the file -->
+                <Border Background="#EEF4FF" BorderBrush="#B9D0F5" BorderThickness="1" CornerRadius="4"
+                        Padding="10,7" Margin="0,0,0,14">
+                    <StackPanel>
+                        <TextBlock Text="Load from a running cluster" FontWeight="SemiBold"/>
+                        <TextBlock Foreground="Gray" FontSize="11" Margin="0,2,0,6" TextWrapping="Wrap"
+                                   Text="Pull the live config straight from a running dfdb router (its GET /cluster/config) so you edit what the cluster is actually running. Applying edits is still file-based — save, then restart the router. Studio can't push config to a live router yet."/>
+                        <StackPanel Orientation="Horizontal">
+                            <ComboBox IsEditable="True" Width="240"
+                                      Text="{Binding RouterEndpoint, UpdateSourceTrigger=PropertyChanged}"
+                                      ItemsSource="{Binding ShardEndpointSuggestions}"
+                                      ToolTip="Endpoint of a running `dfdb router`, e.g. http://localhost:5100"/>
+                            <Button Content="⤓ Load live config" Command="{Binding LoadFromRouterCommand}"
+                                    Padding="10,2" Margin="8,0,0,0"/>
+                        </StackPanel>
+                    </StackPanel>
+                </Border>
+
                 <TextBlock Text="Shards" FontSize="15" FontWeight="SemiBold"/>
                 <TextBlock Foreground="Gray" FontSize="11" Margin="0,2,0,6" TextWrapping="Wrap"
                            Text="Each shard is a node (or a leader+followers replication group). Data is spread across shards by the consistent-hash ring."/>
@@ -90,10 +111,10 @@
                 <Border Background="#FFF8E6" BorderBrush="#F0E0A0" BorderThickness="1" CornerRadius="4"
                         Padding="10,7" Margin="0,20,0,0">
                     <TextBlock TextWrapping="Wrap" FontSize="11" Foreground="#665500">
-                        Studio edits this cluster.json and health-checks shards. Live rebalancing runs through the
-                        engine (issue for HTTP rebalance endpoints is tracked). Known engine caveats to keep in mind:
-                        cross-shard AVG is currently inaccurate (#99) and the CLI router uses a different hash than the
-                        engine ring (#100).
+                        Studio edits your cluster config and health-checks shards. The router reads this config at
+                        startup, so applying changes means saving the file and restarting the router (a live push
+                        endpoint is tracked). Known engine caveats: cross-shard AVG is currently inaccurate (#99) and
+                        the CLI router uses a different hash than the engine ring (#100).
                     </TextBlock>
                 </Border>
             </StackPanel>


### PR DESCRIPTION
feat(studio): cluster editor — hide .json, export, load live config

More cluster polish, driven by "I don't want to see .json" and "can't we push
the config or is it always managing jsons?":

- No more ".json" in the UI surface:
  - Cluster menu is now "New cluster… / Open cluster…".
  - Tab title and status bar show the config name without its extension
    (e.g. "Cluster — prod" instead of "Cluster — prod.json").
  - In-app status messages and the info box say "cluster config", not
    "cluster.json".
- Export: new toolbar button writes a copy of the current config to another
  file without adopting it as the tab's file.
- Load from a running cluster: new panel + Core helper
  ClusterConfig.LoadFromRouterAsync pulls the LIVE config from a running
  `dfdb router` (GET /cluster/config) so you edit what the cluster is actually
  running instead of hunting for the file. Endpoint box reuses the shard
  suggestion list.

Honest about the engine limits: the router reads cluster config at startup and
there is no push/apply endpoint yet, so applying edits still means Save + router
restart. The panel and info box state this plainly. (A live-push endpoint is a
separate engine feature — see follow-up.)

Studio builds clean; all 56 Studio.Core tests pass.
