### PR TITLE
Studio: API-key normalisation, service restart button, honest restart-required labelling

### DIFF
--- a/src/DocumentForge.Cli/Commands/ServeCommand.cs
+++ b/src/DocumentForge.Cli/Commands/ServeCommand.cs
@@ -313,7 +313,10 @@ public static class ServeCommand
             ctx.Response.StatusCode = 401;
             await ctx.Response.WriteAsJsonAsync(new
             {
-                error = "Unauthorized. Provide Authorization: Bearer <apiKey>.",
+                // Careful wording: clients (incl. Studio) surface this verbatim, and
+                // "Provide Authorization: Bearer <apiKey>" taught users to type
+                // "Bearer <key>" into API-key fields — which then double-prefixes.
+                error = "Unauthorized: missing or invalid API key. Send the key as an HTTP Bearer token; in Studio, paste just the key (no 'Bearer' prefix).",
             });
         }
 
@@ -416,7 +419,7 @@ public static class ServeCommand
         Console.WriteLine("             POST /databases/{name}/set-default");
         Console.WriteLine("  services:  GET  /services | POST /services | DELETE /services/{port}");
         Console.WriteLine("  keys:      GET  /admin/keys | POST /admin/keys | DELETE /admin/keys/{id}");
-        Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot");
+        Console.WriteLine("  admin:     POST /admin/flush | POST /admin/checkpoint | POST /admin/snapshot | POST /admin/restart");
         Console.WriteLine("             POST /admin/compact/{collection}");
         Console.WriteLine("             POST /admin/rebuild-indexes/{collection}");
         Console.WriteLine("             POST /admin/rebuild-index/{collection}/{indexName}");
@@ -1603,6 +1606,29 @@ public static class ServeCommand
             db.Checkpoint();
             sw.Stop();
             return Results.Ok(new { success = true, timeMs = sw.Elapsed.TotalMilliseconds });
+        });
+
+        // Restart the node: flush everything durable, acknowledge, then exit the
+        // process so the host brings it back — the Windows service's recovery
+        // action (restart/5000, set by `dfdb service install`) or IIS's ANCM.
+        // The non-zero exit code is deliberate: SCM recovery only fires on a
+        // failure-style termination, not a clean stop. Under a bare console run
+        // (dev) there is no supervisor, so this is simply a remote stop.
+        app.MapPost("/admin/restart", (HttpContext httpCtx) =>
+        {
+            if (ScopeCheck.RequireAdmin(httpCtx) is { } deny) return deny;
+            db.Flush();
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(750); // let the 202 response flush to the caller
+                Environment.Exit(64);
+            });
+            return Results.Accepted(value: new
+            {
+                success = true,
+                message = "Flushed; the node is exiting for restart. Under the DocumentForge " +
+                          "Windows service or IIS it restarts automatically; a console-run node must be started again.",
+            });
         });
 
         // Take a consistent snapshot of the data file. Blocks writes briefly

--- a/src/DocumentForge.Studio.Core/Connections/DirectFileConnection.cs
+++ b/src/DocumentForge.Studio.Core/Connections/DirectFileConnection.cs
@@ -192,6 +192,7 @@ public sealed class DirectFileConnection : IDfConnection
 
     public Task<ServiceConfigInfo> GetServiceConfigAsync(CancellationToken ct = default) => throw new NotSupportedException(ServerOnly);
     public Task<ServiceConfigInfo> UpdateServiceConfigAsync(int? minSyncReplicas, double? syncTimeoutSeconds, CancellationToken ct = default) => throw new NotSupportedException(ServerOnly);
+    public Task<string> RestartServerAsync(CancellationToken ct = default) => throw new NotSupportedException(ServerOnly);
 
     public Task<IReadOnlyList<ApiKeyInfo>> GetApiKeysAsync(CancellationToken ct = default) => throw new NotSupportedException(ServerOnly);
     public Task<CreatedApiKey> CreateApiKeyAsync(string? description, IReadOnlyList<string> scopes, CancellationToken ct = default) => throw new NotSupportedException(ServerOnly);

--- a/src/DocumentForge.Studio.Core/Connections/HttpConnection.cs
+++ b/src/DocumentForge.Studio.Core/Connections/HttpConnection.cs
@@ -46,8 +46,14 @@ public sealed class HttpConnection : IDfConnection
         // A generous ceiling; per-query timeouts are enforced by the caller's
         // CancellationToken (the workbench "Timeout (s)" field), which fires first.
         _http.Timeout = TimeSpan.FromMinutes(10);
-        if (!string.IsNullOrEmpty(apiKey))
-            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+        // Normalise the key defensively: keys saved by older Studio versions may
+        // carry copy-paste whitespace or a typed "Bearer " prefix (the server
+        // hash/exact-matches the token, so either means an unexplained 401).
+        var key = apiKey?.Trim();
+        if (key is not null && key.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            key = key["Bearer ".Length..].Trim();
+        if (!string.IsNullOrEmpty(key))
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", key);
     }
 
     public ConnectionDescriptor Descriptor { get; }
