### PR TITLE
Studio: hide engine _id/_etag columns behind a System fields toggle

### DIFF
--- a/src/DocumentForge.Studio/Views/QueryDocumentView.xaml
+++ b/src/DocumentForge.Studio/Views/QueryDocumentView.xaml
@@ -29,6 +29,10 @@
                 <TextBox Text="{Binding RowLimit}" Width="56" Margin="4,0,0,0" VerticalAlignment="Center"
                          ToolTip="Auto-append LIMIT to unbounded SELECTs"/>
                 <Separator/>
+                <CheckBox x:Name="ShowSystemFields" Content="System fields" IsChecked="False"
+                          VerticalAlignment="Center" Click="OnShowSystemFieldsToggled"
+                          ToolTip="Show the engine's _id / _etag columns (storage identity and concurrency token — not document data)"/>
+                <Separator/>
                 <TextBlock Text="Timeout (s):" VerticalAlignment="Center" Margin="4,0,4,0"/>
                 <TextBox Text="{Binding TimeoutSeconds}" Width="44" VerticalAlignment="Center"
                          ToolTip="Auto-cancel the query after N seconds (0 = no timeout)"/>

--- a/src/DocumentForge.Studio/Views/QueryDocumentView.xaml.cs
+++ b/src/DocumentForge.Studio/Views/QueryDocumentView.xaml.cs
@@ -123,12 +123,28 @@ public partial class QueryDocumentView : UserControl
         await vm.ExecuteAsync(sql);
     }
 
-    // Keep the engine's own _id / _etag columns read-only even when the grid
-    // is editable — they're identity/concurrency tokens, not user data.
+    // The engine's own _id / _etag columns are identity/concurrency tokens,
+    // not user data: hidden by default (the "System fields" toggle brings them
+    // back for CAS debugging), and read-only whenever shown.
     private void OnAutoGeneratingColumn(object? sender, DataGridAutoGeneratingColumnEventArgs e)
     {
-        if (e.PropertyName is "_id" or "_etag")
+        if (e.PropertyName.StartsWith('_'))
+        {
+            if (ShowSystemFields.IsChecked != true)
+            {
+                e.Cancel = true;
+                return;
+            }
             e.Column.IsReadOnly = true;
+        }
+    }
+
+    private void OnShowSystemFieldsToggled(object sender, RoutedEventArgs e)
+    {
+        // Column auto-generation only runs on a rebind — bounce the source.
+        var source = ResultsGrid.ItemsSource;
+        ResultsGrid.ItemsSource = null;
+        ResultsGrid.ItemsSource = source;
     }
 
     private void OnCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)


### PR DESCRIPTION
SELECT * grids presented the engine's `_id`/`_etag` (storage identity + concurrency token) as if they were document data, right next to the document's own `id`. Hidden by default now; a **System fields** toolbar toggle shows them (read-only) for CAS debugging. Result rows still carry them underneath, so cell editing and row deletion keep working with the columns hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)