### PR TITLE
db-scoped by-business-key routes — complete /db/{name} parity for document CRUD

### DIFF
--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -1134,6 +1134,131 @@ public static class DatabaseEndpoints
             return PatchHandler.Handle(db, collection, id, request);
         });
 
+        // ---- Scoped by-business-key routes (GET/PUT/PATCH/DELETE …/by/{field}/{value}).
+        // The flat by-field family only sees the default database, which forced
+        // clients that key documents by their own ids (e.g. AeroBus) onto a
+        // dedicated node per database. Shapes mirror the flat routes exactly,
+        // plus the `database` field every scoped route carries.
+
+        // Look up by any field — e.g. GET /db/airline/collections/orders/by/pnr/ABC123.
+        // Uses an index when one exists on the field; collection scan otherwise.
+        app.MapGet("/db/{name}/collections/{collection}/by/{field}/{value}",
+            (HttpContext ctx, string name, string collection, string field, string value) =>
+        {
+            if (ScopeCheck.RequireDbRead(ctx, name) is { } deny) return deny;
+            var db = registry.TryGet(name);
+            if (db is null) return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            if (!ServeCommand.IsValidCollectionName(collection)) return ServeCommand.InvalidCollectionNameResult();
+            if (!ServeCommand.IsValidFieldPath(field))
+                return Results.BadRequest(new { error = "Field name must match [a-zA-Z_][a-zA-Z0-9_.\\[\\]]*" });
+
+            if (db.GetCollection(collection) is null) return Results.NotFound();
+
+            var safeValue = value.Replace("'", "''");
+            var r = db.Execute($"SELECT * FROM {collection} WHERE {field} = '{safeValue}' LIMIT 1");
+            if (!r.Success) return Results.BadRequest(new { error = r.Message, code = r.ErrorCode });
+            if (r.Documents.Count == 0) return Results.NotFound();
+
+            return Results.Ok(new
+            {
+                database = name,
+                collection,
+                plan = r.QueryPlan,
+                executionTimeMs = r.ExecutionTime.TotalMilliseconds,
+                document = JsonDocument.Parse(r.Documents[0].ToJson()).RootElement,
+            });
+        });
+
+        // Replace by business key — resolves {field}={value} to an _id (honouring
+        // indexes) then replaces the document with the request body.
+        app.MapPut("/db/{name}/collections/{collection}/by/{field}/{value}",
+            async (HttpContext ctx, string name, string collection, string field, string value, HttpRequest request) =>
+        {
+            if (ScopeCheck.RequireDbWrite(ctx, name) is { } deny) return deny;
+            var db = registry.TryGet(name);
+            if (db is null) return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            if (!ServeCommand.IsValidCollectionName(collection)) return ServeCommand.InvalidCollectionNameResult();
+            if (!ServeCommand.IsValidFieldPath(field))
+                return Results.BadRequest(new { error = "Field name must match [a-zA-Z_][a-zA-Z0-9_.\\[\\]]*" });
+
+            using var reader = new StreamReader(request.Body);
+            var json = await reader.ReadToEndAsync();
+            if (string.IsNullOrWhiteSpace(json)) return Results.BadRequest(new { error = "Empty body" });
+
+            if (db.GetCollection(collection) is null) return Results.NotFound();
+
+            var safeValue = value.Replace("'", "''");
+            var found = db.Execute($"SELECT * FROM {collection} WHERE {field} = '{safeValue}' LIMIT 1");
+            if (!found.Success) return Results.BadRequest(new { error = found.Message, code = found.ErrorCode });
+            if (found.Documents.Count == 0) return Results.NotFound();
+
+            try
+            {
+                var docId = found.Documents[0].GetId();
+                if (!db.Replace(collection, docId, json)) return Results.NotFound();
+                return Results.Ok(new
+                {
+                    database = name,
+                    success = true,
+                    id = docId.ToString(),
+                    collection,
+                    matchedBy = new { field, value },
+                    plan = found.QueryPlan,
+                });
+            }
+            catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
+        });
+
+        // PATCH by business key — same resolution, then the shared merge/$ops patch.
+        app.MapPatch("/db/{name}/collections/{collection}/by/{field}/{value}",
+            async (HttpContext ctx, string name, string collection, string field, string value, HttpRequest request) =>
+        {
+            if (ScopeCheck.RequireDbWrite(ctx, name) is { } deny) return deny;
+            var db = registry.TryGet(name);
+            if (db is null) return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            if (!ServeCommand.IsValidCollectionName(collection)) return ServeCommand.InvalidCollectionNameResult();
+            if (!ServeCommand.IsValidFieldPath(field))
+                return Results.BadRequest(new { error = "Field name must match [a-zA-Z_][a-zA-Z0-9_.\\[\\]]*" });
+
+            if (db.GetCollection(collection) is null) return Results.NotFound();
+
+            var safeValue = value.Replace("'", "''");
+            var found = db.Execute($"SELECT * FROM {collection} WHERE {field} = '{safeValue}' LIMIT 1");
+            if (!found.Success) return Results.BadRequest(new { error = found.Message, code = found.ErrorCode });
+            if (found.Documents.Count == 0) return Results.NotFound();
+
+            var docId = found.Documents[0].GetId();
+            return await PatchHandler.Handle(db, collection, docId.ToString(), request);
+        });
+
+        // Delete by any field — deletes ALL matches, mirroring the flat route.
+        app.MapDelete("/db/{name}/collections/{collection}/by/{field}/{value}",
+            (HttpContext ctx, string name, string collection, string field, string value) =>
+        {
+            if (ScopeCheck.RequireDbWrite(ctx, name) is { } deny) return deny;
+            var db = registry.TryGet(name);
+            if (db is null) return Results.NotFound(new { error = $"Database '{name}' is not attached." });
+            if (!ServeCommand.IsValidCollectionName(collection)) return ServeCommand.InvalidCollectionNameResult();
+            if (!ServeCommand.IsValidFieldPath(field))
+                return Results.BadRequest(new { error = "Field name must match [a-zA-Z_][a-zA-Z0-9_.\\[\\]]*" });
+
+            if (db.GetCollection(collection) is null) return Results.NotFound();
+
+            var safeValue = value.Replace("'", "''");
+            var r = db.Execute($"DELETE FROM {collection} WHERE {field} = '{safeValue}'");
+            if (!r.Success) return Results.BadRequest(new { error = r.Message, code = r.ErrorCode });
+
+            return Results.Ok(new
+            {
+                database = name,
+                success = true,
+                collection,
+                deletedCount = r.AffectedCount,
+                plan = r.QueryPlan,
+                executionTimeMs = r.ExecutionTime.TotalMilliseconds,
+            });
+        });
+
         // Scoped delete by internal _id.
         app.MapDelete("/db/{name}/collections/{collection}/{id}", (HttpContext ctx, string name, string collection, string id) =>
         {

--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -377,6 +377,8 @@ public static class ServeCommand
         Console.WriteLine("             POST /seed | GET /health | GET /version");
         Console.WriteLine("  databases: GET  /databases | POST /databases | DELETE /databases/{name}");
         Console.WriteLine("             POST /databases/{name}/set-default");
+        Console.WriteLine("  db-scoped: /db/{db}/query | /db/{db}/collections/{name}[/{id}|/by/{field}/{value}]");
+        Console.WriteLine("             (flat routes target the default database; /db/{db}/… targets any attached one)");
         Console.WriteLine("  services:  GET  /services | POST /services | DELETE /services/{port}");
         Console.WriteLine("  keys:      GET  /admin/keys | POST /admin/keys | DELETE /admin/keys/{id}");
         Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
@@ -1662,7 +1664,7 @@ public static class ServeCommand
     private static readonly System.Text.RegularExpressions.Regex _fieldPathRegex =
         new("^[a-zA-Z_][a-zA-Z0-9_.\\[\\]]*$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
-    private static bool IsValidFieldPath(string field) =>
+    internal static bool IsValidFieldPath(string field) =>
         !string.IsNullOrEmpty(field) && _fieldPathRegex.IsMatch(field);
 
     /// <summary>
@@ -1717,7 +1719,7 @@ public static class ServeCommand
         && name.Length <= MaxCollectionNameLength
         && _collectionNameRegex.IsMatch(name);
 
-    private static IResult InvalidCollectionNameResult() =>
+    internal static IResult InvalidCollectionNameResult() =>
         Results.BadRequest(new { error = $"Collection name must match [a-zA-Z_][a-zA-Z0-9_]* and be at most {MaxCollectionNameLength} chars." });
 
     /// <summary>

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -271,6 +271,98 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
         Assert.Equal("sale", doc["lastOp"].AsString);
     }
 
+    // ---- Scoped by-business-key routes (/db/{name}/collections/{c}/by/{field}/{value}).
+    // Mirror the flat by-field family so multi-DB clients (AeroBus et al) can key
+    // documents by their own ids without a dedicated node per database.
+
+    [Fact]
+    public async Task ScopedByField_Get_FindsDocument_AndMissesReturn404()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        registry.AttachOrCreate("airline", Path.Combine(dataDir, "airline.dfdb"));
+        var db = registry.Get("airline");
+        db.Insert("orders", """{"pnr":"ABC123","status":"held"}""");
+
+        var found = await _http.GetAsync($"{baseUrl}/db/airline/collections/orders/by/pnr/ABC123");
+        Assert.Equal(HttpStatusCode.OK, found.StatusCode);
+        var body = await found.Content.ReadAsStringAsync();
+        Assert.Contains("\"database\":\"airline\"", body);
+        Assert.Contains("\"pnr\":\"ABC123\"", body);
+        Assert.Contains("\"_etag\"", body); // metadata preserved for If-Match flows
+
+        var miss = await _http.GetAsync($"{baseUrl}/db/airline/collections/orders/by/pnr/NOPE99");
+        Assert.Equal(HttpStatusCode.NotFound, miss.StatusCode);
+
+        var wrongDb = await _http.GetAsync($"{baseUrl}/db/ghost/collections/orders/by/pnr/ABC123");
+        Assert.Equal(HttpStatusCode.NotFound, wrongDb.StatusCode);
+    }
+
+    [Fact]
+    public async Task ScopedByField_Put_ReplacesFirstMatch()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        registry.AttachOrCreate("airline", Path.Combine(dataDir, "airline.dfdb"));
+        var db = registry.Get("airline");
+        var id = db.Insert("orders", """{"pnr":"ABC123","status":"held"}""");
+
+        var resp = await _http.PutAsync($"{baseUrl}/db/airline/collections/orders/by/pnr/ABC123",
+            new StringContent("""{"pnr":"ABC123","status":"paid"}""", System.Text.Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"database\":\"airline\"", body);
+        Assert.Contains($"\"id\":\"{id}\"", body);
+
+        Assert.Equal("paid", db.GetCollection("orders")!.FindById(id)!["status"].AsString);
+    }
+
+    [Fact]
+    public async Task ScopedByField_Patch_MergesIntoResolvedDocument()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        registry.AttachOrCreate("airline", Path.Combine(dataDir, "airline.dfdb"));
+        var db = registry.Get("airline");
+        var id = db.Insert("orders", """{"pnr":"ABC123","status":"held","note":"x"}""");
+
+        var resp = await PatchJson($"{baseUrl}/db/airline/collections/orders/by/pnr/ABC123",
+            """{"status":"ticketed","note":null}""");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var doc = db.GetCollection("orders")!.FindById(id)!;
+        Assert.Equal("ticketed", doc["status"].AsString);
+        Assert.False(doc.ContainsKey("note"));
+    }
+
+    [Fact]
+    public async Task ScopedByField_Delete_RemovesAllMatches()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        registry.AttachOrCreate("airline", Path.Combine(dataDir, "airline.dfdb"));
+        var db = registry.Get("airline");
+        db.Insert("etickets", """{"orderId":"OD1","doc":"999-1"}""");
+        db.Insert("etickets", """{"orderId":"OD1","doc":"999-2"}""");
+        db.Insert("etickets", """{"orderId":"OD2","doc":"999-3"}""");
+
+        var resp = await _http.DeleteAsync($"{baseUrl}/db/airline/collections/etickets/by/orderId/OD1");
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"deletedCount\":2", body);
+
+        var remaining = db.Execute("SELECT * FROM etickets");
+        Assert.Single(remaining.Documents);
+    }
+
+    [Fact]
+    public async Task ScopedByField_RejectsHostileFieldPath()
+    {
+        var (registry, baseUrl, dataDir) = BootServer();
+        registry.AttachOrCreate("airline", Path.Combine(dataDir, "airline.dfdb"));
+        registry.Get("airline").Insert("orders", """{"pnr":"ABC123"}""");
+
+        // A field segment that could form SQL syntax must be rejected, not interpolated.
+        var resp = await _http.GetAsync($"{baseUrl}/db/airline/collections/orders/by/pnr%27%20OR%201%3D1--/x");
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
     [Fact]
     public async Task Patch_IfMatch_Mismatch_Returns412_AndWritesNothing()
     {


### PR DESCRIPTION
## Why

The flat by-field family (`GET|PUT|PATCH|DELETE /collections/{name}/by/{field}/{value}`) only sees the **default** database. Every other data-plane verb already has a `/db/{name}/…` twin, so multi-DB HTTP clients that key documents by business ids (AeroBus is the concrete case — it had to run against a dedicated node per database) were blocked on exactly these four routes.

## What

- `GET|PUT|PATCH|DELETE /db/{name}/collections/{collection}/by/{field}/{value}` — shapes mirror the flat routes exactly (`matchedBy`/`plan`/`deletedCount`), plus the `database` field every scoped route carries.
- Same guards as the flat family: per-database ScopeCheck read/write, collection-name + field-path whitelists (SQL-injection safe), value escaping, 404 for unattached DBs / missing collections.
- PATCH resolves the key to an `_id` then reuses `PatchHandler` (merge/$ops + If-Match identical to by-id). DELETE removes **all** matches, mirroring flat semantics.
- Serve banner advertises the `/db/{db}/…` family and clarifies flat = default DB.
- `IsValidFieldPath`/`InvalidCollectionNameResult` promoted to `internal` so `DatabaseEndpoints` shares `ServeCommand`'s validators.

Flat routes are untouched — they remain the sharding/router data plane and the default-DB convenience surface.

## Tests

5 new Kestrel wire tests (found/miss/wrong-db, PUT replace, PATCH merge, DELETE all-matches, hostile field path → 400). Full `DatabaseEndpointsHttpTests` class: **55/55 green**.

## Follow-up (not in this PR)

Flat-only routes still without scoped twins: `bulk`, `tx/batch`, `schema`, `ttl`, `blob`, `seed`, `index` create. AeroBus needs none of them; happy to add on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)