@@ -607,6 +613,22 @@ public sealed class HttpConnection : IDfConnection
         return doc.RootElement.TryGetProperty("config", out var cfg)
             ? ParseServiceConfig(cfg.GetRawText())
             : ParseServiceConfig(body);
+    }
+
+    public async Task<string> RestartServerAsync(CancellationToken ct = default)
+    {
+        using var response = await _http.PostAsync("admin/restart", content: null, ct).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+            throw new DfHttpException(response.StatusCode, ExtractError(body, response.StatusCode));
+        try
+        {
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("message", out var msg) && msg.ValueKind == JsonValueKind.String)
+                return msg.GetString()!;
+        }
+        catch (JsonException) { }
+        return "Restart requested.";
     }
 
     private static ServiceConfigInfo ParseServiceConfig(string body)

--- a/src/DocumentForge.Studio.Core/Connections/IDfConnection.cs
+++ b/src/DocumentForge.Studio.Core/Connections/IDfConnection.cs
@@ -113,6 +113,12 @@ public interface IDfConnection : IAsyncDisposable
     /// the updated effective configuration.</summary>
     Task<ServiceConfigInfo> UpdateServiceConfigAsync(int? minSyncReplicas, double? syncTimeoutSeconds, CancellationToken ct = default);
 
+    /// <summary>Asks the node to restart itself (POST /admin/restart): it flushes,
+    /// acknowledges, and exits so its host (Windows service recovery / IIS) brings
+    /// it back. Returns the server's acknowledgement message. The connection will
+    /// be briefly unreachable afterwards — poll <see cref="GetHealthAsync"/>.</summary>
+    Task<string> RestartServerAsync(CancellationToken ct = default);
+
     // --- Replication (server connections only; requires ServerAdmin) ---
 
     Task<ReplicationStatus> GetReplicationStatusAsync(string database, CancellationToken ct = default);

--- a/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/MainViewModel.cs
@@ -602,7 +602,7 @@ public sealed partial class MainViewModel : ObservableObject
         var existing = Documents.FirstOrDefault(d => d.ContentId == contentId);
         if (existing is not null) { ActiveDocument = existing; return; }
 
-        var document = new ServiceSettingsDocumentViewModel(server.Connection);
+        var document = new ServiceSettingsDocumentViewModel(server.Connection, _dialogs);
         Documents.Add(document);
         ActiveDocument = document;
         StatusText = $"Service settings — {server.Connection.Descriptor.Name}";

