### PR TITLE
fix: honor X-Confirm on DELETE /databases/{name} so drop actually deletes the file

### DIFF
--- a/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
+++ b/src/DocumentForge.Cli/Commands/DatabaseEndpoints.cs
@@ -539,7 +539,8 @@ public static class DatabaseEndpoints
             catch (Exception ex) { return Results.BadRequest(new { error = ex.Message }); }
         });
 
-        // Detach (default) or Drop (delete-files=true). 404 when not
+        // Detach (default) or Drop (deleteFiles=true, or the X-Confirm: true
+        // header every other destructive route uses). 404 when not
         // registered so Studio's idempotent retries get a clear signal.
         app.MapDelete("/databases/{name}", (HttpContext ctx, string name, bool? deleteFiles) =>
         {
@@ -548,7 +549,14 @@ public static class DatabaseEndpoints
                 return Results.BadRequest(new { error = $"Database '{name}' is a system DB and cannot be detached or dropped." });
             try
             {
-                var drop = deleteFiles == true;
+                // An explicit deleteFiles query param wins; otherwise fall
+                // back to the X-Confirm header. Before this fallback, a
+                // caller sending only X-Confirm (the API's destructive-op
+                // convention) got a silent Detach — the .dfdb stayed on
+                // disk and the next create with the same name re-attached
+                // it, resurrecting every old document.
+                var drop = deleteFiles
+                    ?? (ctx.Request.Headers["X-Confirm"].ToString() == "true");
                 var removed = drop ? registry.Drop(name) : registry.Detach(name);
                 if (!removed)
                     return Results.NotFound(new { error = $"Database '{name}' is not attached." });

--- a/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
+++ b/tests/DocumentForge.Tests/DatabaseEndpointsHttpTests.cs
@@ -374,6 +374,65 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
     }
 
     [Fact]
+    public async Task DeleteDatabase_XConfirmHeader_DropsFiles()
+    {
+        // The 2026-07-20 demo-box incident: callers following the API's
+        // destructive-op convention (X-Confirm: true, as required by the
+        // drop-collection routes) got a silent Detach — file left on disk.
+        var (registry, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "doomed2" });
+        var info = registry.List().First();
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"{baseUrl}/databases/doomed2");
+        req.Headers.TryAddWithoutValidation("X-Confirm", "true");
+        var resp = await _http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DeleteDatabaseResponse>();
+        Assert.Equal("dropped", body!.Action);
+        Assert.False(File.Exists(info.FilePath), "X-Confirm drop must delete the data file.");
+    }
+
+    [Fact]
+    public async Task DeleteDatabase_ExplicitDeleteFilesFalse_WinsOverXConfirm()
+    {
+        // Studio sends ?deleteFiles=false for its Detach action; an
+        // explicit query param must not be overridden by the header.
+        var (registry, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "kept" });
+        var info = registry.List().First();
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"{baseUrl}/databases/kept?deleteFiles=false");
+        req.Headers.TryAddWithoutValidation("X-Confirm", "true");
+        var resp = await _http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var body = await resp.Content.ReadFromJsonAsync<DeleteDatabaseResponse>();
+        Assert.Equal("detached", body!.Action);
+        Assert.True(File.Exists(info.FilePath));
+    }
+
+    [Fact]
+    public async Task DeleteDatabase_DropThenRecreate_NoResurrectedDocuments()
+    {
+        // Regression for the demo-box incident: drop a DB with documents,
+        // recreate under the same name, and the new DB must be empty —
+        // NOT a re-attach of the old file with every document back.
+        var (registry, baseUrl, _) = BootServer();
+        await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "phoenix" });
+        registry.Get("phoenix").Insert("orders", """{"pnr":"FRIDAY-1"}""");
+
+        var req = new HttpRequestMessage(HttpMethod.Delete, $"{baseUrl}/databases/phoenix");
+        req.Headers.TryAddWithoutValidation("X-Confirm", "true");
+        (await _http.SendAsync(req)).EnsureSuccessStatusCode();
+
+        var recreate = await _http.PostAsJsonAsync($"{baseUrl}/databases", new { name = "phoenix" });
+        Assert.Equal(HttpStatusCode.Created, recreate.StatusCode);
+
+        var collections = await _http.GetFromJsonAsync<ScopedCollectionsResponse>(
+            $"{baseUrl}/db/phoenix/collections");
+        Assert.Empty(collections!.Collections);
+    }
+
+    [Fact]
     public async Task DeleteDatabase_Unknown_Returns404()
     {
         var (_, baseUrl, _) = BootServer();
@@ -1489,6 +1548,11 @@ public sealed class DatabaseEndpointsHttpTests : IDisposable
         public string Name { get; set; } = "";
         public string Action { get; set; } = "";
         public string? DefaultAfter { get; set; }
+    }
+    private sealed class ScopedCollectionsResponse
+    {
+        public string Database { get; set; } = "";
+        public List<string> Collections { get; set; } = new();
     }
     private sealed class ReplicationStatusResponse
     {


### PR DESCRIPTION
## Problem

`DELETE /databases/{name}` only routed to `registry.Drop` (which deletes the `.dfdb` + sidecars) when `?deleteFiles=true` was passed. The `X-Confirm: true` header — the destructive-op convention every other route in this API uses (drop collection, blob delete) — was silently ignored, so a conventional caller got a **Detach** instead: 200 OK, database gone from the listing, data file left on disk.

The next `POST /databases` / EnsureDatabase with the same name went through `AttachOrCreate`, found the orphaned file, re-attached it, and resurrected every old document. Observed live on the demo box (DocumentForge 1.5.1) on 2026-07-20 with the `verify`, `aurora`, and `control` databases: after aerobus recreated them, all of Friday's documents were back alongside the new ones.

## Fix

In the DELETE handler, an explicit `deleteFiles` query param still wins; otherwise `X-Confirm: true` now selects the drop path:

```csharp
var drop = deleteFiles ?? (ctx.Request.Headers["X-Confirm"].ToString() == "true");
```

Studio's detach flow (`?deleteFiles=false`) is unchanged. `registry.Drop` itself was already correct — it deletes the data file and all sidecars.

## Tests

- `DeleteDatabase_XConfirmHeader_DropsFiles` — header alone deletes the data file
- `DeleteDatabase_ExplicitDeleteFilesFalse_WinsOverXConfirm` — query param precedence pinned
- `DeleteDatabase_DropThenRecreate_NoResurrectedDocuments` — the incident regression: drop → recreate → collection list empty

Full `DocumentForge.Tests` suite: 574/574 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)