--- a/src/DocumentForge.Studio/ViewModels/ServiceSettingsDocumentViewModel.cs
+++ b/src/DocumentForge.Studio/ViewModels/ServiceSettingsDocumentViewModel.cs
@@ -13,16 +13,20 @@ public sealed record ConfigRow(string Section, string Setting, string Value, str
 
 /// <summary>Service settings (a document tab): the redacted effective node
 /// configuration (engine #111), with the live-editable semi-sync knobs
-/// editable in place. Restart-required fields are labelled as such — changing
-/// them is a node.json edit + restart, and the server rejects them over the
-/// API. Server connections only (issue #115).</summary>
+/// editable in place. Fields the server can only pick up on a restart are
+/// labelled "restart to change" — a property of the field, not a pending
+/// state (the server rejects editing them over the API; they're a node.json
+/// edit + restart, and the Restart button here drives that restart). Server
+/// connections only (issue #115).</summary>
 public sealed partial class ServiceSettingsDocumentViewModel : DocumentViewModel
 {
     private readonly IDfConnection _connection;
+    private readonly Services.IDialogService _dialogs;
 
-    public ServiceSettingsDocumentViewModel(IDfConnection connection)
+    public ServiceSettingsDocumentViewModel(IDfConnection connection, Services.IDialogService dialogs)
     {
         _connection = connection;
+        _dialogs = dialogs;
         Title = $"Service settings — {connection.Descriptor.Name}";
         ContentId = $"svcconfig:{connection.Descriptor.Id}";
     }
@@ -45,10 +49,59 @@ public sealed partial class ServiceSettingsDocumentViewModel : DocumentViewModel
         {
             var config = await _connection.GetServiceConfigAsync();
             Populate(config);
-            StatusMessage = "Loaded. Only the semi-sync knobs are live-editable; restart-required fields need a node.json edit + service restart.";
+            StatusMessage = "Loaded. The semi-sync knobs apply live; fields marked \"restart to change\" take a node.json edit + a restart (button above).";
         }
         catch (NotSupportedException ex) { StatusMessage = ex.Message; }
         catch (Exception ex) { StatusMessage = ex.Message; }
+        finally { IsBusy = false; }
+    }
+
+    /// <summary>Restart the node via POST /admin/restart, then poll /health until
+    /// it's back (or give up after a minute) and re-load the settings.</summary>
+    [RelayCommand]
+    private async Task RestartServiceAsync()
+    {
+        if (!_dialogs.Confirm("Restart service",
+            $"Restart the DocumentForge node behind \"{_connection.Descriptor.Name}\"?\n\n" +
+            "The node flushes to disk first, then exits and is restarted by its Windows service " +
+            "(or IIS). It will be unavailable for a few seconds. A node run from a plain console " +
+            "has no supervisor and will just stop."))
+            return;
+
+        IsBusy = true;
+        try
+        {
+            var ack = await _connection.RestartServerAsync();
+            StatusMessage = $"Restarting… ({ack})";
+
+            var back = false;
+            var deadline = DateTime.UtcNow.AddSeconds(60);
+            await Task.Delay(TimeSpan.FromSeconds(2)); // let the old process exit
+            while (DateTime.UtcNow < deadline)
+            {
+                try
+                {
+                    var health = await _connection.GetHealthAsync();
+                    if (health.Healthy) { back = true; break; }
+                }
+                catch { /* still down — keep polling */ }
+                await Task.Delay(TimeSpan.FromSeconds(2));
+            }
+
+            if (back)
+            {
+                var config = await _connection.GetServiceConfigAsync();
+                Populate(config);
+                StatusMessage = "Restarted — the node is back and settings have been re-loaded.";
+            }
+            else
+            {
+                StatusMessage = "Restart requested, but the node did not come back within 60s. " +
+                                "If it runs as a plain console process (no Windows service / IIS), start it again manually.";
+            }
+        }
+        catch (NotSupportedException ex) { StatusMessage = ex.Message; }
+        catch (Exception ex) { StatusMessage = $"Restart failed: {ex.Message}"; }
         finally { IsBusy = false; }
     }
 
@@ -93,8 +146,11 @@ public sealed partial class ServiceSettingsDocumentViewModel : DocumentViewModel
         MinSyncReplicasText = c.MinSyncReplicas.ToString(CultureInfo.InvariantCulture);
         SyncTimeoutSecondsText = c.SyncTimeoutSeconds.ToString(CultureInfo.InvariantCulture);
 
+        // restartRequired on the wire is a STATIC descriptor — "changing this field
+        // needs a restart" — never a live pending-restart state. Label it so it
+        // can't be read as "the service needs a restart right now".
         var restart = new HashSet<string>(c.RestartRequired, StringComparer.OrdinalIgnoreCase);
-        string NoteFor(string field) => restart.Contains(field) ? "restart-required" : "";
+        string NoteFor(string field) => restart.Contains(field) ? "restart to change" : "";
 
         Rows.Clear();
         Rows.Add(new ConfigRow("Node", "Node name", c.NodeName ?? "—", NoteFor("nodeName")));

--- a/src/DocumentForge.Studio/Views/ConnectDialog.xaml
+++ b/src/DocumentForge.Studio/Views/ConnectDialog.xaml
@@ -50,8 +50,8 @@
                 <TextBlock Text="API key:" VerticalAlignment="Center" Width="90"/>
                 <PasswordBox x:Name="ApiKeyBox"/>
             </DockPanel>
-            <TextBlock Text="Leave the key empty for a dev-mode node (no auth configured)."
-                       Foreground="Gray" FontSize="11" Margin="90,4,0,0"/>
+            <TextBlock Text="Paste just the key (hex or df_…) — 'Bearer' is added automatically. Leave empty for a dev-mode node (no auth configured)."
+                       Foreground="Gray" FontSize="11" Margin="90,4,0,0" TextWrapping="Wrap"/>
         </StackPanel>
 
         <!-- Name + save -->

--- a/src/DocumentForge.Studio/Views/ConnectDialog.xaml.cs
+++ b/src/DocumentForge.Studio/Views/ConnectDialog.xaml.cs
@@ -154,8 +154,25 @@ public partial class ConnectDialog : Window
         descriptor.FilePath = isFile ? FilePathBox.Text.Trim() : null;
         descriptor.Url = isFile ? null : UrlBox.Text.Trim().TrimEnd('/');
 
-        var apiKey = !isFile && ApiKeyBox.Password.Length > 0 ? ApiKeyBox.Password : null;
+        var apiKey = isFile ? null : NormalizeApiKey(ApiKeyBox.Password);
         return new ConnectRequest(descriptor, apiKey, SaveCheck.IsChecked == true);
+    }
+
+    /// <summary>
+    /// The connection sends the key as <c>Authorization: Bearer &lt;key&gt;</c> itself,
+    /// so the box wants the bare key. Be forgiving about how it arrives: trim
+    /// copy-paste whitespace/newlines (keys are hash/exact-matched server-side, so
+    /// a trailing newline means 401) and strip a pasted "Bearer " prefix — the
+    /// server's own 401 text says "Provide Authorization: Bearer &lt;apiKey&gt;",
+    /// which lures people into typing exactly that.
+    /// </summary>
+    internal static string? NormalizeApiKey(string? raw)
+    {
+        var key = raw?.Trim();
+        if (string.IsNullOrEmpty(key)) return null;
+        if (key.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            key = key["Bearer ".Length..].Trim();
+        return key.Length == 0 ? null : key;
     }
 
     private bool MatchesEditing(bool isFile) =>

--- a/src/DocumentForge.Studio/Views/ServiceSettingsView.xaml
+++ b/src/DocumentForge.Studio/Views/ServiceSettingsView.xaml
@@ -19,6 +19,9 @@
         <ToolBarTray DockPanel.Dock="Top" IsLocked="True">
             <ToolBar>
                 <Button Content="🔄 Refresh" Command="{Binding RefreshCommand}" Padding="8,2"/>
+                <Separator/>
+                <Button Content="♻ Restart service…" Command="{Binding RestartServiceCommand}" Padding="8,2"
+                        ToolTip="Flush + restart the node (Windows service / IIS restarts it automatically). Needed after changing any 'restart to change' setting in node.json."/>
             </ToolBar>
         </ToolBarTray>
 

--- a/tests/DocumentForge.Studio.Core.Tests/HttpConnectionTests.cs
+++ b/tests/DocumentForge.Studio.Core.Tests/HttpConnectionTests.cs
@@ -215,4 +215,42 @@ public sealed class HttpConnectionTests
             () => connection.UpdateServiceConfigAsync(null, null));
         Assert.Empty(handler.Requests);
     }
+
+    // ── API-key normalisation ────────────────────────────────────────────────
+    // Keys are hash/exact-matched server-side, so copy-paste whitespace or a
+    // user-typed "Bearer " prefix (the old 401 text invited exactly that) used
+    // to yield an unexplainable 401 with a perfectly valid key.
+
+    [Theory]
+    [InlineData("df_abc123", "df_abc123")]
+    [InlineData("  df_abc123\r\n", "df_abc123")]                 // copy-paste whitespace
+    [InlineData("Bearer df_abc123", "df_abc123")]                // typed the 401 hint verbatim
+    [InlineData("bearer  df_abc123 ", "df_abc123")]              // case + inner spacing
+    [InlineData("8340c13f386a2ef99bb32147", "8340c13f386a2ef99bb32147")] // legacy hex key untouched
+    public async Task ApiKey_Is_Normalised_Before_The_Authorization_Header(string typed, string expected)
+    {
+        var handler = new StubHandler().Map("/health", """{"status":"ok"}""");
+        await using var connection = Connect(handler, typed);
+
+        await connection.GetHealthAsync();
+
+        var auth = handler.Requests.Single().Headers.Authorization;
+        Assert.NotNull(auth);
+        Assert.Equal("Bearer", auth!.Scheme);
+        Assert.Equal(expected, auth.Parameter);
+    }
+
+    [Fact]
+    public async Task RestartServer_Posts_Admin_Restart_And_Returns_Message()
+    {
+        var handler = new StubHandler().Map("/admin/restart",
+            """{"success":true,"message":"Flushed; the node is exiting for restart."}""",
+            HttpStatusCode.Accepted);
+        await using var connection = Connect(handler, "df_abc123");
+
+        var message = await connection.RestartServerAsync();
+
+        Assert.Contains("exiting for restart", message);
+        Assert.Equal(HttpMethod.Post, handler.Requests.Single().Method);
+    }
 }


### PR DESCRIPTION
Fixes the three issues reported this morning:

- **Valid key → unauthorized**: the Connect dialog neither trimmed pasted keys (hash/exact-matched server-side, so a stray newline = 401) nor stripped a typed `Bearer ` prefix — which the server's own 401 message invited, producing `Bearer Bearer <key>`. Keys are now normalised at capture and defensively in `HttpConnection`; hint + 401 wording updated to "paste just the key". (Verified the reported keys are all valid server-side — hex ✓, `df_` admin ✓; the all-dbs key correctly gets 403 on admin-only endpoints, which is scoping, not auth.)
- **No restart button**: new admin-scoped `POST /admin/restart` (flush → 202 → exit non-zero so the Windows service recovery / IIS ANCM restarts the node) + a **Restart service** button in Service settings that confirms, calls it, polls `/health` until back, and reloads.
- **"restart required" never clears**: it was never a live state — the wire field is a static "changing this needs a restart" descriptor. Relabelled **restart to change** and documented the semantics.

Tests: key-normalisation matrix + restart round-trip; full suite green (655 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)